### PR TITLE
feat: add S3-compatible object storage support

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "db:seed": "bun run src/seeds/cards.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.629.0",
     "@better-auth/expo": "^1.2.12",
     "@types/image-size": "^0.8.0",
     "better-auth": "^1.2.12",

--- a/backend/src/config/storage.ts
+++ b/backend/src/config/storage.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+const S3ConfigSchema = z.object({
+  AWS_S3_BUCKET: z.string().min(1, 'S3 bucket name is required'),
+  AWS_S3_REGION: z.string().min(1, 'S3 region is required'),
+  AWS_S3_ENDPOINT: z.string().url().optional(),
+  AWS_ACCESS_KEY_ID: z.string().optional(),
+  AWS_SECRET_ACCESS_KEY: z.string().optional(),
+  AWS_S3_FORCE_PATH_STYLE: z.string().transform(val => val === 'true').optional(),
+});
+
+export type S3Config = z.infer<typeof S3ConfigSchema>;
+
+export function getStorageConfig(): { type: 'local' | 's3'; config?: S3Config } {
+  const s3Bucket = process.env['AWS_S3_BUCKET'];
+  const s3Region = process.env['AWS_S3_REGION'];
+
+  // If S3 bucket and region are provided, try to use S3
+  if (s3Bucket && s3Region) {
+    try {
+      const config = S3ConfigSchema.parse({
+        AWS_S3_BUCKET: s3Bucket,
+        AWS_S3_REGION: s3Region,
+        AWS_S3_ENDPOINT: process.env['AWS_S3_ENDPOINT'],
+        AWS_ACCESS_KEY_ID: process.env['AWS_ACCESS_KEY_ID'],
+        AWS_SECRET_ACCESS_KEY: process.env['AWS_SECRET_ACCESS_KEY'],
+        AWS_S3_FORCE_PATH_STYLE: process.env['AWS_S3_FORCE_PATH_STYLE'],
+      });
+
+      // Check if credentials are provided (optional for IAM roles)
+      const hasCredentials = config.AWS_ACCESS_KEY_ID && config.AWS_SECRET_ACCESS_KEY;
+      const hasEndpoint = config.AWS_S3_ENDPOINT;
+
+      if (!hasCredentials && !hasEndpoint) {
+        console.warn('S3 configuration incomplete: Using AWS credentials chain or IAM roles');
+      }
+
+      console.log(`Using S3 storage: bucket=${config.AWS_S3_BUCKET}, region=${config.AWS_S3_REGION}`);
+      return { type: 's3', config };
+    } catch (error) {
+      console.warn('Invalid S3 configuration, falling back to local storage:', error);
+      return { type: 'local' };
+    }
+  }
+
+  console.log('Using local file storage');
+  return { type: 'local' };
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,6 +8,8 @@ import { auth } from './auth';
 import { userRoutes } from './routes/users';
 import { cardRoutes } from './routes/cards';
 import { healthRoutes } from './health';
+import { getStorageConfig } from './config/storage.js';
+import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
 
 // App with type-safe context
 const app = new Hono<{
@@ -59,51 +61,113 @@ app.route('/api/users', userRoutes);
 app.route('/api/cards', cardRoutes);
 app.route('/api', healthRoutes);
 
-// Serve uploaded files with proper headers for audio
-app.use('/api/uploads/*', async (c, next) => {
+// Serve uploaded files - handles both local and S3 storage
+app.get('/api/uploads/*', async (c) => {
   const path = c.req.path;
-  const filePath = path.replace('/api/uploads', '');
+  const filePath = path.replace('/api/uploads/', '');
 
   console.log(`[Uploads] Serving file: ${filePath}`);
 
   // Get file extension to determine content type
   const ext = filePath.split('.').pop()?.toLowerCase();
 
-  // Set appropriate content type and headers for audio files
+  // Set appropriate content type
+  let contentType = 'application/octet-stream';
   if (ext === 'm4a' || ext === 'mp4' || ext === 'aac') {
-    c.header('Content-Type', 'audio/mp4');
-    c.header('Accept-Ranges', 'bytes');
-    c.header('Access-Control-Allow-Origin', '*');
-    c.header('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS');
-    c.header('Access-Control-Allow-Headers', 'Range, Content-Range, Content-Length');
+    contentType = 'audio/mp4';
   } else if (ext === 'mp3') {
-    c.header('Content-Type', 'audio/mpeg');
-    c.header('Accept-Ranges', 'bytes');
-    c.header('Access-Control-Allow-Origin', '*');
-    c.header('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS');
-    c.header('Access-Control-Allow-Headers', 'Range, Content-Range, Content-Length');
+    contentType = 'audio/mpeg';
   } else if (ext === 'wav') {
-    c.header('Content-Type', 'audio/wav');
-    c.header('Accept-Ranges', 'bytes');
-    c.header('Access-Control-Allow-Origin', '*');
-    c.header('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS');
-    c.header('Access-Control-Allow-Headers', 'Range, Content-Range, Content-Length');
+    contentType = 'audio/wav';
   } else if (ext === 'ogg') {
-    c.header('Content-Type', 'audio/ogg');
-    c.header('Accept-Ranges', 'bytes');
-    c.header('Access-Control-Allow-Origin', '*');
-    c.header('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS');
-    c.header('Access-Control-Allow-Headers', 'Range, Content-Range, Content-Length');
+    contentType = 'audio/ogg';
+  } else if (ext === 'webm') {
+    contentType = 'video/webm';
+  } else if (ext === 'jpg' || ext === 'jpeg') {
+    contentType = 'image/jpeg';
+  } else if (ext === 'png') {
+    contentType = 'image/png';
+  } else if (ext === 'gif') {
+    contentType = 'image/gif';
+  } else if (ext === 'webp') {
+    contentType = 'image/webp';
   }
 
-  return next();
-});
+  // Set headers
+  c.header('Content-Type', contentType);
+  c.header('Accept-Ranges', 'bytes');
+  c.header('Access-Control-Allow-Origin', '*');
+  c.header('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS');
+  c.header('Access-Control-Allow-Headers', 'Range, Content-Range, Content-Length');
 
-app.use('/api/uploads/*', serveStatic({
-  root: process.env['UPLOAD_PATH'] || './uploads',
-  rewriteRequestPath: (path) => path.replace('/api/uploads', ''),
-  onNotFound: (path) => console.log(`Upload file not found: ${path}`)
-}));
+  const storageConfig = getStorageConfig();
+
+  if (storageConfig.type === 's3' && storageConfig.config) {
+    // Serve from S3
+    try {
+      const s3Client = new S3Client({
+        region: storageConfig.config.AWS_S3_REGION,
+        endpoint: storageConfig.config.AWS_S3_ENDPOINT,
+        credentials: storageConfig.config.AWS_ACCESS_KEY_ID && storageConfig.config.AWS_SECRET_ACCESS_KEY ? {
+          accessKeyId: storageConfig.config.AWS_ACCESS_KEY_ID,
+          secretAccessKey: storageConfig.config.AWS_SECRET_ACCESS_KEY,
+        } : undefined,
+        forcePathStyle: storageConfig.config.AWS_S3_FORCE_PATH_STYLE || false,
+      });
+
+      const command = new GetObjectCommand({
+        Bucket: storageConfig.config.AWS_S3_BUCKET,
+        Key: filePath,
+      });
+
+      const response = await s3Client.send(command);
+      
+      if (response.Body) {
+        const stream = response.Body as ReadableStream;
+        return new Response(stream, {
+          headers: {
+            'Content-Type': contentType,
+            'Content-Length': response.ContentLength?.toString() || '',
+            'Accept-Ranges': 'bytes',
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
+            'Access-Control-Allow-Headers': 'Range, Content-Range, Content-Length',
+          }
+        });
+      }
+      
+      return c.text('File not found', 404);
+    } catch (error) {
+      console.error(`Failed to serve S3 file ${filePath}:`, error);
+      return c.text('File not found', 404);
+    }
+  } else {
+    // Serve from local storage
+    const uploadPath = process.env['UPLOAD_PATH'] || './uploads';
+    const fullPath = `${uploadPath}/${filePath}`;
+    
+    try {
+      const file = Bun.file(fullPath);
+      if (!(await file.exists())) {
+        return c.text('File not found', 404);
+      }
+      
+      return new Response(file, {
+        headers: {
+          'Content-Type': contentType,
+          'Content-Length': file.size.toString(),
+          'Accept-Ranges': 'bytes',
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
+          'Access-Control-Allow-Headers': 'Range, Content-Range, Content-Length',
+        }
+      });
+    } catch (error) {
+      console.error(`Failed to serve local file ${fullPath}:`, error);
+      return c.text('File not found', 404);
+    }
+  }
+});
 
 // Protected session endpoint
 app.get('/api/session', (c) => {

--- a/backend/src/services/card/AudioCardProcessor.ts
+++ b/backend/src/services/card/AudioCardProcessor.ts
@@ -3,7 +3,8 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { CardProcessor } from './CardProcessor.js';
 import type { ProcessedCardData, ProcessingContext } from './CardProcessor.js';
-import { LocalFileUploadService } from '../file/LocalFileUploadService.js';
+import { createFileUploadService } from '../file/FileUploadFactory.js';
+import type { FileUploadService } from '../file/FileUploadService.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -16,11 +17,11 @@ interface AudioMetadata {
 }
 
 export class AudioCardProcessor extends CardProcessor {
-  private fileUploadService: LocalFileUploadService;
+  private fileUploadService: FileUploadService;
 
   constructor() {
     super();
-    this.fileUploadService = new LocalFileUploadService();
+    this.fileUploadService = createFileUploadService();
   }
 
   async process(context: ProcessingContext): Promise<ProcessedCardData> {

--- a/backend/src/services/card/ImageCardProcessor.ts
+++ b/backend/src/services/card/ImageCardProcessor.ts
@@ -1,13 +1,14 @@
 import { CardProcessor } from './CardProcessor.js';
 import type { ProcessedCardData, ProcessingContext } from './CardProcessor.js';
-import { LocalFileUploadService } from '../file/LocalFileUploadService.js';
+import { createFileUploadService } from '../file/FileUploadFactory.js';
+import type { FileUploadService } from '../file/FileUploadService.js';
 
 export class ImageCardProcessor extends CardProcessor {
-  private fileUploadService: LocalFileUploadService;
+  private fileUploadService: FileUploadService;
 
   constructor() {
     super();
-    this.fileUploadService = new LocalFileUploadService();
+    this.fileUploadService = createFileUploadService();
   }
 
   async process(context: ProcessingContext): Promise<ProcessedCardData> {

--- a/backend/src/services/card/VideoCardProcessor.ts
+++ b/backend/src/services/card/VideoCardProcessor.ts
@@ -3,7 +3,8 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { CardProcessor } from './CardProcessor.js';
 import type { ProcessedCardData, ProcessingContext } from './CardProcessor.js';
-import { LocalFileUploadService } from '../file/LocalFileUploadService.js';
+import { createFileUploadService } from '../file/FileUploadFactory.js';
+import type { FileUploadService } from '../file/FileUploadService.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -18,11 +19,11 @@ interface VideoMetadata {
 }
 
 export class VideoCardProcessor extends CardProcessor {
-  private fileUploadService: LocalFileUploadService;
+  private fileUploadService: FileUploadService;
 
   constructor() {
     super();
-    this.fileUploadService = new LocalFileUploadService();
+    this.fileUploadService = createFileUploadService();
   }
 
   async process(context: ProcessingContext): Promise<ProcessedCardData> {

--- a/backend/src/services/file/FileUploadFactory.ts
+++ b/backend/src/services/file/FileUploadFactory.ts
@@ -1,0 +1,21 @@
+import { FileUploadService } from './FileUploadService.js';
+import { LocalFileUploadService } from './LocalFileUploadService.js';
+import { S3FileUploadService } from './S3FileUploadService.js';
+import { getStorageConfig } from '../../config/storage.js';
+
+export function createFileUploadService(): FileUploadService {
+  const storageConfig = getStorageConfig();
+
+  if (storageConfig.type === 's3' && storageConfig.config) {
+    return new S3FileUploadService({
+      bucket: storageConfig.config.AWS_S3_BUCKET,
+      region: storageConfig.config.AWS_S3_REGION,
+      endpoint: storageConfig.config.AWS_S3_ENDPOINT,
+      accessKeyId: storageConfig.config.AWS_ACCESS_KEY_ID,
+      secretAccessKey: storageConfig.config.AWS_SECRET_ACCESS_KEY,
+      forcePathStyle: storageConfig.config.AWS_S3_FORCE_PATH_STYLE,
+    });
+  }
+
+  return new LocalFileUploadService();
+}

--- a/backend/src/services/file/S3FileUploadService.ts
+++ b/backend/src/services/file/S3FileUploadService.ts
@@ -1,0 +1,125 @@
+import { S3Client, PutObjectCommand, DeleteObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { fileTypeFromBuffer } from 'file-type';
+import imageSize from 'image-size';
+import { FileUploadService } from './FileUploadService.js';
+import type { UploadedFile, UploadOptions } from './FileUploadService.js';
+
+export interface S3Config {
+  bucket: string;
+  region: string;
+  endpoint?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  forcePathStyle?: boolean;
+}
+
+export class S3FileUploadService extends FileUploadService {
+  private s3Client: S3Client;
+  private bucket: string;
+
+  constructor(config: S3Config) {
+    super();
+    this.bucket = config.bucket;
+    
+    this.s3Client = new S3Client({
+      region: config.region,
+      endpoint: config.endpoint,
+      credentials: config.accessKeyId && config.secretAccessKey ? {
+        accessKeyId: config.accessKeyId,
+        secretAccessKey: config.secretAccessKey,
+      } : undefined,
+      forcePathStyle: config.forcePathStyle || false,
+    });
+  }
+
+  async uploadFile(file: File, options: UploadOptions): Promise<UploadedFile> {
+    // Validate file size
+    if (file.size > options.maxSize) {
+      throw new Error(`File size ${file.size} bytes exceeds maximum allowed size of ${options.maxSize} bytes`);
+    }
+
+    // Read file buffer
+    const buffer = await file.arrayBuffer();
+    const uint8Array = new Uint8Array(buffer);
+
+    // Detect file type
+    const fileType = await fileTypeFromBuffer(uint8Array);
+    if (!fileType) {
+      throw new Error('Unable to detect file type');
+    }
+
+    // Validate file type if restrictions provided
+    if (options.allowedTypes && !options.allowedTypes.includes(fileType.mime)) {
+      throw new Error(`File type ${fileType.mime} is not allowed`);
+    }
+
+    // Generate paths (maintain same structure as local storage)
+    const datePath = this.createDatePath();
+    const filename = this.generateUniqueFilename(file.name);
+    const key = `${datePath}/${filename}`;
+
+    // Upload to S3
+    const uploadCommand = new PutObjectCommand({
+      Bucket: this.bucket,
+      Key: key,
+      Body: uint8Array,
+      ContentType: fileType.mime,
+      ContentLength: file.size,
+    });
+
+    await this.s3Client.send(uploadCommand);
+
+    // Generate URL
+    const url = options.generateUrl(key);
+
+    // Extract image dimensions if it's an image
+    let width: number | undefined;
+    let height: number | undefined;
+
+    if (fileType.mime.startsWith('image/')) {
+      try {
+        const dimensions = imageSize(uint8Array);
+        width = dimensions.width;
+        height = dimensions.height;
+      } catch (error) {
+        console.warn('Failed to extract image dimensions:', error);
+      }
+    }
+
+    return {
+      filename,
+      originalName: file.name,
+      path: key,
+      size: file.size,
+      mimeType: fileType.mime,
+      url,
+      width,
+      height
+    };
+  }
+
+  async deleteFile(key: string): Promise<void> {
+    try {
+      const deleteCommand = new DeleteObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+      });
+      await this.s3Client.send(deleteCommand);
+    } catch (error) {
+      console.warn(`Failed to delete S3 object ${key}:`, error);
+    }
+  }
+
+  async fileExists(key: string): Promise<boolean> {
+    try {
+      const command = new GetObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+      });
+      await this.s3Client.send(command);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/backend/src/services/index.ts
+++ b/backend/src/services/index.ts
@@ -1,6 +1,8 @@
 // File upload services
 export { FileUploadService } from './file/FileUploadService.js';
 export { LocalFileUploadService } from './file/LocalFileUploadService.js';
+export { S3FileUploadService } from './file/S3FileUploadService.js';
+export { createFileUploadService } from './file/FileUploadFactory.js';
 
 // Card processing services
 export { CardProcessor } from './card/CardProcessor.js';

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -10,6 +10,24 @@ NODE_ENV=production
 PORT=80
 BACKEND_PORT=3001
 
+# File Upload Configuration
+UPLOAD_PATH=./uploads
+
+# Optional: S3-Compatible Object Storage Configuration
+# Remove the # prefix to enable S3 storage instead of local storage
+# AWS_S3_BUCKET=your-bucket-name
+# AWS_S3_REGION=us-east-1
+# AWS_S3_ENDPOINT=https://s3.amazonaws.com  # Optional: for S3-compatible providers
+# AWS_ACCESS_KEY_ID=your-access-key         # Optional: can use IAM roles instead
+# AWS_SECRET_ACCESS_KEY=your-secret-key     # Optional: can use IAM roles instead
+# AWS_S3_FORCE_PATH_STYLE=false            # Set to true for MinIO/self-hosted S3
+
+# S3 Provider Examples:
+# AWS S3: Use default endpoint or omit AWS_S3_ENDPOINT
+# Cloudflare R2: AWS_S3_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com
+# MinIO: AWS_S3_ENDPOINT=https://your-minio-server.com and AWS_S3_FORCE_PATH_STYLE=true
+# Wasabi: AWS_S3_ENDPOINT=https://s3.wasabisys.com
+
 # Optional: Custom database configuration
 # POSTGRES_HOST=localhost
 # POSTGRES_PORT=5432

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,6 +14,13 @@ services:
       - BETTER_AUTH_SECRET=your-super-secret-key-change-this-in-production
       - BETTER_AUTH_URL=http://localhost:80
       - UPLOAD_PATH=/app/uploads
+      # Optional S3 Configuration (remove AWS_ prefix to use local storage)
+      # - AWS_S3_BUCKET=your-bucket-name
+      # - AWS_S3_REGION=us-east-1
+      # - AWS_S3_ENDPOINT=https://s3.amazonaws.com
+      # - AWS_ACCESS_KEY_ID=your-access-key
+      # - AWS_SECRET_ACCESS_KEY=your-secret-key
+      # - AWS_S3_FORCE_PATH_STYLE=false
     volumes:
       - uploads_data:/app/uploads
     depends_on:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -177,3 +177,129 @@ docker-compose -f docker/docker-compose.dev.yml logs -f frontend
 5. **Automated Setup**: Database migrations and seeding happen automatically
 
 **Final Status**: ✅ All tasks completed successfully with comprehensive testing and documentation
+
+---
+
+# File Upload S3 Integration Analysis and Plan
+
+## Current File Upload System Analysis
+
+### Current Architecture
+The Teak application currently uses a **local file storage system** with the following components:
+
+#### 1. Upload Routes and Endpoints
+- **Main upload endpoint**: `POST /api/cards` with `multipart/form-data` support
+- **File serving endpoint**: `/api/uploads/*` - serves uploaded files statically
+- **Upload middleware**: `fileUploadMiddleware` in `/Users/praveenjuge/Projects/teak/backend/src/middleware/fileUpload.ts`
+
+#### 2. File Storage Logic
+- **Service abstraction**: `FileUploadService` (abstract base class)
+- **Local implementation**: `LocalFileUploadService` extends `FileUploadService`
+- **Storage location**: `./uploads` directory (configurable via `UPLOAD_PATH` env var)
+- **File organization**: Date-based structure `YYYY/MM/DD/timestamp-random.extension`
+- **File serving**: Static file serving via Hono's `serveStatic` middleware
+
+#### 3. File Processing Components
+- **Card processors**: Type-specific processors for audio, video, image cards
+  - `AudioCardProcessor` - handles audio files, extracts metadata with ffprobe
+  - `VideoCardProcessor` - handles video files, extracts metadata with ffprobe  
+  - `ImageCardProcessor` - handles image files, extracts dimensions
+- **File validation**: MIME type checking, file size limits
+- **Metadata extraction**: Audio/video duration, bitrate, dimensions, etc.
+
+#### 4. Current Directory Structure
+```
+backend/
+├── src/
+│   ├── middleware/fileUpload.ts          # Upload middleware
+│   ├── services/file/
+│   │   ├── FileUploadService.ts          # Abstract base class
+│   │   └── LocalFileUploadService.ts     # Local storage implementation
+│   ├── services/card/
+│   │   ├── CardProcessor.ts              # Base processor
+│   │   ├── AudioCardProcessor.ts         # Audio file processor
+│   │   ├── VideoCardProcessor.ts         # Video file processor
+│   │   ├── ImageCardProcessor.ts         # Image file processor
+│   │   └── CardService.ts                # Main card service
+│   ├── routes/cards.ts                   # Upload endpoints
+│   └── schemas/fileUpload.ts             # Validation schemas
+└── uploads/                              # Local storage directory
+    └── 2025/07/06/                      # Date-based organization
+```
+
+#### 5. Storage Abstraction Quality
+The codebase has **excellent abstraction** for storage services:
+- Abstract `FileUploadService` base class with clean interface
+- Pluggable design allowing easy swapping of storage implementations
+- Consistent `UploadedFile` interface across all processors
+- Clear separation between file upload and card processing logic
+
+## S3 Integration Plan
+
+### Phase 1: Create S3 File Upload Service
+- [ ] Install AWS SDK v3 (`@aws-sdk/client-s3`)
+- [ ] Create `S3FileUploadService` class extending `FileUploadService`
+- [ ] Implement S3 upload with proper error handling
+- [ ] Add S3 configuration (bucket, region, credentials)
+- [ ] Maintain same `UploadedFile` interface for compatibility
+
+### Phase 2: Update Card Processors
+- [ ] Modify `AudioCardProcessor` to use configurable file upload service
+- [ ] Modify `VideoCardProcessor` to use configurable file upload service  
+- [ ] Modify `ImageCardProcessor` to use configurable file upload service
+- [ ] Ensure metadata extraction still works with S3 URLs
+
+### Phase 3: Configuration and Environment
+- [ ] Add S3 environment variables (bucket name, region, access keys)
+- [ ] Create service factory to choose between Local and S3 storage
+- [ ] Update Docker configuration for S3 environment variables
+- [ ] Add fallback mechanism for development (local storage)
+
+### Phase 4: File Serving Updates
+- [ ] Update URL generation for S3 files (direct S3 URLs vs presigned URLs)
+- [ ] Remove local file serving middleware when using S3
+- [ ] Handle CORS for S3 bucket access
+- [ ] Update file deletion logic for S3
+
+### Phase 5: Migration and Testing
+- [ ] Create migration script for existing files (optional)
+- [ ] Update Postman collection with S3 examples
+- [ ] Test all media types (audio, video, image) with S3
+- [ ] Verify metadata extraction works with S3 storage
+- [ ] Run TypeScript checks (`bunx tsc --noEmit`)
+
+## Key Files to Modify
+
+### Core Service Files
+1. `/Users/praveenjuge/Projects/teak/backend/src/services/file/S3FileUploadService.ts` (NEW)
+2. `/Users/praveenjuge/Projects/teak/backend/src/services/card/AudioCardProcessor.ts`
+3. `/Users/praveenjuge/Projects/teak/backend/src/services/card/VideoCardProcessor.ts`  
+4. `/Users/praveenjuge/Projects/teak/backend/src/services/card/ImageCardProcessor.ts`
+5. `/Users/praveenjuge/Projects/teak/backend/src/services/index.ts`
+
+### Configuration Files
+6. `/Users/praveenjuge/Projects/teak/backend/package.json` (add AWS SDK)
+7. `/Users/praveenjuge/Projects/teak/docker/docker-compose.yml` (S3 env vars)
+8. `/Users/praveenjuge/Projects/teak/docker/docker-compose.dev.yml` (S3 env vars)
+
+### Optional Updates
+9. `/Users/praveenjuge/Projects/teak/backend/src/index.ts` (remove static file serving for S3)
+10. `/Users/praveenjuge/Projects/teak/postman/Teak-API.postman_collection.json`
+
+## Benefits of Current Architecture
+
+1. **Clean Abstraction**: The `FileUploadService` abstract class makes S3 integration straightforward
+2. **Minimal Changes**: Only need to create new S3 service and inject it into processors
+3. **Backward Compatibility**: Can maintain local storage for development environments
+4. **Type Safety**: Strong TypeScript interfaces ensure consistency
+5. **Metadata Preservation**: All existing metadata extraction logic will work unchanged
+
+## Recommendations
+
+1. **Gradual Migration**: Implement S3 as an optional storage backend first
+2. **Environment-Based**: Use environment variables to choose storage type
+3. **Dual Support**: Keep both local and S3 implementations for flexibility
+4. **Presigned URLs**: Consider using presigned URLs for secure file access
+5. **CDN Integration**: S3 can be paired with CloudFront for better performance
+
+The current codebase is well-architected for this integration with minimal breaking changes required.


### PR DESCRIPTION
Implement optional S3-compatible object storage for file uploads while maintaining local storage as default.

## Features
- Automatic storage detection: uses S3 when AWS_S3_BUCKET and AWS_S3_REGION are set
- Supports multiple S3-compatible providers (AWS S3, Cloudflare R2, MinIO, Wasabi)
- Maintains existing directory structure and file paths
- Seamless file serving through existing /api/uploads/* routes
- Full backward compatibility with local storage

## Implementation
- Created S3FileUploadService extending abstract FileUploadService
- Added storage factory pattern for automatic service selection
- Updated file serving route to handle both local and S3 storage
- Added comprehensive environment configuration with validation
- Updated Docker compose with S3 environment variables
- Added detailed .env.example documentation

## Architecture
- Preserves existing abstraction layer design
- Zero breaking changes to existing upload/download functionality
- Type-safe implementation with full TypeScript support
- Proper error handling and logging throughout

Resolves #5

🤖 Generated with [Claude Code](https://claude.ai/code)