### PR TITLE
[codex] migrate API key management

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "portless api.teak tsx watch --import ./src/instrument.ts src/server.ts",
+    "dev": "portless api.teak tsx watch src/server.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node --import ./dist/instrument.js dist/server.js",
     "lint": "ultracite check src",

--- a/apps/desktop/src/pages/SettingsPage.tsx
+++ b/apps/desktop/src/pages/SettingsPage.tsx
@@ -53,6 +53,8 @@ export function SettingsPage({ onNavigateBack }: SettingsPageProps) {
         onCreateCustomerPortal={settings.handleCreateCustomerPortal}
         onDeleteAccount={settings.handleDeleteAccount}
         onDeleteDialogOpenChange={settings.setDeleteDialogOpen}
+        onRevokeApiKey={settings.handleRevokeApiKey}
+        onRotateApiKey={settings.handleRotateApiKey}
         onSignOut={settings.handleSignOut}
         onUpgrade={() => {
           void handleUpgradeClick();

--- a/apps/docs/src/content/changelog/2026-06-15.mdx
+++ b/apps/docs/src/content/changelog/2026-06-15.mdx
@@ -1,0 +1,7 @@
+---
+title: "June 2026: better API key management"
+date: "2026-06-15"
+---
+
+- API keys now have a dedicated management window in Settings, with clearer status, copy, revoke, disable, and regenerate controls.
+- Existing keys continue to work, and keys that should be refreshed are marked with an update prompt in Settings.

--- a/apps/docs/src/content/docs/docs/api.mdx
+++ b/apps/docs/src/content/docs/docs/api.mdx
@@ -25,10 +25,10 @@ See the dedicated [MCP docs](./mcp) for tool contracts and JSON-RPC examples.
 All API requests require your Teak API key in the `Authorization` header:
 
 ```bash
-Authorization: Bearer teakapi_xxx_xxx
+Authorization: Bearer teakapi_secret_live_a1b2c3d4_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
-Generate API keys in Teak Settings: `https://app.teakvault.com/settings`.
+Generate and manage API keys in Teak Settings: `https://app.teakvault.com/settings`.
 
 ## Headers
 

--- a/apps/docs/src/content/docs/docs/mcp.mdx
+++ b/apps/docs/src/content/docs/docs/mcp.mdx
@@ -15,10 +15,10 @@ Teak provides a remote MCP server at `https://api.teakvault.com/mcp`.
 All MCP requests require your Teak API key in the `Authorization` header:
 
 ```bash
-Authorization: Bearer teakapi_xxx_xxx
+Authorization: Bearer teakapi_secret_live_a1b2c3d4_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
 
-Generate API keys in Teak Settings: `https://app.teakvault.com/settings`.
+Generate and manage API keys in Teak Settings: `https://app.teakvault.com/settings`.
 
 ## Transport
 

--- a/apps/docs/src/content/docs/docs/raycast.mdx
+++ b/apps/docs/src/content/docs/docs/raycast.mdx
@@ -7,7 +7,7 @@ Use Teak in Raycast to save ideas and find cards without leaving your keyboard f
 
 ## Quick setup
 
-1. In Teak, open `/settings` > **API Keys**, then generate and copy a key.
+1. In Teak, open `/settings`, choose **Manage API Keys**, then generate and copy a key.
 2. Install the extension:
 
 [![Install teak-raycast Raycast Extension](https://www.raycast.com/praveenjuge/teak-raycast/install_button@2x.png?v=1.1)](https://www.raycast.com/praveenjuge/teak-raycast)
@@ -43,4 +43,4 @@ AI tools use the same API key as the extension — no extra setup required.
 ## Security
 
 - Your API key only connects Raycast to your Teak account.
-- Revoke or regenerate it anytime from Teak Settings.
+- Revoke, disable, or regenerate it anytime from Teak Settings.

--- a/apps/raycast/README.md
+++ b/apps/raycast/README.md
@@ -15,6 +15,6 @@ Keyboard-first Teak workflows for capture and retrieval directly inside Raycast.
 
 ## Troubleshooting
 
-- Invalid key errors: regenerate key in Teak Settings > API Keys, then update extension preferences.
+- Invalid key errors: regenerate key in Teak Settings > Manage API Keys, then update extension preferences.
 - Rate limited errors: wait briefly and retry.
 - Network errors: verify connectivity to `app.teakvault.com` and `api.teakvault.com`.

--- a/apps/raycast/package.json
+++ b/apps/raycast/package.json
@@ -19,7 +19,7 @@
       "title": "API Key",
       "type": "password",
       "required": true,
-      "description": "Generate in Teak Settings > API Keys, then paste it here."
+      "description": "Generate in Teak Settings > Manage API Keys, then paste it here."
     }
   ],
   "commands": [

--- a/apps/raycast/raycast-env.d.ts
+++ b/apps/raycast/raycast-env.d.ts
@@ -8,7 +8,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 type ExtensionPreferences = {
-  /** API Key - Generate in Teak Settings > API Keys, then paste it here. */
+  /** API Key - Generate in Teak Settings > Manage API Keys, then paste it here. */
   "apiKey": string
 }
 

--- a/apps/raycast/src/__tests__/api.test.ts
+++ b/apps/raycast/src/__tests__/api.test.ts
@@ -64,6 +64,13 @@ describe("raycast api helpers", () => {
     expect(getRecoveryHint(error)).toContain("Check network connectivity");
   });
 
+  test("maps missing local api gateway errors to dev guidance", () => {
+    const error = new RaycastApiError("DEV_API_UNAVAILABLE", 404);
+
+    expect(getUserFacingErrorMessage(error)).toContain("API gateway");
+    expect(getRecoveryHint(error)).toContain("bun run dev:api");
+  });
+
   test("maps not found errors without implying a card was deleted", () => {
     const error = new RaycastApiError("NOT_FOUND", 404);
 

--- a/apps/raycast/src/__tests__/api.test.ts
+++ b/apps/raycast/src/__tests__/api.test.ts
@@ -64,6 +64,15 @@ describe("raycast api helpers", () => {
     expect(getRecoveryHint(error)).toContain("Check network connectivity");
   });
 
+  test("maps API config errors to local setup guidance", () => {
+    const error = new RaycastApiError("CONFIG_ERROR", 500);
+
+    expect(getUserFacingErrorMessage(error)).toContain(
+      "missing required configuration",
+    );
+    expect(getRecoveryHint(error)).toContain("CONVEX_HTTP_BASE_URL");
+  });
+
   test("maps missing local api gateway errors to dev guidance", () => {
     const error = new RaycastApiError("DEV_API_UNAVAILABLE", 404);
 

--- a/apps/raycast/src/__tests__/api.test.ts
+++ b/apps/raycast/src/__tests__/api.test.ts
@@ -64,6 +64,16 @@ describe("raycast api helpers", () => {
     expect(getRecoveryHint(error)).toContain("Check network connectivity");
   });
 
+  test("maps not found errors without implying a card was deleted", () => {
+    const error = new RaycastApiError("NOT_FOUND", 404);
+
+    expect(getUserFacingErrorMessage(error)).toContain("requested resource");
+    expect(getUserFacingErrorMessage(error)).not.toContain(
+      "card no longer exists",
+    );
+    expect(getRecoveryHint(error)).toContain("API URL");
+  });
+
   test("handles unknown error values", () => {
     expect(getUserFacingErrorMessage(null)).toContain(
       "temporarily unavailable",

--- a/apps/raycast/src/__tests__/request.test.ts
+++ b/apps/raycast/src/__tests__/request.test.ts
@@ -216,6 +216,37 @@ describe("raycast request handling", () => {
     }
   });
 
+  test("maps missing Portless dev API registration to DEV_API_UNAVAILABLE", async () => {
+    mockRaycastApi(true);
+    const { searchCards: searchCardsInDev } = await import(
+      `../lib/api?missing-dev-api=${crypto.randomUUID()}`
+    );
+
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          "<!doctype html><html><body>No app registered for api.teak.localhost</body></html>",
+          {
+            headers: {
+              "Content-Type": "text/html",
+              "X-Portless": "1",
+            },
+            status: 404,
+          },
+        ),
+    ) as unknown as typeof fetch;
+
+    try {
+      await searchCardsInDev({ limit: 1 });
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(RaycastApiError);
+      expect((error as InstanceType<typeof RaycastApiError>).code).toBe(
+        "DEV_API_UNAVAILABLE",
+      );
+    }
+  });
+
   test("setCardFavorite patches favorite state on the favorite endpoint", async () => {
     let capturedUrl: string | null = null;
     let capturedMethod: string | null = null;

--- a/apps/raycast/src/__tests__/request.test.ts
+++ b/apps/raycast/src/__tests__/request.test.ts
@@ -216,6 +216,32 @@ describe("raycast request handling", () => {
     }
   });
 
+  test("maps API configuration failures to CONFIG_ERROR", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            code: "CONFIG_ERROR",
+            error: "Missing or invalid CONVEX_HTTP_BASE_URL",
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 500,
+          },
+        ),
+    ) as unknown as typeof fetch;
+
+    try {
+      await searchCards({ limit: 1 });
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(RaycastApiError);
+      expect((error as InstanceType<typeof RaycastApiError>).code).toBe(
+        "CONFIG_ERROR",
+      );
+    }
+  });
+
   test("maps missing Portless dev API registration to DEV_API_UNAVAILABLE", async () => {
     mockRaycastApi(true);
     const { searchCards: searchCardsInDev } = await import(

--- a/apps/raycast/src/components/CardsListCommand.tsx
+++ b/apps/raycast/src/components/CardsListCommand.tsx
@@ -137,12 +137,6 @@ export function CardsListCommand({
         setItems(response.items);
       } catch (requestError) {
         const message = getUserFacingErrorMessage(requestError);
-        console.error("[Teak Raycast] Cards list failed", {
-          error: requestError,
-          input,
-          message,
-          navigationTitle,
-        });
         setError(message);
         setItems([]);
       } finally {

--- a/apps/raycast/src/components/CardsListCommand.tsx
+++ b/apps/raycast/src/components/CardsListCommand.tsx
@@ -137,6 +137,12 @@ export function CardsListCommand({
         setItems(response.items);
       } catch (requestError) {
         const message = getUserFacingErrorMessage(requestError);
+        console.error("[Teak Raycast] Cards list failed", {
+          error: requestError,
+          input,
+          message,
+          navigationTitle,
+        });
         setError(message);
         setItems([]);
       } finally {

--- a/apps/raycast/src/components/MissingApiKeyDetail.tsx
+++ b/apps/raycast/src/components/MissingApiKeyDetail.tsx
@@ -17,7 +17,7 @@ export function MissingApiKeyDetail() {
       markdown={[
         "# API key required",
         "",
-        "Create an API key in **Teak Settings > API Keys** and add it to Raycast preferences.",
+        "Create an API key in **Teak Settings > Manage API Keys** and add it to Raycast preferences.",
         "",
         "Use **Set API Key** to open extension preferences instantly.",
       ].join("\n")}

--- a/apps/raycast/src/lib/api.ts
+++ b/apps/raycast/src/lib/api.ts
@@ -121,6 +121,22 @@ const buildHeaders = (apiKey: string, initHeaders?: HeadersInit): Headers => {
   return headers;
 };
 
+const logApiRequestFailure = (
+  context: Record<string, unknown>,
+  error?: unknown,
+) => {
+  console.error("[Teak Raycast] API request failed", {
+    ...context,
+    error:
+      error instanceof Error
+        ? {
+            message: error.message,
+            name: error.name,
+          }
+        : error,
+  });
+};
+
 export const request = async <T>(
   path: string,
   parseResponse: (payload: unknown) => T,
@@ -151,14 +167,31 @@ export const request = async <T>(
 
   try {
     response = await fetch(requestUrl, requestInit);
-  } catch {
+  } catch (requestError) {
     if (fallbackUrl !== requestUrl) {
       try {
         response = await fetch(fallbackUrl, requestInit);
-      } catch {
+      } catch (fallbackError) {
+        logApiRequestFailure(
+          {
+            fallbackUrl,
+            method: requestInit.method ?? "GET",
+            path,
+            url: requestUrl,
+          },
+          fallbackError,
+        );
         throw new RaycastApiError("NETWORK_ERROR");
       }
     } else {
+      logApiRequestFailure(
+        {
+          method: requestInit.method ?? "GET",
+          path,
+          url: requestUrl,
+        },
+        requestError,
+      );
       throw new RaycastApiError("NETWORK_ERROR");
     }
   } finally {
@@ -172,11 +205,20 @@ export const request = async <T>(
 
   const payload = await parseJson(response);
   const payloadCode = getPayloadCode(payload);
+  const code = getErrorCodeFromResponse(payloadCode, response.status);
 
-  throw new RaycastApiError(
-    getErrorCodeFromResponse(payloadCode, response.status),
-    response.status,
-  );
+  logApiRequestFailure({
+    code,
+    method: requestInit.method ?? "GET",
+    path,
+    payload,
+    payloadCode,
+    status: response.status,
+    statusText: response.statusText,
+    url: response.url || requestUrl,
+  });
+
+  throw new RaycastApiError(code, response.status);
 };
 
 export const createCard = (

--- a/apps/raycast/src/lib/api.ts
+++ b/apps/raycast/src/lib/api.ts
@@ -1,3 +1,4 @@
+import { environment } from "@raycast/api";
 import {
   buildCardsSearchParams,
   DEFAULT_LIMIT,
@@ -74,6 +75,30 @@ const getErrorCodeFromResponse = (
   }
 
   return toErrorCode(payloadCode, "REQUEST_FAILED");
+};
+
+const isMissingDevApiGatewayResponse = (
+  response: Response,
+  payload: unknown,
+  requestUrl: string,
+): boolean => {
+  if (!environment.isDevelopment || response.status !== 404 || payload) {
+    return false;
+  }
+
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(requestUrl);
+  } catch {
+    return false;
+  }
+
+  return (
+    parsedUrl.hostname === "api.teak.localhost" &&
+    response.headers.get("x-portless") === "1" &&
+    !response.headers.get("content-type")?.includes("application/json")
+  );
 };
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
@@ -205,10 +230,13 @@ export const request = async <T>(
 
   const payload = await parseJson(response);
   const payloadCode = getPayloadCode(payload);
-  const code = getErrorCodeFromResponse(payloadCode, response.status);
+  const code = isMissingDevApiGatewayResponse(response, payload, requestUrl)
+    ? "DEV_API_UNAVAILABLE"
+    : getErrorCodeFromResponse(payloadCode, response.status);
 
   logApiRequestFailure({
     code,
+    contentType: response.headers.get("content-type"),
     method: requestInit.method ?? "GET",
     path,
     payload,
@@ -216,6 +244,7 @@ export const request = async <T>(
     status: response.status,
     statusText: response.statusText,
     url: response.url || requestUrl,
+    xPortless: response.headers.get("x-portless"),
   });
 
   throw new RaycastApiError(code, response.status);

--- a/apps/raycast/src/lib/apiErrors.ts
+++ b/apps/raycast/src/lib/apiErrors.ts
@@ -3,6 +3,7 @@ export const MAX_LIMIT = 100;
 
 const KNOWN_ERROR_CODES = [
   "BAD_REQUEST",
+  "DEV_API_UNAVAILABLE",
   "INTERNAL_ERROR",
   "INVALID_API_KEY",
   "INVALID_INPUT",
@@ -36,6 +37,8 @@ const getErrorMessage = (code: RaycastApiErrorCode): string => {
       return "Too many requests right now. Please wait a moment and try again.";
     case "NETWORK_ERROR":
       return "Unable to reach Teak. Check your internet connection and try again.";
+    case "DEV_API_UNAVAILABLE":
+      return "Local Teak API gateway is not running.";
     case "NOT_FOUND":
       return "Teak could not find the requested resource.";
     case "INVALID_INPUT":
@@ -150,6 +153,8 @@ export const getRecoveryHint = (error: unknown): string | null => {
       return "Wait a few seconds, then retry.";
     case "NETWORK_ERROR":
       return "Check network connectivity, then retry.";
+    case "DEV_API_UNAVAILABLE":
+      return "Run bun run dev:api from the Teak repo, or set TEAK_DEV_API_URL to a running API URL.";
     case "NOT_FOUND":
       return "Check your API key, API URL, and network connection, then retry.";
     default:

--- a/apps/raycast/src/lib/apiErrors.ts
+++ b/apps/raycast/src/lib/apiErrors.ts
@@ -37,7 +37,7 @@ const getErrorMessage = (code: RaycastApiErrorCode): string => {
     case "NETWORK_ERROR":
       return "Unable to reach Teak. Check your internet connection and try again.";
     case "NOT_FOUND":
-      return "This card no longer exists in Teak.";
+      return "Teak could not find the requested resource.";
     case "INVALID_INPUT":
     case "BAD_REQUEST":
       return "The request could not be processed. Please check your input and try again.";
@@ -151,7 +151,7 @@ export const getRecoveryHint = (error: unknown): string | null => {
     case "NETWORK_ERROR":
       return "Check network connectivity, then retry.";
     case "NOT_FOUND":
-      return "Refresh the card list and try again.";
+      return "Check your API key, API URL, and network connection, then retry.";
     default:
       return null;
   }

--- a/apps/raycast/src/lib/apiErrors.ts
+++ b/apps/raycast/src/lib/apiErrors.ts
@@ -31,7 +31,7 @@ const getErrorMessage = (code: RaycastApiErrorCode): string => {
       return "Set your Teak API key in extension preferences to continue.";
     case "INVALID_API_KEY":
     case "UNAUTHORIZED":
-      return "Your Teak API key is invalid or revoked. Generate a new key in Teak Settings > API Keys.";
+      return "Your Teak API key is invalid or revoked. Generate a new key in Teak Settings > Manage API Keys.";
     case "RATE_LIMITED":
       return "Too many requests right now. Please wait a moment and try again.";
     case "NETWORK_ERROR":

--- a/apps/raycast/src/lib/apiErrors.ts
+++ b/apps/raycast/src/lib/apiErrors.ts
@@ -3,6 +3,7 @@ export const MAX_LIMIT = 100;
 
 const KNOWN_ERROR_CODES = [
   "BAD_REQUEST",
+  "CONFIG_ERROR",
   "DEV_API_UNAVAILABLE",
   "INTERNAL_ERROR",
   "INVALID_API_KEY",
@@ -37,6 +38,8 @@ const getErrorMessage = (code: RaycastApiErrorCode): string => {
       return "Too many requests right now. Please wait a moment and try again.";
     case "NETWORK_ERROR":
       return "Unable to reach Teak. Check your internet connection and try again.";
+    case "CONFIG_ERROR":
+      return "Teak API is missing required configuration.";
     case "DEV_API_UNAVAILABLE":
       return "Local Teak API gateway is not running.";
     case "NOT_FOUND":
@@ -153,6 +156,8 @@ export const getRecoveryHint = (error: unknown): string | null => {
       return "Wait a few seconds, then retry.";
     case "NETWORK_ERROR":
       return "Check network connectivity, then retry.";
+    case "CONFIG_ERROR":
+      return "For local development, set CONVEX_HTTP_BASE_URL in apps/api/.env and restart bun run dev:api.";
     case "DEV_API_UNAVAILABLE":
       return "Run bun run dev:api from the Teak repo, or set TEAK_DEV_API_URL to a running API URL.";
     case "NOT_FOUND":

--- a/apps/raycast/src/tags.tsx
+++ b/apps/raycast/src/tags.tsx
@@ -63,7 +63,12 @@ export default function TagsCommand() {
         }
       } catch (requestError) {
         if (isMounted) {
-          setError(getUserFacingErrorMessage(requestError));
+          const message = getUserFacingErrorMessage(requestError);
+          console.error("[Teak Raycast] Tags list failed", {
+            error: requestError,
+            message,
+          });
+          setError(message);
           setTags([]);
         }
       } finally {

--- a/apps/raycast/src/tags.tsx
+++ b/apps/raycast/src/tags.tsx
@@ -64,10 +64,6 @@ export default function TagsCommand() {
       } catch (requestError) {
         if (isMounted) {
           const message = getUserFacingErrorMessage(requestError);
-          console.error("[Teak Raycast] Tags list failed", {
-            error: requestError,
-            message,
-          });
           setError(message);
           setTags([]);
         }

--- a/apps/web/src/app/(settings)/settings/page.tsx
+++ b/apps/web/src/app/(settings)/settings/page.tsx
@@ -146,6 +146,8 @@ export default function ProfileSettingsPage() {
       onCreateCustomerPortal={settings.handleCreateCustomerPortal}
       onDeleteAccount={settings.handleDeleteAccount}
       onDeleteDialogOpenChange={settings.setDeleteDialogOpen}
+      onRevokeApiKey={settings.handleRevokeApiKey}
+      onRotateApiKey={settings.handleRotateApiKey}
       onSignOut={settings.handleSignOut}
       onUpgrade={() => {
         setSubscriptionOpen(true);

--- a/bun.lock
+++ b/bun.lock
@@ -219,6 +219,7 @@
         "@convex-dev/workpool": "^0.4.6",
         "@onkernel/sdk": "^0.52.0",
         "@polar-sh/sdk": "^0.47.1",
+        "@vllnt/convex-api-keys": "0.2.0",
         "ai": "^6.0.184",
         "better-auth": "1.6.11",
         "convex": "^1.39.0",
@@ -609,6 +610,8 @@
     "@convex-dev/ratelimiter": ["@convex-dev/ratelimiter@0.1.7", "", { "peerDependencies": { "convex": "~1.16.5 || ~1.17.0" } }, "sha512-fzrx0mrWxF4n+F54bg84VQOK62C0Qxcu8UHuBIKOdl1p+frBsYaakhT7S4EMPKKt9E/tS4gJKl+m8UKqZNYwiQ=="],
 
     "@convex-dev/resend": ["@convex-dev/resend@0.2.4", "", { "dependencies": { "@convex-dev/rate-limiter": "^0.3.0", "@convex-dev/workpool": "^0.4.6", "remeda": "^2.26.0", "resend": "^6.6.0", "svix": "^1.70.0" }, "peerDependencies": { "convex": "^1.31.7", "convex-helpers": "^0.1.106" } }, "sha512-R009qlbXG+6R0p/WmkTbfHzBo48ocKyfoqRAJ41AQdQDrdW6pPZrVOGgTOTLSIZwmXZp+1BbiNpzjc/+Zh/OVg=="],
+
+    "@convex-dev/sharded-counter": ["@convex-dev/sharded-counter@0.2.0", "", { "peerDependencies": { "convex": "^1.24.8" } }, "sha512-Qv1TvFXyQ60rADS1fWH01mnMDNSPfmKKowXva6WxIXGIC2ta5xvohe9TfUhXp4AT1vtOXoFgse3Z9mJB9fJlSQ=="],
 
     "@convex-dev/workflow": ["@convex-dev/workflow@0.3.12", "", { "dependencies": { "async-channel": "^0.2.0" }, "peerDependencies": { "@convex-dev/workpool": "^0.3.0 || ^0.4.0", "convex": "^1.31.7", "convex-helpers": "^0.1.99" } }, "sha512-4c4eSe2sXnhxE6Td4benRg6OMJahWkOHdLv++FxpjZVZUANFmJqYKZxx8Bxqs0SB4ECGd2j0MZalNppLPKxQ7Q=="],
 
@@ -1743,6 +1746,8 @@
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
 
     "@vitejs/plugin-react-swc": ["@vitejs/plugin-react-swc@4.3.1", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.0", "@swc/core": "^1.15.11" }, "peerDependencies": { "vite": "^4 || ^5 || ^6 || ^7 || ^8" } }, "sha512-PaeokKjAGraNN+s5SIApgsktnJprIyt3zgEIu7awnEdfn29QiB2crTcCzyi2XGpX9rUnTc0cKU07Wm0N0g7H2w=="],
+
+    "@vllnt/convex-api-keys": ["@vllnt/convex-api-keys@0.2.0", "", { "dependencies": { "@convex-dev/sharded-counter": "^0.2.0" }, "peerDependencies": { "convex": "^1.36.1" } }, "sha512-1m50cbGJMCbDn2TbnbOKZGAvfFz5FFMPbg4YBQJZaKXxc/3uk+aNXndf3iPhebUe7qR7mikUp43uF+sh1YXPZg=="],
 
     "@volar/kit": ["@volar/kit@2.4.28", "", { "dependencies": { "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "typesafe-path": "^0.2.2", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "typescript": "*" } }, "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg=="],
 

--- a/packages/convex/__tests__/apiKeys.test.ts
+++ b/packages/convex/__tests__/apiKeys.test.ts
@@ -6,6 +6,7 @@ import {
   listUserApiKeys,
   revokeAllActiveApiKeysForPrefixCutover,
   revokeUserApiKey,
+  rotateUserApiKey,
   validateUserApiKey,
 } from "../apiKeys";
 
@@ -16,403 +17,304 @@ const runHandler = (fn: any, ctx: any, args: any) => {
   return handler(ctx, args);
 };
 
+const toHex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+
+const hashLegacyApiKey = async (key: string): Promise<string> => {
+  const payload = `${key}:${process.env.BETTER_AUTH_SECRET ?? ""}`;
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(payload)
+  );
+  return toHex(new Uint8Array(digest));
+};
+
+const componentKey = {
+  createdAt: 300,
+  env: "live",
+  keyId: "component_key",
+  lastUsedAt: 350,
+  lookupPrefix: "a1b2c3d4",
+  metadata: undefined,
+  name: "SDK Key",
+  remaining: undefined,
+  scopes: ["full_access"],
+  status: "active",
+  tags: [],
+  type: "secret",
+};
+
+const buildLegacyQuery = (rows: any[]) => ({
+  withIndex: mock(() => ({
+    collect: mock().mockResolvedValue(rows),
+    order: mock(() => ({
+      take: mock().mockResolvedValue(rows),
+    })),
+    take: mock().mockResolvedValue(rows),
+  })),
+  filter: mock(() => ({
+    collect: mock().mockResolvedValue(rows),
+  })),
+});
+
+const buildAuth = (subject = "user_1") => ({
+  getUserIdentity: mock().mockResolvedValue({ subject }),
+});
+
 describe("apiKeys", () => {
-  test("create stores only hashed key and revokes active key", async () => {
-    const collectMock = mock()
-      .mockResolvedValueOnce([
-        {
-          _id: "old_key",
-          userId: "user_1",
-          revokedAt: undefined,
-        },
-      ])
-      .mockResolvedValueOnce([]);
-
-    const db = {
-      query: mock(() => ({
-        withIndex: mock(() => ({
-          collect: collectMock,
-          order: mock(() => ({ collect: collectMock })),
-        })),
-      })),
-      patch: mock().mockResolvedValue(null),
-      insert: mock().mockResolvedValue("new_key"),
-      get: mock(),
-    };
-
+  test("create stores new keys in the component", async () => {
+    const key = `teakapi_secret_live_a1b2c3d4_${"f".repeat(64)}`;
     const ctx = {
-      auth: {
-        getUserIdentity: mock().mockResolvedValue({ subject: "user_1" }),
-      },
-      db,
+      auth: buildAuth(),
+      runMutation: mock().mockResolvedValue({
+        key,
+        keyId: "component_key",
+      }),
     };
 
     const result = await runHandler(createUserApiKey, ctx, {
-      name: "API Keys",
+      name: "SDK Key",
     });
 
-    expect(result.id).toBe("new_key");
-    expect(result.key).toStartWith("teakapi_");
-    expect(db.patch).toHaveBeenCalledWith(
-      "apiKeys",
-      "old_key",
-      expect.objectContaining({ revokedAt: expect.any(Number) })
+    expect(result).toEqual({
+      access: "full_access",
+      createdAt: expect.any(Number),
+      id: "component_key",
+      key,
+      keyPrefix: "a1b2c3d4",
+      name: "SDK Key",
+      source: "component",
+      status: "active",
+    });
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        env: "live",
+        name: "SDK Key",
+        ownerId: "user_1",
+        scopes: ["full_access"],
+        type: "secret",
+      })
     );
-
-    const insertCall = db.insert.mock.calls[0];
-    expect(insertCall[0]).toBe("apiKeys");
-    expect(insertCall[1].keyHash).toBeString();
-    expect(insertCall[1].keyHash).not.toContain(result.key);
-    expect(insertCall[1]).not.toHaveProperty("key");
   });
 
-  test("list returns masked key metadata", async () => {
-    const collectMock = mock().mockResolvedValue([
-      {
-        _id: "k1",
-        userId: "user_1",
-        name: "API Keys",
-        keyPrefix: "abc123",
-        access: "full_access",
-        createdAt: 100,
-        updatedAt: 200,
-        lastUsedAt: 150,
-        revokedAt: undefined,
-      },
-    ]);
-
+  test("list returns component keys and legacy keys marked for update", async () => {
+    const legacyKey = {
+      _id: "legacy_key",
+      access: "full_access",
+      createdAt: 100,
+      keyPrefix: "abc123",
+      lastUsedAt: 150,
+      name: "Old Key",
+      revokedAt: undefined,
+      updatedAt: 200,
+      userId: "user_1",
+    };
     const ctx = {
-      auth: {
-        getUserIdentity: mock().mockResolvedValue({ subject: "user_1" }),
-      },
+      auth: buildAuth(),
       db: {
-        query: mock(() => ({
-          withIndex: mock(() => ({
-            collect: collectMock,
-            order: mock(() => ({ collect: collectMock })),
-          })),
-        })),
+        query: mock(() => buildLegacyQuery([legacyKey])),
       },
+      runQuery: mock().mockResolvedValue([componentKey]),
     };
 
     const result = await runHandler(listUserApiKeys, ctx, {});
-    expect(result).toHaveLength(1);
-    expect(result[0].maskedKey).toContain("••••••••");
-    expect(result[0].access).toBe("full_access");
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: "component_key",
+        maskedKey: `teakapi_secret_live_a1b2c3d4_••••••••`,
+        requiresUpdate: false,
+        source: "component",
+      }),
+      expect.objectContaining({
+        id: "legacy_key",
+        maskedKey: "abc123••••••••",
+        requiresUpdate: true,
+        source: "legacy",
+      }),
+    ]);
   });
 
-  test("revoke marks selected key as revoked", async () => {
+  test("revoke marks legacy keys as revoked", async () => {
     const ctx = {
-      auth: {
-        getUserIdentity: mock().mockResolvedValue({ subject: "user_1" }),
-      },
+      auth: buildAuth(),
       db: {
         get: mock().mockResolvedValue({
-          _id: "k1",
+          _id: "legacy_key",
           userId: "user_1",
-          revokedAt: undefined,
         }),
         patch: mock().mockResolvedValue(null),
       },
     };
 
-    await runHandler(revokeUserApiKey, ctx, { keyId: "k1" });
+    await runHandler(revokeUserApiKey, ctx, {
+      keyId: "legacy_key",
+      source: "legacy",
+    });
 
     expect(ctx.db.patch).toHaveBeenCalledWith(
-      "apiKeys",
-      "k1",
+      "legacy_key",
       expect.objectContaining({ revokedAt: expect.any(Number) })
     );
   });
 
-  test("validate accepts valid key and updates lastUsedAt", async () => {
-    const createCollectMock = mock().mockResolvedValue([]);
-    const createDb = {
-      query: mock(() => ({
-        withIndex: mock(() => ({
-          collect: createCollectMock,
-          order: mock(() => ({ collect: createCollectMock })),
-        })),
-      })),
-      patch: mock().mockResolvedValue(null),
-      insert: mock().mockResolvedValue("k_new"),
+  test("revoke component keys through the component", async () => {
+    const ctx = {
+      auth: buildAuth(),
+      runMutation: mock().mockResolvedValue(null),
     };
 
-    const createCtx = {
-      auth: {
-        getUserIdentity: mock().mockResolvedValue({ subject: "user_1" }),
-      },
-      db: createDb,
-    };
-
-    const created = await runHandler(createUserApiKey, createCtx, {
-      name: "API Keys",
+    await runHandler(revokeUserApiKey, ctx, {
+      keyId: "component_key",
+      source: "component",
     });
 
-    const insertedPayload = createDb.insert.mock.calls[0][1];
-
-    const validateCollectMock = mock().mockResolvedValue([
-      {
-        _id: "k_new",
-        userId: "user_1",
-        keyPrefix: insertedPayload.keyPrefix,
-        keyHash: insertedPayload.keyHash,
-        access: "full_access",
-        revokedAt: undefined,
-      },
+    expect(ctx.runMutation).toHaveBeenCalledTimes(1);
+    expect(ctx.runMutation.mock.calls.map((call) => call[1])).toEqual([
+      { keyId: "component_key", ownerId: "user_1" },
     ]);
+  });
 
-    const validateCtx = {
-      runQuery: mock().mockResolvedValue({
-        _id: "user_1",
+  test("rotate creates a replacement key and immediately revokes the old component key", async () => {
+    const newKey = `teakapi_secret_live_e5f6a7b8_${"a".repeat(64)}`;
+    const ctx = {
+      auth: buildAuth(),
+      runMutation: mock()
+        .mockResolvedValueOnce({
+          key: newKey,
+          keyId: "new_component_key",
+        })
+        .mockResolvedValueOnce(null),
+      runQuery: mock().mockResolvedValue([componentKey]),
+    };
+
+    const result = await runHandler(rotateUserApiKey, ctx, {
+      keyId: "component_key",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: "new_component_key",
+        key: newKey,
+        keyPrefix: "e5f6a7b8",
+        source: "component",
+      })
+    );
+    expect(ctx.runMutation.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        env: "live",
+        name: "SDK Key",
+        ownerId: "user_1",
+        scopes: ["full_access"],
+      })
+    );
+    expect(ctx.runMutation.mock.calls[1][1]).toEqual({
+      keyId: "component_key",
+      ownerId: "user_1",
+    });
+  });
+
+  test("validate accepts component keys and maps them to Teak authorization", async () => {
+    const token = `teakapi_secret_live_a1b2c3d4_${"f".repeat(64)}`;
+    const ctx = {
+      runMutation: mock().mockResolvedValue({
+        env: "live",
+        keyId: "component_key",
+        ownerId: "user_1",
+        scopes: ["full_access"],
+        tags: [],
+        type: "secret",
+        valid: true,
       }),
-      db: {
-        query: mock(() => ({
-          withIndex: mock(() => ({
-            collect: validateCollectMock,
-          })),
-        })),
-        patch: mock().mockResolvedValue(null),
-      },
-    };
-
-    const result = await runHandler(validateUserApiKey, validateCtx, {
-      token: created.key,
-    });
-
-    expect(result).toEqual({
-      keyId: "k_new",
-      userId: "user_1",
-      access: "full_access",
-    });
-    expect(validateCtx.db.patch).toHaveBeenCalledWith(
-      "apiKeys",
-      "k_new",
-      expect.objectContaining({ lastUsedAt: expect.any(Number) })
-    );
-    expect(validateCtx.runQuery).toHaveBeenCalled();
-  });
-
-  test("validate skips lastUsedAt write when recently used", async () => {
-    const createCollectMock = mock().mockResolvedValue([]);
-    const createDb = {
-      query: mock(() => ({
-        withIndex: mock(() => ({
-          collect: createCollectMock,
-          order: mock(() => ({ collect: createCollectMock })),
-        })),
-      })),
-      patch: mock().mockResolvedValue(null),
-      insert: mock().mockResolvedValue("k_recent"),
-    };
-
-    const createCtx = {
-      auth: {
-        getUserIdentity: mock().mockResolvedValue({ subject: "user_1" }),
-      },
-      db: createDb,
-    };
-
-    const created = await runHandler(createUserApiKey, createCtx, {
-      name: "API Keys",
-    });
-
-    const insertedPayload = createDb.insert.mock.calls[0][1];
-
-    const validateCollectMock = mock().mockResolvedValue([
-      {
-        _id: "k_recent",
-        userId: "user_1",
-        keyPrefix: insertedPayload.keyPrefix,
-        keyHash: insertedPayload.keyHash,
-        access: "full_access",
-        // Used moments ago, so validation must not write again.
-        lastUsedAt: Date.now(),
-        revokedAt: undefined,
-      },
-    ]);
-
-    const validateCtx = {
       runQuery: mock().mockResolvedValue({ _id: "user_1" }),
-      db: {
-        query: mock(() => ({
-          withIndex: mock(() => ({
-            collect: validateCollectMock,
-          })),
-        })),
-        patch: mock().mockResolvedValue(null),
-      },
     };
 
-    const result = await runHandler(validateUserApiKey, validateCtx, {
-      token: created.key,
-    });
+    const result = await runHandler(validateUserApiKey, ctx, { token });
 
     expect(result).toEqual({
-      keyId: "k_recent",
-      userId: "user_1",
       access: "full_access",
+      keyId: "component_key",
+      rateLimitKey: "component:component_key",
+      source: "component",
+      userId: "user_1",
     });
-    expect(validateCtx.db.patch).not.toHaveBeenCalled();
   });
 
-  test("validate refreshes lastUsedAt when stale", async () => {
-    const createCollectMock = mock().mockResolvedValue([]);
-    const createDb = {
-      query: mock(() => ({
-        withIndex: mock(() => ({
-          collect: createCollectMock,
-          order: mock(() => ({ collect: createCollectMock })),
-        })),
-      })),
-      patch: mock().mockResolvedValue(null),
-      insert: mock().mockResolvedValue("k_stale"),
-    };
-
-    const createCtx = {
-      auth: {
-        getUserIdentity: mock().mockResolvedValue({ subject: "user_1" }),
-      },
-      db: createDb,
-    };
-
-    const created = await runHandler(createUserApiKey, createCtx, {
-      name: "API Keys",
-    });
-
-    const insertedPayload = createDb.insert.mock.calls[0][1];
-
-    const validateCollectMock = mock().mockResolvedValue([
-      {
-        _id: "k_stale",
-        userId: "user_1",
-        keyPrefix: insertedPayload.keyPrefix,
-        keyHash: insertedPayload.keyHash,
-        access: "full_access",
-        // Used long ago (1 hour), so validation should refresh it.
-        lastUsedAt: Date.now() - 60 * 60 * 1000,
-        revokedAt: undefined,
-      },
-    ]);
-
-    const validateCtx = {
-      runQuery: mock().mockResolvedValue({ _id: "user_1" }),
-      db: {
-        query: mock(() => ({
-          withIndex: mock(() => ({
-            collect: validateCollectMock,
-          })),
-        })),
-        patch: mock().mockResolvedValue(null),
-      },
-    };
-
-    const result = await runHandler(validateUserApiKey, validateCtx, {
-      token: created.key,
-    });
-
-    expect(result).toEqual({
-      keyId: "k_stale",
-      userId: "user_1",
+  test("validate preserves legacy key compatibility", async () => {
+    const token = "teakapi_abc123_secretvalue";
+    const insertedPayload = {
       access: "full_access",
-    });
-    expect(validateCtx.db.patch).toHaveBeenCalledWith(
-      "apiKeys",
-      "k_stale",
-      expect.objectContaining({ lastUsedAt: expect.any(Number) })
-    );
-  });
-
-  test("validate rejects invalid key", async () => {
+      createdAt: 100,
+      keyHash: await hashLegacyApiKey(token),
+      keyPrefix: "abc123",
+      lastUsedAt: undefined,
+      name: "Old Key",
+      revokedAt: undefined,
+      updatedAt: 100,
+      userId: "user_1",
+    };
     const ctx = {
       db: {
-        query: mock(() => ({
-          withIndex: mock(() => ({ collect: mock().mockResolvedValue([]) })),
-        })),
-        patch: mock(),
+        patch: mock().mockResolvedValue(null),
+        query: mock(() =>
+          buildLegacyQuery([
+            {
+              _id: "legacy_key",
+              ...insertedPayload,
+            },
+          ])
+        ),
       },
+      runQuery: mock().mockResolvedValue({ _id: "user_1" }),
     };
 
     const result = await runHandler(validateUserApiKey, ctx, {
-      token: "teakapi_badprefix_secret",
+      token,
     });
 
-    expect(result).toBeNull();
-    expect(ctx.db.patch).not.toHaveBeenCalled();
-  });
-
-  test("validate revokes matched key when auth user no longer exists", async () => {
-    const createCollectMock = mock().mockResolvedValue([]);
-    const createDb = {
-      query: mock(() => ({
-        withIndex: mock(() => ({
-          collect: createCollectMock,
-          order: mock(() => ({ collect: createCollectMock })),
-        })),
-      })),
-      patch: mock().mockResolvedValue(null),
-      insert: mock().mockResolvedValue("k_deleted"),
-    };
-
-    const createCtx = {
-      auth: {
-        getUserIdentity: mock().mockResolvedValue({ subject: "deleted_user" }),
-      },
-      db: createDb,
-    };
-
-    const created = await runHandler(createUserApiKey, createCtx, {
-      name: "API Keys",
-    });
-    const insertedPayload = createDb.insert.mock.calls[0][1];
-    const matchedCandidate = {
-      _id: "k_deleted",
-      userId: "deleted_user",
-      keyPrefix: insertedPayload.keyPrefix,
-      keyHash: insertedPayload.keyHash,
+    expect(result).toEqual({
       access: "full_access",
-      revokedAt: undefined,
-    };
-    const validateCollectMock = mock().mockResolvedValue([matchedCandidate]);
-
-    const validateCtx = {
-      runQuery: mock().mockResolvedValue(null),
-      db: {
-        query: mock(() => ({
-          withIndex: mock(() => ({
-            collect: validateCollectMock,
-          })),
-        })),
-        patch: mock().mockResolvedValue(null),
-      },
-    };
-
-    const result = await runHandler(validateUserApiKey, validateCtx, {
-      token: created.key,
+      keyId: "legacy_key",
+      rateLimitKey: "legacy:legacy_key",
+      source: "legacy",
+      userId: "user_1",
     });
-
-    expect(result).toBeNull();
-    expect(validateCtx.db.patch).toHaveBeenCalledWith(
-      "apiKeys",
-      "k_deleted",
-      expect.objectContaining({ revokedAt: expect.any(Number) })
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "legacy_key",
+      expect.objectContaining({ lastUsedAt: expect.any(Number) })
     );
   });
 
-  test("cutover revoke-all revokes every active key", async () => {
+  test("validate rejects malformed keys without touching storage or components", async () => {
+    const ctx = {
+      db: {
+        query: mock(),
+      },
+      runMutation: mock(),
+      runQuery: mock(),
+    };
+
+    const result = await runHandler(validateUserApiKey, ctx, {
+      token: "teakapi_bad",
+    });
+
+    expect(result).toBeNull();
+    expect(ctx.db.query).not.toHaveBeenCalled();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+    expect(ctx.runQuery).not.toHaveBeenCalled();
+  });
+
+  test("cutover helper only revokes legacy active keys", async () => {
     const activeKeys = [
-      { _id: "k1", revokedAt: undefined },
-      { _id: "k2", revokedAt: undefined },
+      { _id: "legacy_1", revokedAt: undefined },
+      { _id: "legacy_2", revokedAt: undefined },
     ];
 
     const ctx = {
       db: {
-        query: mock(() => ({
-          filter: mock(() => ({
-            collect: mock().mockResolvedValue(activeKeys),
-          })),
-        })),
         patch: mock().mockResolvedValue(null),
+        query: mock(() => buildLegacyQuery(activeKeys)),
       },
     };
 
@@ -423,17 +325,6 @@ describe("apiKeys", () => {
     );
 
     expect(result.revokedCount).toBe(2);
-    expect(result.revokedAt).toEqual(expect.any(Number));
     expect(ctx.db.patch).toHaveBeenCalledTimes(2);
-    expect(ctx.db.patch).toHaveBeenCalledWith(
-      "apiKeys",
-      "k1",
-      expect.objectContaining({ revokedAt: expect.any(Number) })
-    );
-    expect(ctx.db.patch).toHaveBeenCalledWith(
-      "apiKeys",
-      "k2",
-      expect.objectContaining({ revokedAt: expect.any(Number) })
-    );
   });
 });

--- a/packages/convex/__tests__/apiKeys.test.ts
+++ b/packages/convex/__tests__/apiKeys.test.ts
@@ -215,6 +215,27 @@ describe("apiKeys", () => {
     });
   });
 
+  test("rotate rejects exhausted component keys on the server", async () => {
+    const ctx = {
+      auth: buildAuth(),
+      runMutation: mock(),
+      runQuery: mock().mockResolvedValue([
+        {
+          ...componentKey,
+          status: "exhausted",
+        },
+      ]),
+    };
+
+    await expect(
+      runHandler(rotateUserApiKey, ctx, {
+        keyId: "component_key",
+      })
+    ).rejects.toThrow("API key cannot be regenerated");
+
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
   test("validate accepts component keys and maps them to Teak authorization", async () => {
     const token = `teakapi_secret_live_a1b2c3d4_${"f".repeat(64)}`;
     const ctx = {

--- a/packages/convex/__tests__/convex.config.test.ts
+++ b/packages/convex/__tests__/convex.config.test.ts
@@ -22,6 +22,9 @@ mock.module("@convex-dev/ratelimiter/convex.config", () => ({
 mock.module("@convex-dev/r2/convex.config.js", () => ({
   default: { componentDefinitionPath: "r2" },
 }));
+mock.module("@vllnt/convex-api-keys/convex.config", () => ({
+  default: { componentDefinitionPath: "apiKeys" },
+}));
 
 describe("convex.config.ts", () => {
   test("module exports", async () => {

--- a/packages/convex/__tests__/publicApiHttp.test.ts
+++ b/packages/convex/__tests__/publicApiHttp.test.ts
@@ -25,6 +25,8 @@ const buildAuthorizedMutationMock = () =>
       keyId: "key_1",
       userId: "user_1",
       access: "full_access",
+      source: "legacy",
+      rateLimitKey: "legacy:key_1",
     })
     // ...then the per-key rate limit check.
     .mockResolvedValueOnce({ ok: true, retryAt: undefined });
@@ -69,6 +71,8 @@ describe("publicApiHttp", () => {
         keyId: "key_1",
         userId: "user_1",
         access: "full_access",
+        source: "legacy",
+        rateLimitKey: "legacy:key_1",
       })
       // ...then the per-key rate limit rejects.
       .mockResolvedValueOnce({
@@ -102,6 +106,8 @@ describe("publicApiHttp", () => {
         keyId: "key_1",
         userId: "user_1",
         access: "full_access",
+        source: "legacy",
+        rateLimitKey: "legacy:key_1",
       })
       // ...then the per-key rate limit hits document contention.
       .mockRejectedValueOnce(
@@ -177,6 +183,43 @@ describe("publicApiHttp", () => {
     expect(payload.code).toBe("INVALID_API_KEY");
     // Only the invalid-auth bucket consume runs; validation is never reached.
     expect(runMutation).toHaveBeenCalledTimes(1);
+  });
+
+  test("createCardV1 accepts component-format API keys before validation", async () => {
+    const token = `teakapi_secret_live_a1b2c3d4_${"f".repeat(64)}`;
+    const runMutation = mock()
+      .mockResolvedValueOnce({
+        access: "full_access",
+        keyId: "component_key",
+        rateLimitKey: "component:component_key",
+        source: "component",
+        userId: "user_1",
+      })
+      .mockResolvedValueOnce({ ok: true, retryAt: undefined })
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({
+        cardId: "card_1",
+        status: "created",
+    });
+
+    const response = await runHandler(
+      createCardV1,
+      { runMutation, runQuery: mock() },
+      new Request("https://example.com/v1/cards", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ content: "hello" }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(runMutation.mock.calls[0][1]).toEqual({ token });
+    expect(runMutation.mock.calls[1][1]).toEqual({
+      rateLimitKey: "key:component:component_key",
+    });
   });
 
   test("createCardV1 returns 429 when the shared invalid-auth bucket is exhausted", async () => {
@@ -350,6 +393,8 @@ describe("publicApiHttp", () => {
         access: "full_access",
         keyId: "key_1",
         userId: "user_1",
+        source: "legacy",
+        rateLimitKey: "legacy:key_1",
       })
       // ...then per-key rate limit...
       .mockResolvedValueOnce({ ok: true, retryAt: undefined })

--- a/packages/convex/_generated/api.d.ts
+++ b/packages/convex/_generated/api.d.ts
@@ -252,4 +252,5 @@ export declare const components: {
   resend: import("@convex-dev/resend/_generated/component.js").ComponentApi<"resend">;
   ratelimiter: import("@convex-dev/ratelimiter/_generated/component.js").ComponentApi<"ratelimiter">;
   r2: import("@convex-dev/r2/_generated/component.js").ComponentApi<"r2">;
+  apiKeys: import("@vllnt/convex-api-keys/_generated/component.js").ComponentApi<"apiKeys">;
 };

--- a/packages/convex/apiKeys.ts
+++ b/packages/convex/apiKeys.ts
@@ -179,6 +179,9 @@ const getComponentKeyForOwner = async (
   return key;
 };
 
+const isRotatableComponentKeyStatus = (status: KeyMetadata["status"]) =>
+  status === "active" || status === "disabled";
+
 const validateComponentApiKey = async (
   ctx: MutationCtx,
   token: string
@@ -381,6 +384,10 @@ export const rotateUserApiKey = mutation({
   handler: async (ctx, args) => {
     const ownerId = await getAuthenticatedOwnerId(ctx);
     const existing = await getComponentKeyForOwner(ctx, ownerId, args.keyId);
+    if (!isRotatableComponentKeyStatus(existing.status)) {
+      throw new Error("API key cannot be regenerated");
+    }
+
     const name = normalizeApiKeyName(existing.name);
     const created = await componentApiKeys.create(ctx, {
       env: COMPONENT_ENV,

--- a/packages/convex/apiKeys.ts
+++ b/packages/convex/apiKeys.ts
@@ -1,52 +1,80 @@
+import { ApiKeys, type KeyMetadata } from "@vllnt/convex-api-keys";
 import { v } from "convex/values";
 import { components } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
 import {
   internalMutation,
   type MutationCtx,
   mutation,
+  type QueryCtx,
   query,
 } from "./_generated/server";
 import {
   API_KEY_TOKEN_PREFIX,
-  isWellFormedApiKey,
+  getApiKeyFormat,
+  isLegacyApiKey,
 } from "./shared/apiKeyFormat";
 
-const API_KEY_NAME_DEFAULT = "API Keys";
+const API_KEY_NAME_DEFAULT = "Default API key";
+const API_KEY_NAME_LEGACY_DEFAULT = "API Keys";
 const API_KEY_ACCESS = "full_access" as const;
-const KEY_PREFIX_BYTES = 6;
-const KEY_SECRET_BYTES = 24;
-// Only refresh `lastUsedAt` when the recorded value is older than this window.
-// Throttling the write keeps validation effectively read-only on the hot path
-// so concurrent requests sharing one key don't contend on a single document.
+const COMPONENT_ENV = "live";
+const COMPONENT_SCOPES = [API_KEY_ACCESS];
+const LIST_LIMIT = 100;
+// Only refresh legacy `lastUsedAt` when the recorded value is older than this
+// window, preserving the low-contention behavior existing production keys had.
 const LAST_USED_THROTTLE_MS = 5 * 60 * 1000;
 
+const componentApiKeys = new ApiKeys(components.apiKeys, {
+  defaultType: "secret",
+  prefix: API_KEY_TOKEN_PREFIX,
+});
+
 const apiKeyAccessValidator = v.literal(API_KEY_ACCESS);
+const apiKeySourceValidator = v.union(
+  v.literal("component"),
+  v.literal("legacy")
+);
+const apiKeyStatusValidator = v.union(
+  v.literal("active"),
+  v.literal("disabled"),
+  v.literal("rotating"),
+  v.literal("expired"),
+  v.literal("exhausted")
+);
 
 const listedApiKeyValidator = v.object({
-  id: v.id("apiKeys"),
+  id: v.string(),
   name: v.string(),
   keyPrefix: v.string(),
   maskedKey: v.string(),
   access: apiKeyAccessValidator,
+  source: apiKeySourceValidator,
+  status: apiKeyStatusValidator,
+  requiresUpdate: v.boolean(),
   createdAt: v.number(),
   updatedAt: v.number(),
   lastUsedAt: v.optional(v.number()),
 });
 
 const createdApiKeyValidator = v.object({
-  id: v.id("apiKeys"),
+  id: v.string(),
   name: v.string(),
   keyPrefix: v.string(),
   key: v.string(),
   access: apiKeyAccessValidator,
+  source: v.literal("component"),
+  status: v.literal("active"),
   createdAt: v.number(),
 });
 
 const validatedApiKeyValidator = v.union(
   v.object({
-    keyId: v.id("apiKeys"),
+    keyId: v.string(),
     userId: v.string(),
     access: apiKeyAccessValidator,
+    source: apiKeySourceValidator,
+    rateLimitKey: v.string(),
   }),
   v.null()
 );
@@ -56,21 +84,17 @@ const revokeAllApiKeysResultValidator = v.object({
   revokedAt: v.number(),
 });
 
+const componentKeyActionValidator = v.object({
+  keyId: v.string(),
+});
+
+const revokeKeyArgsValidator = v.object({
+  keyId: v.string(),
+  source: apiKeySourceValidator,
+});
+
 const toHex = (bytes: Uint8Array): string =>
   Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
-
-const createRandomHex = (size: number): string => {
-  const bytes = new Uint8Array(size);
-  crypto.getRandomValues(bytes);
-  return toHex(bytes);
-};
-
-const buildApiKey = (): { key: string; keyPrefix: string } => {
-  const keyPrefix = createRandomHex(KEY_PREFIX_BYTES);
-  const secret = createRandomHex(KEY_SECRET_BYTES);
-  const key = `${API_KEY_TOKEN_PREFIX}_${keyPrefix}_${secret}`;
-  return { key, keyPrefix };
-};
 
 const hashApiKey = async (key: string): Promise<string> => {
   const pepper = process.env.BETTER_AUTH_SECRET ?? "";
@@ -95,33 +119,161 @@ const timingSafeEqual = (left: string, right: string): boolean => {
   return mismatch === 0;
 };
 
-const revokeActiveKeysForUser = async (
-  ctx: MutationCtx,
-  userId: string,
-  now: number
-): Promise<number> => {
-  const activeKeys = await ctx.db
-    .query("apiKeys")
-    .withIndex("by_user_revoked", (q) =>
-      q.eq("userId", userId).eq("revokedAt", undefined)
-    )
-    .collect();
-
-  for (const key of activeKeys) {
-    await ctx.db.patch("apiKeys", key._id, {
-      revokedAt: now,
-      updatedAt: now,
-    });
-  }
-
-  return activeKeys.length;
-};
-
 const getAuthUserById = async (ctx: MutationCtx, userId: string) =>
   ctx.runQuery(components.betterAuth.adapter.findOne, {
     model: "user",
     where: [{ field: "_id", operator: "eq", value: userId }],
   });
+
+const getAuthenticatedOwnerId = async (
+  ctx: QueryCtx | MutationCtx
+): Promise<string> => {
+  const user = await ctx.auth.getUserIdentity();
+  if (!user) {
+    throw new Error("User must be authenticated");
+  }
+  return user.subject;
+};
+
+const getComponentKeysForOwner = async (
+  ctx: QueryCtx,
+  ownerId: string
+): Promise<KeyMetadata[]> => {
+  const keys = await componentApiKeys.list(ctx, {
+    ownerId,
+    limit: LIST_LIMIT,
+  });
+
+  return keys.filter((key) => key.status !== "revoked");
+};
+
+const normalizeApiKeyName = (name: string) =>
+  name === API_KEY_NAME_LEGACY_DEFAULT ? API_KEY_NAME_DEFAULT : name;
+
+const mapComponentKey = (key: KeyMetadata) => ({
+  id: key.keyId,
+  name: normalizeApiKeyName(key.name),
+  keyPrefix: key.lookupPrefix,
+  maskedKey: `${API_KEY_TOKEN_PREFIX}_${key.type === "publishable" ? "pub" : "secret"}_${key.env}_${key.lookupPrefix}_••••••••`,
+  access: API_KEY_ACCESS,
+  source: "component" as const,
+  status:
+    key.status === "revoked" ? ("expired" as const) : key.status,
+  requiresUpdate: false,
+  createdAt: key.createdAt,
+  updatedAt: key.createdAt,
+  lastUsedAt: key.lastUsedAt,
+});
+
+const getComponentKeyForOwner = async (
+  ctx: QueryCtx,
+  ownerId: string,
+  keyId: string
+): Promise<KeyMetadata> => {
+  const key = (await getComponentKeysForOwner(ctx, ownerId)).find(
+    (candidate) => candidate.keyId === keyId
+  );
+  if (!key) {
+    throw new Error("API key not found");
+  }
+  return key;
+};
+
+const validateComponentApiKey = async (
+  ctx: MutationCtx,
+  token: string
+) => {
+  const result = await componentApiKeys.validate(ctx, { key: token });
+  if (!result.valid) {
+    return null;
+  }
+
+  if (
+    result.type !== "secret" ||
+    result.env !== COMPONENT_ENV ||
+    !result.scopes.includes(API_KEY_ACCESS)
+  ) {
+    return null;
+  }
+
+  const authUser = await getAuthUserById(ctx, result.ownerId);
+  if (!authUser) {
+    await componentApiKeys.revoke(ctx, {
+      keyId: result.keyId,
+      ownerId: result.ownerId,
+    });
+    return null;
+  }
+
+  return {
+    keyId: result.keyId,
+    userId: result.ownerId,
+    access: API_KEY_ACCESS,
+    source: "component" as const,
+    rateLimitKey: `component:${result.keyId}`,
+  };
+};
+
+const validateLegacyApiKey = async (
+  ctx: MutationCtx,
+  token: string
+) => {
+  const parts = token.split("_");
+  const keyPrefix = parts[1];
+  if (!keyPrefix) {
+    return null;
+  }
+
+  const candidates = await ctx.db
+    .query("apiKeys")
+    .withIndex("by_prefix_revoked", (q) =>
+      q.eq("keyPrefix", keyPrefix).eq("revokedAt", undefined)
+    )
+    .take(LIST_LIMIT);
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const tokenHash = await hashApiKey(token);
+
+  for (const candidate of candidates) {
+    if (!timingSafeEqual(candidate.keyHash, tokenHash)) {
+      continue;
+    }
+
+    const now = Date.now();
+    const authUser = await getAuthUserById(ctx, candidate.userId);
+    if (!authUser) {
+      await ctx.db.patch(candidate._id, {
+        revokedAt: now,
+        updatedAt: now,
+      });
+      continue;
+    }
+
+    const lastUsedAt = candidate.lastUsedAt;
+    if (
+      lastUsedAt === undefined ||
+      now - lastUsedAt >= LAST_USED_THROTTLE_MS
+    ) {
+      await ctx.db.patch(candidate._id, {
+        lastUsedAt: now,
+        updatedAt: now,
+      });
+    }
+
+    return {
+      keyId: candidate._id,
+      userId: candidate.userId,
+      access: candidate.access,
+      source: "legacy" as const,
+      rateLimitKey: `legacy:${candidate._id}`,
+    };
+  }
+
+  return null;
+};
 
 export const createUserApiKey = mutation({
   args: {
@@ -129,37 +281,26 @@ export const createUserApiKey = mutation({
   },
   returns: createdApiKeyValidator,
   handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
-    if (!user) {
-      throw new Error("User must be authenticated");
-    }
-
-    const now = Date.now();
-    await revokeActiveKeysForUser(ctx, user.subject, now);
-
-    const { key, keyPrefix } = buildApiKey();
-    const keyHash = await hashApiKey(key);
-    const name = args.name?.trim() || API_KEY_NAME_DEFAULT;
-
-    const keyId = await ctx.db.insert("apiKeys", {
-      userId: user.subject,
+    const ownerId = await getAuthenticatedOwnerId(ctx);
+    const name = normalizeApiKeyName(args.name?.trim() || API_KEY_NAME_DEFAULT);
+    const created = await componentApiKeys.create(ctx, {
+      env: COMPONENT_ENV,
       name,
-      keyPrefix,
-      keyHash,
-      access: API_KEY_ACCESS,
-      createdAt: now,
-      updatedAt: now,
-      lastUsedAt: undefined,
-      revokedAt: undefined,
+      ownerId,
+      scopes: COMPONENT_SCOPES,
+      type: "secret",
     });
 
+    const [, , , lookupPrefix] = created.key.split("_");
     return {
-      id: keyId,
+      id: created.keyId,
       name,
-      keyPrefix,
-      key,
+      keyPrefix: lookupPrefix ?? "",
+      key: created.key,
       access: API_KEY_ACCESS,
-      createdAt: now,
+      source: "component" as const,
+      status: "active" as const,
+      createdAt: Date.now(),
     };
   },
 });
@@ -168,59 +309,102 @@ export const listUserApiKeys = query({
   args: {},
   returns: v.array(listedApiKeyValidator),
   handler: async (ctx) => {
-    const user = await ctx.auth.getUserIdentity();
-    if (!user) {
+    let ownerId: string;
+    try {
+      ownerId = await getAuthenticatedOwnerId(ctx);
+    } catch {
       return [];
     }
 
-    const keys = await ctx.db
-      .query("apiKeys")
-      .withIndex("by_user_revoked", (q) =>
-        q.eq("userId", user.subject).eq("revokedAt", undefined)
-      )
-      .order("desc")
-      .collect();
+    const [componentKeys, legacyKeys] = await Promise.all([
+      getComponentKeysForOwner(ctx, ownerId),
+      ctx.db
+        .query("apiKeys")
+        .withIndex("by_user_revoked", (q) =>
+          q.eq("userId", ownerId).eq("revokedAt", undefined)
+        )
+        .order("desc")
+        .take(LIST_LIMIT),
+    ]);
 
-    return keys.map((key) => ({
-      id: key._id,
-      name: key.name,
-      keyPrefix: key.keyPrefix,
-      maskedKey: `${key.keyPrefix}••••••••`,
-      access: key.access,
-      createdAt: key.createdAt,
-      updatedAt: key.updatedAt,
-      lastUsedAt: key.lastUsedAt,
-    }));
+    return [
+      ...componentKeys.map(mapComponentKey),
+      ...legacyKeys.map((key) => ({
+        id: key._id,
+        name: normalizeApiKeyName(key.name),
+        keyPrefix: key.keyPrefix,
+        maskedKey: `${key.keyPrefix}••••••••`,
+        access: key.access,
+        source: "legacy" as const,
+        status: "active" as const,
+        requiresUpdate: true,
+        createdAt: key.createdAt,
+        updatedAt: key.updatedAt,
+        lastUsedAt: key.lastUsedAt,
+      })),
+    ].sort((left, right) => right.createdAt - left.createdAt);
   },
 });
 
 export const revokeUserApiKey = mutation({
-  args: {
-    keyId: v.optional(v.id("apiKeys")),
-  },
+  args: revokeKeyArgsValidator,
   returns: v.null(),
   handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
-    if (!user) {
-      throw new Error("User must be authenticated");
-    }
+    const ownerId = await getAuthenticatedOwnerId(ctx);
 
-    const now = Date.now();
-
-    if (args.keyId) {
-      const key = await ctx.db.get("apiKeys", args.keyId);
-      if (!key || key.userId !== user.subject) {
-        throw new Error("API key not found");
-      }
-      await ctx.db.patch("apiKeys", args.keyId, {
-        revokedAt: now,
-        updatedAt: now,
+    if (args.source === "component") {
+      await componentApiKeys.revoke(ctx, {
+        keyId: args.keyId,
+        ownerId,
       });
       return null;
     }
 
-    await revokeActiveKeysForUser(ctx, user.subject, now);
+    const legacyKeyId = args.keyId as Id<"apiKeys">;
+    const key = await ctx.db.get(legacyKeyId);
+    if (!key || key.userId !== ownerId) {
+      throw new Error("API key not found");
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(legacyKeyId, {
+      revokedAt: now,
+      updatedAt: now,
+    });
     return null;
+  },
+});
+
+export const rotateUserApiKey = mutation({
+  args: componentKeyActionValidator,
+  returns: createdApiKeyValidator,
+  handler: async (ctx, args) => {
+    const ownerId = await getAuthenticatedOwnerId(ctx);
+    const existing = await getComponentKeyForOwner(ctx, ownerId, args.keyId);
+    const name = normalizeApiKeyName(existing.name);
+    const created = await componentApiKeys.create(ctx, {
+      env: COMPONENT_ENV,
+      name,
+      ownerId,
+      scopes: COMPONENT_SCOPES,
+      type: "secret",
+    });
+    await componentApiKeys.revoke(ctx, {
+      keyId: args.keyId,
+      ownerId,
+    });
+
+    const [, , , lookupPrefix] = created.key.split("_");
+    return {
+      id: created.keyId,
+      name,
+      keyPrefix: lookupPrefix ?? "",
+      key: created.key,
+      access: API_KEY_ACCESS,
+      source: "component" as const,
+      status: "active" as const,
+      createdAt: Date.now(),
+    };
   },
 });
 
@@ -231,71 +415,25 @@ export const validateUserApiKey = internalMutation({
   returns: validatedApiKeyValidator,
   handler: async (ctx, args) => {
     const token = args.token.trim();
-    if (!isWellFormedApiKey(token)) {
+    const format = getApiKeyFormat(token);
+    if (format === "malformed") {
       return null;
     }
 
-    const parts = token.split("_");
-    const keyPrefix = parts[1];
-    if (!keyPrefix) {
-      return null;
+    if (format === "component") {
+      return validateComponentApiKey(ctx, token);
     }
 
-    const candidates = await ctx.db
-      .query("apiKeys")
-      .withIndex("by_prefix_revoked", (q) =>
-        q.eq("keyPrefix", keyPrefix).eq("revokedAt", undefined)
-      )
-      .collect();
-
-    if (candidates.length === 0) {
-      return null;
-    }
-
-    const tokenHash = await hashApiKey(token);
-
-    for (const candidate of candidates) {
-      if (!timingSafeEqual(candidate.keyHash, tokenHash)) {
-        continue;
-      }
-
-      const now = Date.now();
-      const authUser = await getAuthUserById(ctx, candidate.userId);
-      if (!authUser) {
-        await ctx.db.patch("apiKeys", candidate._id, {
-          revokedAt: now,
-          updatedAt: now,
-        });
-        continue;
-      }
-
-      // Best-effort, throttled usage tracking. Skipping the write on the hot
-      // path keeps validation effectively read-only so concurrent requests
-      // sharing one key don't contend on a single document every request.
-      const lastUsedAt = candidate.lastUsedAt;
-      if (
-        lastUsedAt === undefined ||
-        now - lastUsedAt >= LAST_USED_THROTTLE_MS
-      ) {
-        await ctx.db.patch("apiKeys", candidate._id, {
-          lastUsedAt: now,
-          updatedAt: now,
-        });
-      }
-
-      return {
-        keyId: candidate._id,
-        userId: candidate.userId,
-        access: candidate.access,
-      };
+    if (isLegacyApiKey(token)) {
+      return validateLegacyApiKey(ctx, token);
     }
 
     return null;
   },
 });
 
-// One-time cutover helper for rotating token prefix.
-// Run once during rollout to force regeneration under the new prefix format.
+// Historical one-time helper retained for old tests/manual cleanup. New
+// component-managed keys are intentionally unaffected by this legacy mutation.
 export const revokeAllActiveApiKeysForPrefixCutover = internalMutation({
   args: {},
   returns: revokeAllApiKeysResultValidator,
@@ -307,7 +445,7 @@ export const revokeAllActiveApiKeysForPrefixCutover = internalMutation({
       .collect();
 
     for (const key of activeKeys) {
-      await ctx.db.patch("apiKeys", key._id, {
+      await ctx.db.patch(key._id, {
         revokedAt: now,
         updatedAt: now,
       });

--- a/packages/convex/convex.config.ts
+++ b/packages/convex/convex.config.ts
@@ -5,6 +5,7 @@ import r2 from "@convex-dev/r2/convex.config.js";
 import ratelimiter from "@convex-dev/ratelimiter/convex.config";
 import resend from "@convex-dev/resend/convex.config";
 import workflow from "@convex-dev/workflow/convex.config";
+import apiKeys from "@vllnt/convex-api-keys/convex.config";
 import { defineApp } from "convex/server";
 
 const app = defineApp();
@@ -15,5 +16,6 @@ app.use(workflow);
 app.use(resend);
 app.use(ratelimiter);
 app.use(r2);
+app.use(apiKeys);
 
 export default app;

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -38,6 +38,7 @@
     "@convex-dev/workpool": "^0.4.6",
     "@onkernel/sdk": "^0.52.0",
     "@polar-sh/sdk": "^0.47.1",
+    "@vllnt/convex-api-keys": "0.2.0",
     "ai": "^6.0.184",
     "better-auth": "1.6.11",
     "convex": "^1.39.0",

--- a/packages/convex/publicApiHttp.ts
+++ b/packages/convex/publicApiHttp.ts
@@ -36,6 +36,8 @@ type ErrorCode =
 interface AuthorizedUser {
   access: "full_access";
   keyId: string;
+  rateLimitKey: string;
+  source: "component" | "legacy";
   userId: string;
 }
 
@@ -423,7 +425,7 @@ const withAuthorizedUser = async (
     rateLimit = await ctx.runMutation(
       (internal as any).raycast.checkApiRateLimit,
       {
-        rateLimitKey: `key:${validated.keyId}`,
+        rateLimitKey: `key:${validated.rateLimitKey}`,
       }
     );
   } catch (error) {

--- a/packages/convex/shared/apiKeyFormat.test.ts
+++ b/packages/convex/shared/apiKeyFormat.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, test } from "bun:test";
-import { API_KEY_TOKEN_PREFIX, isWellFormedApiKey } from "./apiKeyFormat";
+import {
+  API_KEY_TOKEN_PREFIX,
+  getApiKeyFormat,
+  isWellFormedApiKey,
+} from "./apiKeyFormat";
 
 describe("apiKeyFormat", () => {
   test("accepts a canonical teakapi_<prefix>_<secret> token", () => {
-    expect(
-      isWellFormedApiKey(`${API_KEY_TOKEN_PREFIX}_abc123_secretvalue`)
-    ).toBe(true);
+    const token = `${API_KEY_TOKEN_PREFIX}_abc123_secretvalue`;
+
+    expect(isWellFormedApiKey(token)).toBe(true);
+    expect(getApiKeyFormat(token)).toBe("legacy");
+  });
+
+  test("accepts a component-managed teakapi secret token", () => {
+    const token = `${API_KEY_TOKEN_PREFIX}_secret_live_a1b2c3d4_${"f".repeat(64)}`;
+
+    expect(isWellFormedApiKey(token)).toBe(true);
+    expect(getApiKeyFormat(token)).toBe("component");
   });
 
   test("trims surrounding whitespace before checking", () => {
@@ -20,6 +32,19 @@ describe("apiKeyFormat", () => {
   test("rejects tokens with the wrong number of segments", () => {
     expect(isWellFormedApiKey("teakapi_abc123")).toBe(false);
     expect(isWellFormedApiKey("teakapi_abc123_secret_extra")).toBe(false);
+    expect(isWellFormedApiKey("teakapi_secret_live_lookup")).toBe(false);
+  });
+
+  test("rejects malformed component tokens", () => {
+    expect(
+      isWellFormedApiKey(`${API_KEY_TOKEN_PREFIX}_write_live_a1b2c3d4_${"f".repeat(64)}`)
+    ).toBe(false);
+    expect(
+      isWellFormedApiKey(`${API_KEY_TOKEN_PREFIX}_secret_live_short_${"f".repeat(64)}`)
+    ).toBe(false);
+    expect(
+      isWellFormedApiKey(`${API_KEY_TOKEN_PREFIX}_secret_live_a1b2c3d4_short`)
+    ).toBe(false);
   });
 
   test("rejects tokens with empty prefix or secret segments", () => {

--- a/packages/convex/shared/apiKeyFormat.ts
+++ b/packages/convex/shared/apiKeyFormat.ts
@@ -1,30 +1,63 @@
 // Canonical Teak public-API key format helpers.
 //
-// Keys are minted as `teakapi_<prefix>_<secret>` (see apiKeys.ts). Centralizing
-// the shape check lets every entry point (rate limiting, validation) reject
-// obviously malformed tokens the same way, so the public API never spends a
-// database write on garbage that can never resolve to a real key.
+// Legacy keys were minted as `teakapi_<prefix>_<secret>`. New keys are minted
+// by @vllnt/convex-api-keys as `teakapi_<type>_<env>_<lookup>_<secret>`.
+// Centralizing the shape check lets every entry point reject obviously
+// malformed tokens before touching the database.
 
 export const API_KEY_TOKEN_PREFIX = "teakapi";
 
-const API_KEY_PART_COUNT = 3;
+const LEGACY_API_KEY_PART_COUNT = 3;
+const COMPONENT_API_KEY_PART_COUNT = 5;
+const COMPONENT_LOOKUP_PREFIX_LENGTH = 8;
+const COMPONENT_SECRET_LENGTH = 64;
+
+export type ApiKeyFormat = "component" | "legacy" | "malformed";
 
 /**
- * Returns true when `token` matches the `teakapi_<prefix>_<secret>` shape.
+ * Returns the key format when `token` matches a supported Teak key shape.
  * This is a cheap, allocation-light structural check only; it does not confirm
  * the key exists or is active.
  */
-export const isWellFormedApiKey = (token: string): boolean => {
+export const getApiKeyFormat = (token: string): ApiKeyFormat => {
   const trimmed = token.trim();
   if (!trimmed.startsWith(`${API_KEY_TOKEN_PREFIX}_`)) {
-    return false;
+    return "malformed";
   }
 
   const parts = trimmed.split("_");
-  if (parts.length !== API_KEY_PART_COUNT) {
-    return false;
+  if (parts.length === LEGACY_API_KEY_PART_COUNT) {
+    return parts[1] && parts[2] ? "legacy" : "malformed";
   }
 
-  // prefix and secret segments must both be non-empty.
-  return Boolean(parts[1]) && Boolean(parts[2]);
+  if (parts.length !== COMPONENT_API_KEY_PART_COUNT) {
+    return "malformed";
+  }
+
+  const [, type, env, lookupPrefix, secret] = parts;
+  if (type !== "secret" && type !== "pub") {
+    return "malformed";
+  }
+
+  if (!(env && lookupPrefix && secret)) {
+    return "malformed";
+  }
+
+  if (
+    lookupPrefix.length !== COMPONENT_LOOKUP_PREFIX_LENGTH ||
+    secret.length !== COMPONENT_SECRET_LENGTH
+  ) {
+    return "malformed";
+  }
+
+  return "component";
 };
+
+export const isLegacyApiKey = (token: string): boolean =>
+  getApiKeyFormat(token) === "legacy";
+
+export const isComponentApiKey = (token: string): boolean =>
+  getApiKeyFormat(token) === "component";
+
+export const isWellFormedApiKey = (token: string): boolean =>
+  getApiKeyFormat(token) !== "malformed";

--- a/packages/ui/src/components/settings/ApiKeysDialog.tsx
+++ b/packages/ui/src/components/settings/ApiKeysDialog.tsx
@@ -1,0 +1,275 @@
+import { Copy, KeyRound, RotateCw, Trash2 } from "lucide-react";
+import { useRef, useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { Input } from "../ui/input";
+import { Spinner } from "../ui/spinner";
+
+export interface ApiKeyListItem {
+  id: string;
+  name: string;
+  maskedKey: string;
+  source: "component" | "legacy";
+  status: "active" | "disabled" | "rotating" | "expired" | "exhausted";
+  requiresUpdate: boolean;
+  createdAt: number;
+  lastUsedAt?: number;
+}
+
+export interface CreatedApiKey {
+  id?: string;
+  key: string;
+}
+
+interface ApiKeysDialogProps {
+  isLoading: boolean;
+  keys: ApiKeyListItem[] | undefined;
+  onCreateKey: () => Promise<CreatedApiKey | null>;
+  onOpenChange: (open: boolean) => void;
+  onRevokeKey: (
+    keyId: string,
+    source: ApiKeyListItem["source"]
+  ) => Promise<void>;
+  onRotateKey: (keyId: string) => Promise<CreatedApiKey | null>;
+  open: boolean;
+}
+
+const formatDate = (value?: number) => {
+  if (!value) {
+    return "Never";
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+};
+
+const getStatusVariant = (
+  status: ApiKeyListItem["status"]
+): "default" | "outline" | "secondary" =>
+  status === "active"
+    ? "outline"
+    : status === "disabled"
+      ? "secondary"
+      : "outline";
+
+const formatStatus = (status: ApiKeyListItem["status"]) =>
+  status
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+
+const formatKeyName = (name: string) =>
+  name === "API Keys" ? "Default API key" : name;
+
+export function ApiKeysDialog({
+  isLoading,
+  keys,
+  onCreateKey,
+  onOpenChange,
+  onRevokeKey,
+  onRotateKey,
+  open,
+}: ApiKeysDialogProps) {
+  const [revealedKey, setRevealedKey] = useState<CreatedApiKey | null>(null);
+  const [actionKey, setActionKey] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const isCreatingRef = useRef(false);
+
+  const handleCreate = async () => {
+    if (isCreatingRef.current) {
+      return;
+    }
+
+    isCreatingRef.current = true;
+    setIsCreating(true);
+    setRevealedKey(null);
+    const toastId = toast.loading("Generating API key...");
+    try {
+      const created = await onCreateKey();
+      if (created) {
+        setRevealedKey(created);
+        toast.success("API key generated. Copy it now.", { id: toastId });
+      }
+    } catch {
+      toast.error("Failed to generate API key.", { id: toastId });
+    } finally {
+      isCreatingRef.current = false;
+      setIsCreating(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!revealedKey) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(revealedKey.key);
+      toast.success("API key copied.");
+    } catch {
+      toast.error("Could not copy API key.");
+    }
+  };
+
+  const runKeyAction = async (
+    keyId: string,
+    action: () => Promise<void | CreatedApiKey | null>,
+    successMessage: string
+  ) => {
+    setActionKey(keyId);
+    const toastId = toast.loading("Updating API key...");
+    try {
+      const result = await action();
+      if (result?.key) {
+        setRevealedKey(result);
+      }
+      toast.success(successMessage, { id: toastId });
+    } catch {
+      toast.error("Could not update API key.", { id: toastId });
+    } finally {
+      setActionKey(null);
+    }
+  };
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="max-h-[82vh] gap-3 overflow-y-auto p-4 sm:max-w-xl">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <DialogHeader className="gap-1">
+            <DialogTitle>Manage API Keys</DialogTitle>
+            <DialogDescription>
+              {keys?.length ? `${keys.length} keys` : "No keys yet"} for API,
+              MCP, and Raycast access.
+            </DialogDescription>
+          </DialogHeader>
+
+          <Button
+            className="shrink-0"
+            disabled={isCreating}
+            onClick={handleCreate}
+            size="sm"
+          >
+            {isCreating ? <Spinner /> : <KeyRound />}
+            Generate Key
+          </Button>
+        </div>
+
+        <div className="space-y-3">
+          {revealedKey && (
+            <div
+              className="space-y-2 rounded-md border p-2.5"
+              key={revealedKey.id ?? revealedKey.key}
+            >
+              <div className="font-medium text-sm">Copy your new key now</div>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Input
+                  key={revealedKey.id ?? revealedKey.key}
+                  readOnly
+                  value={revealedKey.key}
+                />
+                <Button onClick={handleCopy} size="sm" variant="secondary">
+                  <Copy />
+                  Copy
+                </Button>
+              </div>
+            </div>
+          )}
+
+          <div className="divide-y rounded-md border">
+            {isLoading && (
+              <div className="flex items-center justify-center p-6">
+                <Spinner />
+              </div>
+            )}
+
+            {!isLoading && (!keys || keys.length === 0) && (
+              <div className="p-6 text-center text-muted-foreground text-sm">
+                Generate your first API key to connect external tools.
+              </div>
+            )}
+
+            {keys?.map((key) => {
+              const isBusy = actionKey === key.id;
+              const canRotate =
+                key.source === "component" &&
+                (key.status === "active" || key.status === "disabled");
+
+              return (
+                <div
+                  className="flex flex-col gap-2 p-2.5 sm:flex-row sm:items-center sm:justify-between"
+                  key={`${key.source}-${key.id}`}
+                >
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-medium text-sm">
+                        {formatKeyName(key.name)}
+                      </span>
+                      {key.status !== "active" && (
+                        <Badge variant={getStatusVariant(key.status)}>
+                          {formatStatus(key.status)}
+                        </Badge>
+                      )}
+                      {key.requiresUpdate && <Badge>Update required</Badge>}
+                    </div>
+                    <div className="break-all font-mono text-muted-foreground text-xs">
+                      {key.maskedKey}
+                    </div>
+                    <div className="text-muted-foreground text-xs">
+                      Last used: {formatDate(key.lastUsedAt)}
+                    </div>
+                  </div>
+
+                  <div className="flex shrink-0 flex-wrap gap-1.5 sm:justify-end">
+                    {canRotate && (
+                      <Button
+                        disabled={isBusy}
+                        onClick={() =>
+                          runKeyAction(
+                            key.id,
+                            () => onRotateKey(key.id),
+                            "API key regenerated. Copy the new key now."
+                          )
+                        }
+                        size="sm"
+                        variant="outline"
+                      >
+                        {isBusy ? <Spinner /> : <RotateCw />}
+                        Regenerate
+                      </Button>
+                    )}
+
+                    <Button
+                      disabled={isBusy}
+                      onClick={() =>
+                        runKeyAction(
+                          key.id,
+                          () => onRevokeKey(key.id, key.source),
+                          "API key revoked."
+                        )
+                      }
+                      size="sm"
+                      variant="ghost"
+                    >
+                      {isBusy ? <Spinner /> : <Trash2 />}
+                      Revoke
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/ui/src/components/settings/ApiKeysDialog.tsx
+++ b/packages/ui/src/components/settings/ApiKeysDialog.tsx
@@ -55,12 +55,12 @@ const formatDate = (value?: number) => {
 
 const getStatusVariant = (
   status: ApiKeyListItem["status"]
-): "default" | "outline" | "secondary" =>
+): "default" | "outline" | "secondary" | "destructive" =>
   status === "active"
     ? "outline"
     : status === "disabled"
       ? "secondary"
-      : "outline";
+      : "destructive";
 
 const formatStatus = (status: ApiKeyListItem["status"]) =>
   status

--- a/packages/ui/src/components/settings/ApiKeysSection.tsx
+++ b/packages/ui/src/components/settings/ApiKeysSection.tsx
@@ -1,116 +1,62 @@
 import { useState } from "react";
-import { toast } from "sonner";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
-import { CardTitle } from "../ui/card";
-import { Input } from "../ui/input";
 import { Spinner } from "../ui/spinner";
-
-interface ApiKeyListItem {
-  id: string;
-}
-
-interface CreatedApiKey {
-  key: string;
-}
+import {
+  ApiKeysDialog,
+  type ApiKeyListItem,
+  type CreatedApiKey,
+} from "./ApiKeysDialog";
+import { SettingRow } from "./SettingRow";
 
 interface ApiKeysSectionProps {
   isLoading: boolean;
   keys: ApiKeyListItem[] | undefined;
   onCreateKey: () => Promise<CreatedApiKey | null>;
+  onRevokeKey: (
+    keyId: string,
+    source: ApiKeyListItem["source"]
+  ) => Promise<void>;
+  onRotateKey: (keyId: string) => Promise<CreatedApiKey | null>;
 }
 
 export function ApiKeysSection({
-  keys,
   isLoading,
+  keys,
   onCreateKey,
+  onRevokeKey,
+  onRotateKey,
 }: ApiKeysSectionProps) {
-  const [revealedKey, setRevealedKey] = useState<string | null>(null);
-  const [isCreating, setIsCreating] = useState(false);
-
-  const activeKey = keys?.[0] ?? null;
-
-  const handleCreateOrRotate = async () => {
-    setIsCreating(true);
-    const toastId = toast.loading("Generating API key...");
-    try {
-      const created = await onCreateKey();
-      if (created) {
-        setRevealedKey(created.key);
-        toast.success(
-          "API key generated. Copy it now, it won't be shown again.",
-          {
-            id: toastId,
-          }
-        );
-      }
-    } catch {
-      toast.error("Failed to generate API key.", {
-        id: toastId,
-      });
-    } finally {
-      setIsCreating(false);
-    }
-  };
-
-  const handleCopy = async () => {
-    if (!revealedKey) {
-      return;
-    }
-
-    try {
-      await navigator.clipboard.writeText(revealedKey);
-      toast.success("API key copied.");
-    } catch {
-      toast.error("Could not copy API key.");
-    }
-  };
-
-  const generateButtonLabel = activeKey ? "Regenerate" : "Generate";
+  const [open, setOpen] = useState(false);
 
   return (
-    <div className="space-y-3">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <CardTitle>API Keys</CardTitle>
-        <div className="-mx-2.5 flex items-center justify-end gap-2 -space-x-2.5">
-          {isLoading ? (
-            <Button disabled size="sm" variant="ghost">
-              <Spinner />
+    <>
+      <SettingRow title="API Keys">
+        {isLoading ? (
+          <Button disabled size="sm" variant="ghost">
+            <Spinner />
+          </Button>
+        ) : (
+          <>
+            <Badge variant={keys?.length ? "outline" : "secondary"}>
+              {keys?.length ? `${keys.length} keys` : "No keys"}
+            </Badge>
+            <Button onClick={() => setOpen(true)} size="sm" variant="link">
+              Manage
             </Button>
-          ) : (
-            <>
-              {activeKey && <Badge variant="outline">Active</Badge>}
-              <Button
-                disabled={isCreating}
-                onClick={handleCreateOrRotate}
-                size="sm"
-                type="button"
-                variant="link"
-              >
-                {isCreating ? "Generating..." : generateButtonLabel}
-              </Button>
-            </>
-          )}
-        </div>
-      </div>
+          </>
+        )}
+      </SettingRow>
 
-      {revealedKey && (
-        <div className="space-y-2">
-          <div className="flex flex-col gap-2 sm:flex-row">
-            <Input readOnly value={revealedKey} />
-            <Button
-              onClick={handleCopy}
-              size="sm"
-              type="button"
-              variant="secondary"
-            >
-              Copy
-            </Button>
-          </div>
-        </div>
-      )}
-    </div>
+      <ApiKeysDialog
+        isLoading={isLoading}
+        keys={keys}
+        onCreateKey={onCreateKey}
+        onOpenChange={setOpen}
+        onRevokeKey={onRevokeKey}
+        onRotateKey={onRotateKey}
+        open={open}
+      />
+    </>
   );
 }
-
-export type { ApiKeyListItem, CreatedApiKey };

--- a/packages/ui/src/components/settings/SettingsContent.tsx
+++ b/packages/ui/src/components/settings/SettingsContent.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Spinner } from "../ui/spinner";
+import type { ApiKeyListItem } from "./ApiKeysDialog";
 import { ApiKeysSection } from "./ApiKeysSection";
 import { CustomerPortalButton } from "./CustomerPortalButton";
 import { DeleteAccountDialog } from "./DeleteAccountDialog";
@@ -20,11 +21,16 @@ interface SettingsContentProps {
   email?: string | null;
   hasPremium?: boolean;
   isLoading: boolean;
-  keys: { id: string }[] | undefined;
+  keys: ApiKeyListItem[] | undefined;
   onCreateApiKey: () => Promise<{ key: string }>;
   onCreateCustomerPortal: () => Promise<void>;
   onDeleteAccount: () => Promise<void>;
   onDeleteDialogOpenChange: (open: boolean) => void;
+  onRevokeApiKey: (
+    keyId: string,
+    source: ApiKeyListItem["source"]
+  ) => Promise<void>;
+  onRotateApiKey: (keyId: string) => Promise<{ key: string }>;
   onSignOut: () => Promise<void> | void;
   onThemeChange?: (value: string) => void;
   onUpgrade: () => void;
@@ -45,6 +51,8 @@ export function SettingsContent({
   onCreateCustomerPortal,
   onDeleteAccount,
   onDeleteDialogOpenChange,
+  onRevokeApiKey,
+  onRotateApiKey,
   onSignOut,
   onThemeChange,
   onUpgrade,
@@ -101,6 +109,8 @@ export function SettingsContent({
         isLoading={keys === undefined}
         keys={keys}
         onCreateKey={onCreateApiKey}
+        onRevokeKey={onRevokeApiKey}
+        onRotateKey={onRotateApiKey}
       />
 
       <SettingRow title="Theme">

--- a/packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx
+++ b/packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx
@@ -1,0 +1,156 @@
+import { describe, expect, mock, test } from "bun:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+mock.module("../../ui/badge", () => ({
+  Badge: ({ children, variant }: any) =>
+    React.createElement("span", { "data-variant": variant }, children),
+}));
+
+mock.module("../../ui/button", () => ({
+  Button: ({ children, disabled, onClick, size, variant }: any) =>
+    React.createElement(
+      "button",
+      {
+        disabled,
+        onClick,
+        "data-size": size,
+        "data-variant": variant,
+      },
+      children
+    ),
+  buttonVariants: () => "",
+}));
+
+mock.module("../../ui/dialog", () => ({
+  Dialog: ({ children, open }: any) =>
+    open ? React.createElement("div", { "data-dialog": "" }, children) : null,
+  DialogContent: ({ children }: any) =>
+    React.createElement("div", { "data-dialog-content": "" }, children),
+  DialogDescription: ({ children }: any) =>
+    React.createElement("p", { "data-dialog-description": "" }, children),
+  DialogHeader: ({ children }: any) =>
+    React.createElement("div", { "data-dialog-header": "" }, children),
+  DialogTitle: ({ children }: any) =>
+    React.createElement("h2", { "data-dialog-title": "" }, children),
+}));
+
+mock.module("../../ui/input", () => ({
+  Input: ({ value, readOnly }: any) =>
+    React.createElement("input", { readOnly, value }),
+}));
+
+mock.module("../../ui/spinner", () => ({
+  Spinner: () => React.createElement("span", { "data-spinner": "" }),
+}));
+
+mock.module("sonner", () => ({
+  toast: {
+    error: mock(),
+    loading: mock(() => "toast-id"),
+    success: mock(),
+  },
+}));
+
+const { ApiKeysDialog } = await import("../ApiKeysDialog");
+const { ApiKeysSection } = await import("../ApiKeysSection");
+
+const keys = [
+  {
+    createdAt: 300,
+    id: "component_key",
+    lastUsedAt: 350,
+    maskedKey: "teakapi_secret_live_a1b2c3d4_••••••••",
+    name: "SDK Key",
+    requiresUpdate: false,
+    source: "component" as const,
+    status: "active" as const,
+  },
+  {
+    createdAt: 100,
+    id: "legacy_key",
+    lastUsedAt: 150,
+    maskedKey: "abc123••••••••",
+    name: "Old Key",
+    requiresUpdate: true,
+    source: "legacy" as const,
+    status: "active" as const,
+  },
+  {
+    createdAt: 200,
+    id: "disabled_key",
+    maskedKey: "teakapi_secret_live_e5f6a7b8_••••••••",
+    name: "Disabled Key",
+    requiresUpdate: false,
+    source: "component" as const,
+    status: "disabled" as const,
+  },
+];
+
+const handlers = {
+  onCreateKey: mock(() => Promise.resolve({ key: "new-key" })),
+  onRevokeKey: mock(() => Promise.resolve()),
+  onRotateKey: mock(() => Promise.resolve({ key: "rotated-key" })),
+};
+
+describe("ApiKeysSection", () => {
+  test("keeps the settings page compact", () => {
+    const markup = renderToStaticMarkup(
+      <ApiKeysSection isLoading={false} keys={keys} {...handlers} />
+    );
+
+    expect(markup).toContain("API Keys");
+    expect(markup).toContain(">Manage</button>");
+    expect(markup).not.toContain("Manage API Keys");
+    expect(markup).toContain("3 keys");
+    expect(markup).not.toContain("Update required");
+    expect(markup).not.toContain("Generate Key");
+  });
+});
+
+describe("ApiKeysDialog", () => {
+  test("renders component, disabled, and legacy key states", () => {
+    const markup = renderToStaticMarkup(
+      <ApiKeysDialog
+        isLoading={false}
+        keys={keys}
+        onOpenChange={mock()}
+        open={true}
+        {...handlers}
+      />
+    );
+
+    expect(markup).toContain("Manage API Keys");
+    expect(markup).toContain("Generate Key");
+    expect(markup).toContain("SDK Key");
+    expect(markup).toContain("Regenerate");
+    expect(markup).not.toContain(">Disable<");
+    expect(markup).toContain("Disabled Key");
+    expect(markup).not.toContain(">Enable<");
+    expect(markup).toContain("Old Key");
+    expect(markup).toContain("Update required");
+    expect(markup).not.toContain(">Active</span>");
+    expect(markup).toContain(">Update required</span>");
+    expect(markup).not.toContain(">active<");
+  });
+
+  test("renames the old default key label in the modal", () => {
+    const markup = renderToStaticMarkup(
+      <ApiKeysDialog
+        isLoading={false}
+        keys={[
+          {
+            ...keys[0],
+            name: "API Keys",
+          },
+        ]}
+        onOpenChange={mock()}
+        open={true}
+        {...handlers}
+      />
+    );
+
+    expect(markup).toContain("Default API key");
+    expect(markup).not.toContain(">API Keys</span>");
+  });
+});

--- a/packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx
+++ b/packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx
@@ -153,4 +153,26 @@ describe("ApiKeysDialog", () => {
     expect(markup).toContain("Default API key");
     expect(markup).not.toContain(">API Keys</span>");
   });
+
+  test("renders terminal key statuses as destructive badges", () => {
+    const markup = renderToStaticMarkup(
+      <ApiKeysDialog
+        isLoading={false}
+        keys={[
+          {
+            ...keys[0],
+            id: "exhausted_key",
+            name: "Exhausted Key",
+            status: "exhausted" as const,
+          },
+        ]}
+        onOpenChange={mock()}
+        open={true}
+        {...handlers}
+      />
+    );
+
+    expect(markup).toContain('data-variant="destructive"');
+    expect(markup).toContain(">Exhausted</span>");
+  });
 });

--- a/packages/ui/src/components/settings/index.ts
+++ b/packages/ui/src/components/settings/index.ts
@@ -1,3 +1,4 @@
+export * from "./ApiKeysDialog";
 export * from "./ApiKeysSection";
 export * from "./CustomerPortalButton";
 export * from "./DeleteAccountDialog";

--- a/packages/ui/src/hooks/useSettingsController.ts
+++ b/packages/ui/src/hooks/useSettingsController.ts
@@ -31,12 +31,34 @@ export function useSettingsController({
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const createCustomerPortal = useAction(api.billing.createCustomerPortal);
   const keys = useQuery(api.apiKeys.listUserApiKeys, {}) as
-    | { id: string }[]
+    | {
+        id: string;
+        name: string;
+        maskedKey: string;
+        source: "component" | "legacy";
+        status: "active" | "disabled" | "rotating" | "expired" | "exhausted";
+        requiresUpdate: boolean;
+        createdAt: number;
+        lastUsedAt?: number;
+      }[]
     | undefined;
   const createKey = useMutation(api.apiKeys.createUserApiKey);
+  const revokeKey = useMutation(api.apiKeys.revokeUserApiKey);
+  const rotateKey = useMutation(api.apiKeys.rotateUserApiKey);
 
   const handleCreateApiKey = async () => {
-    return (await createKey({ name: "API Keys" })) as { key: string };
+    return (await createKey({ name: "Default API key" })) as { key: string };
+  };
+
+  const handleRevokeApiKey = async (
+    keyId: string,
+    source: "component" | "legacy"
+  ) => {
+    await revokeKey({ keyId, source });
+  };
+
+  const handleRotateApiKey = async (keyId: string) => {
+    return (await rotateKey({ keyId })) as { key: string };
   };
 
   const handleCreateCustomerPortal = async () => {
@@ -98,6 +120,8 @@ export function useSettingsController({
     handleCreateApiKey,
     handleCreateCustomerPortal,
     handleDeleteAccount,
+    handleRevokeApiKey,
+    handleRotateApiKey,
     handleSignOut,
     hasPremium: user?.hasPremium,
     isLoading: user === undefined,


### PR DESCRIPTION
## Summary
- replace newly generated Teak API keys with @vllnt/convex-api-keys while preserving legacy teakapi_<prefix>_<secret> validation
- move API key management into a compact shared settings modal for web and desktop
- update API, MCP, and Raycast docs plus the public changelog for the new key management flow

## Validation
- bun run test
- bun run typecheck
- bun run lint
- bun run pre-commit
- targeted UI and Convex API key tests during follow-up tweaks

## Notes
- Existing production API keys remain valid indefinitely unless revoked.
- No backfill or forced migration is included.