### PR TITLE
fix: update docs footer links

### DIFF
--- a/apps/docs/components/Footer.tsx
+++ b/apps/docs/components/Footer.tsx
@@ -23,12 +23,12 @@ export function Footer() {
               GitHub
             </a>
             <a
-              href="https://app.teakvault.com"
+              href="https://x.com/praveenjuge"
               className="hover:text-foreground"
               target="_blank"
               rel="noopener noreferrer"
             >
-              Login
+              X (Twitter)
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the footer login link with an external X (Twitter) profile link in the docs app

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec9bf1a2bc832ba74ce77f86f10b0b