### PR TITLE
Adjust link preview layout on mobile

### DIFF
--- a/src/components/card-previews/LinkPreview.tsx
+++ b/src/components/card-previews/LinkPreview.tsx
@@ -41,13 +41,13 @@ export function LinkPreview({
         href={card.url || "#"}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex border rounded w-full hover:bg-accent overflow-hidden items-center"
+        className="flex w-full flex-col overflow-hidden rounded border hover:bg-accent sm:flex-row"
       >
         {linkImage && (
           <Image
             src={linkImage}
             alt="Open Graph preview"
-            className="w-full max-h-26 object-contain"
+            className="h-auto w-full max-h-60 object-contain sm:h-full sm:max-h-40 sm:w-60"
             preview={false}
             placeholder
           />
@@ -57,13 +57,13 @@ export function LinkPreview({
           <Image
             src={screenshotUrl}
             alt="Rendered webpage screenshot"
-            className="w-full max-h-26 object-contain"
+            className="h-auto w-full max-h-60 object-contain sm:h-full sm:max-h-40 sm:w-60"
             preview={false}
             placeholder
           />
         )}
 
-        <div className="min-w-0 shrink-0 flex-1 space-y-1 p-4">
+        <div className="min-w-0 flex-1 shrink-0 space-y-1 p-4">
           <div className="flex items-center justify-between w-full">
             <div className="flex items-center gap-2">
               {faviconUrl && (


### PR DESCRIPTION
## Summary
- stack link preview content vertically on small screens so images appear above details
- widen image rendering to avoid cutting off open graph previews on mobile

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942a042b92c832b9a92733356bb3e3d)