### PR TITLE
fix: improve privacy permission strings with clearer purpose descriptions

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -21,7 +21,14 @@
       [
         "expo-audio",
         {
-          "microphonePermission": "Allow Teak to access your microphone for voice recordings."
+          "microphonePermission": "Teak needs microphone access to record voice notes and audio reminders that you can save to your inspiration collection."
+        }
+      ],
+      [
+        "expo-image-picker",
+        {
+          "cameraPermission": "Teak needs camera access to let you capture photos and videos that you want to save to your inspiration collection.",
+          "photoLibraryPermission": "Teak needs access to your photo library so you can select existing photos and videos to save as inspirations."
         }
       ],
       "expo-web-browser",


### PR DESCRIPTION
## Summary

This PR updates the iOS/Android privacy permission strings in `mobile/app.json` to be more descriptive and user-friendly.

### Changes

- **Microphone Permission**: Updated from a generic "Allow Teak to access your microphone for voice recordings" to a more detailed explanation: "Teak needs microphone access to record voice notes and audio reminders that you can save to your inspiration collection."

- **Added expo-image-picker Plugin**: Added configuration for the image picker with:
  - Camera permission: "Teak needs camera access to let you capture photos and videos that you want to save to your inspiration collection."
  - Photo library permission: "Teak needs access to your photo library so you can select existing photos and videos to save as inspirations."

All permission strings now clearly explain to users why the app needs each permission and how it relates to the inspiration collection feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image picker functionality with camera and photo library access permissions.

* **Improvements**
  * Enhanced microphone permission messaging for improved user clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->