### PR TITLE
fix: update development docs quick start

### DIFF
--- a/apps/docs/content/docs/development.mdx
+++ b/apps/docs/content/docs/development.mdx
@@ -13,7 +13,7 @@ description: Development setup and workflow guide for Teak
 
 ```bash
 git clone https://github.com/praveenjuge/teak.git
-cd teak-convex-nextjs
+cd teak
 bun install
 bun run predev
 ```
@@ -26,7 +26,7 @@ This will:
 ## Project Structure
 
 ```
-teak-convex-nextjs/
+teak/
 ├── apps/
 │   ├── web/              # Next.js frontend app
 │   ├── mobile/           # Expo React Native mobile app


### PR DESCRIPTION
## Summary
- update the Quick Start instructions to change into the `teak` directory
- refresh the project structure example to use the current repository name

## Testing
- not run (docs-only change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dbcc69e54832b9b10d3e985a4da19)