### PR TITLE
Potential fix for code scanning alert no. 56: Incomplete URL substring sanitization

### DIFF
--- a/packages/convex/__tests__/workflows/steps/linkMetadata/fetchMetadata.test.ts
+++ b/packages/convex/__tests__/workflows/steps/linkMetadata/fetchMetadata.test.ts
@@ -230,20 +230,23 @@ describe("fetchMetadata", () => {
             ? input.toString()
             : input;
 
-      if (typeof url === "string" && new URL(url).hostname.endsWith("cdninstagram.com")) {
-        return {
-          ok: true,
-          status: 200,
-          headers: {
-            get: (header: string) =>
-              header === "content-type"
-                ? url.endsWith(".mp4")
-                  ? "video/mp4"
-                  : "image/jpeg"
-                : null,
-          },
-          arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
-        };
+      if (typeof url === "string") {
+        const hostname = new URL(url).hostname;
+        if (hostname === "cdninstagram.com") {
+          return {
+            ok: true,
+            status: 200,
+            headers: {
+              get: (header: string) =>
+                header === "content-type"
+                  ? url.endsWith(".mp4")
+                    ? "video/mp4"
+                    : "image/jpeg"
+                  : null,
+            },
+            arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
+          };
+        }
       }
 
       throw new Error(`Unexpected fetch URL: ${String(url)}`);


### PR DESCRIPTION
Potential fix for [https://github.com/praveenjuge/teak/security/code-scanning/56](https://github.com/praveenjuge/teak/security/code-scanning/56)

In general, to fix incomplete URL substring sanitization, you should avoid host checks based on `includes`, `endsWith`, or other substring logic and instead strictly compare the parsed URL host against an explicit whitelist of allowed hostnames. If subdomains are intended to be allowed, the logic should deliberately and safely account for that (e.g., check for `host === "example.com"` or `host.endsWith(".example.com")` with care for edge cases).

For this specific test file, on line 233 the code currently allows any hostname that merely ends with `"cdninstagram.com"`. Since the test data uses URLs exactly like `https://cdninstagram.com/...`, we can narrow the condition to permit only the precise host `cdninstagram.com`. This preserves test behavior while removing the problematic pattern. Concretely, we should:

- Parse the URL once and store its hostname in a local variable (for clarity and reuse).
- Change the condition from `.endsWith("cdninstagram.com")` to a strict equality check against `cdninstagram.com`.

No new imports are needed, since the `URL` constructor is already used. The change is confined to the `mockFetch.mockImplementation` block in `packages/convex/__tests__/workflows/steps/linkMetadata/fetchMetadata.test.ts`, around lines 225–249.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
