### PR TITLE
fix: add OG image and Twitter card tags to docs

### DIFF
--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -16,12 +16,27 @@ export const metadata: Metadata = {
   keywords:
     "teak, visual bookmarking, design inspiration management, design bookmarks, visual inspiration, design workflow, developer resources",
   authors: [{ name: "Teak Team" }],
+  twitter: {
+    card: "summary_large_image",
+    title: "Teak - Visual Bookmarking & Design Inspiration Manager",
+    description:
+      "Complete guide to setting up and using Teak for visual bookmarking and design inspiration management across all platforms",
+    images: ["/hero-image.png"],
+  },
   openGraph: {
     title: "Teak - Visual Bookmarking & Design Inspiration Manager",
     description:
       "Complete guide to setting up and using Teak for visual bookmarking and design inspiration management across all platforms",
     type: "website",
     siteName: "Teak",
+    images: [
+      {
+        url: "/hero-image.png",
+        width: 1200,
+        height: 630,
+        alt: "Teak - Visual Bookmarking & Design Inspiration Manager",
+      },
+    ],
   },
   robots: {
     index: true,


### PR DESCRIPTION
## Summary
- Add `twitter:card` with `summary_large_image` for large Twitter cards
- Add `openGraph.images` with url, width, height, and alt text
- Ensures proper OG image display when sharing docs.teakvault.com on Twitter/X

## Test plan
- Deploy and verify with https://cards-dev.twitter.com/validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced social media preview metadata, including Twitter card and OpenGraph configurations to improve how shared links appear on social platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->