### PR TITLE
feat: add pre-permission alerts for iOS app compliance

### DIFF
--- a/mobile/app/(tabs)/add/index.tsx
+++ b/mobile/app/(tabs)/add/index.tsx
@@ -2,6 +2,7 @@ import {
   useAudioRecorder,
   RecordingPresets,
   requestRecordingPermissionsAsync,
+  getRecordingPermissionsAsync,
   setAudioModeAsync,
 } from "expo-audio";
 import * as DocumentPicker from "expo-document-picker";
@@ -155,6 +156,19 @@ export default function AddScreen() {
     }
 
     try {
+      // Check if we need to show pre-permission alert (only for first-time requests)
+      const existingStatus = await getRecordingPermissionsAsync();
+      if (existingStatus.status === "notDetermined") {
+        // Show pre-permission alert (Apple HIG compliance: single "Continue" button, no cancel)
+        await new Promise<void>((resolve) => {
+          Alert.alert(
+            "Microphone Access Required",
+            "Teak uses the microphone to record voice notes and audio reminders. These recordings are saved directly to your inspiration collection so you can capture ideas on the go.",
+            [{ text: "Continue", onPress: () => resolve() }]
+          );
+        });
+      }
+
       // Request audio recording permissions
       const { granted } = await requestRecordingPermissionsAsync();
       if (!granted) {
@@ -207,6 +221,19 @@ export default function AddScreen() {
     }
 
     try {
+      // Check if we need to show pre-permission alert (only for first-time requests)
+      const existingStatus = await ImagePicker.getMediaLibraryPermissionsAsync();
+      if (existingStatus === null || existingStatus === "notDetermined") {
+        // Show pre-permission alert (Apple HIG compliance: single "Continue" button, no cancel)
+        await new Promise<void>((resolve) => {
+          Alert.alert(
+            "Photo Library Access Required",
+            "Teak needs access to your photo library so you can select existing photos and videos to save as inspirations. This lets you add content you've already captured to your collection.",
+            [{ text: "Continue", onPress: () => resolve() }]
+          );
+        });
+      }
+
       const permissionResult =
         await ImagePicker.requestMediaLibraryPermissionsAsync();
 
@@ -250,6 +277,19 @@ export default function AddScreen() {
     }
 
     try {
+      // Check if we need to show pre-permission alert (only for first-time requests)
+      const existingStatus = await ImagePicker.getCameraPermissionsAsync();
+      if (existingStatus === null || existingStatus === "notDetermined") {
+        // Show pre-permission alert (Apple HIG compliance: single "Continue" button, no cancel)
+        await new Promise<void>((resolve) => {
+          Alert.alert(
+            "Camera Access Required",
+            "Teak uses the camera to let you capture new photos and videos directly within the app. This makes it easy to add fresh inspirations to your collection.",
+            [{ text: "Continue", onPress: () => resolve() }]
+          );
+        });
+      }
+
       const permissionResult =
         await ImagePicker.requestCameraPermissionsAsync();
 


### PR DESCRIPTION
## Summary
- Add user-friendly permission dialogs before requesting system permissions
- Covers microphone, photo library, and camera access
- Follows Apple Human Interface Guidelines with single "Continue" button flow
- Only shows alert on first-time permission requests (status === "notDetermined")

## Test plan
- [ ] Test microphone permission flow on iOS
- [ ] Test photo library permission flow on iOS
- [ ] Test camera permission flow on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added confirmation prompts for recording, photo library, and camera access requests. Users will now see a pre-permission dialog before system permission prompts appear, clarifying intent before granting access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->