### PR TITLE
[codex] track legacy API key usage

### DIFF
--- a/packages/convex/__tests__/admin.test.ts
+++ b/packages/convex/__tests__/admin.test.ts
@@ -6,6 +6,7 @@ mock.module("../storage/r2", r2MockModuleFactory);
 
 describe("admin.ts", () => {
   let getAccess: any;
+  let getLegacyApiKeyUsageAnalytics: any;
   let getOverview: any;
   let resetCardProcessingState: any;
   let refreshCardProcessing: any;
@@ -13,6 +14,7 @@ describe("admin.ts", () => {
   beforeEach(async () => {
     const module = await import("../admin");
     getAccess = module.getAccess;
+    getLegacyApiKeyUsageAnalytics = module.getLegacyApiKeyUsageAnalytics;
     getOverview = module.getOverview;
     resetCardProcessingState = module.resetCardProcessingState;
     refreshCardProcessing = module.refreshCardProcessing;
@@ -56,6 +58,144 @@ describe("admin.ts", () => {
       const handler = (getAccess as any).handler ?? getAccess;
       const result = await handler(ctx, {});
       expect(result).toEqual({ allowed: false });
+    });
+  });
+
+  describe("getLegacyApiKeyUsageAnalytics", () => {
+    test("throws when unauthorized", async () => {
+      const ctx = {
+        auth: { getUserIdentity: mock().mockResolvedValue(null) },
+        runQuery: mock().mockResolvedValue({ page: [] }),
+      } as any;
+      const handler =
+        (getLegacyApiKeyUsageAnalytics as any).handler ??
+        getLegacyApiKeyUsageAnalytics;
+
+      await expect(handler(ctx, {})).rejects.toThrow("Unauthorized");
+    });
+
+    test("returns default legacy key usage analytics for admin", async () => {
+      const now = Date.UTC(2026, 0, 31, 12, 0, 0);
+      const originalDateNow = Date.now;
+      Date.now = () => now;
+      try {
+        const totalsRows = [
+          {
+            _id: "totals_1",
+            date: "2026-01-31",
+            firstUsedAt: now - 10_000,
+            lastUsedAt: now,
+            observedUseCount: 3,
+            uniqueKeyCount: 2,
+            uniqueUserCount: 1,
+            updatedAt: now,
+          },
+        ];
+        const keyRows = [
+          {
+            _id: "usage_older",
+            date: "2026-01-31",
+            legacyKeyId: "legacy_older",
+            userId: "user_1",
+            keyPrefix: "older",
+            observedUseCount: 1,
+            firstUsedAt: now - 20_000,
+            lastUsedAt: now - 20_000,
+            updatedAt: now - 20_000,
+          },
+          {
+            _id: "usage_newer",
+            date: "2026-01-31",
+            legacyKeyId: "legacy_newer",
+            userId: "user_1",
+            keyPrefix: "newer",
+            observedUseCount: 2,
+            firstUsedAt: now - 10_000,
+            lastUsedAt: now,
+            lastEndpoint: "/v1/cards/search",
+            lastMethod: "GET",
+            updatedAt: now,
+          },
+        ];
+        const ctx = {
+          auth: {
+            getUserIdentity: mock().mockResolvedValue({ subject: "user_1" }),
+          },
+          runQuery: mock().mockResolvedValue({ page: [{ _id: "user_1" }] }),
+          db: {
+            query: mock((table: string) => ({
+              withIndex: mock(() => ({
+                order: mock(() => ({
+                  take: mock().mockResolvedValue(
+                    table === "legacyApiKeyUsageTotalsDaily"
+                      ? totalsRows
+                      : keyRows
+                  ),
+                })),
+              })),
+            })),
+          },
+        } as any;
+        const handler =
+          (getLegacyApiKeyUsageAnalytics as any).handler ??
+          getLegacyApiKeyUsageAnalytics;
+
+        const result = await handler(ctx, {});
+
+        expect(result.days).toBe(30);
+        expect(result.windowStartDate).toBe("2026-01-02");
+        expect(result.totals).toEqual([
+          expect.objectContaining({
+            date: "2026-01-31",
+            observedUseCount: 3,
+            uniqueKeyCount: 2,
+            uniqueUserCount: 1,
+          }),
+        ]);
+        expect(result.recentLegacyKeys.map((row: any) => row.legacyKeyId)).toEqual(
+          ["legacy_newer", "legacy_older"]
+        );
+      } finally {
+        Date.now = originalDateNow;
+      }
+    });
+
+    test("supports a custom bounded analytics window", async () => {
+      const now = Date.UTC(2026, 0, 31, 12, 0, 0);
+      const originalDateNow = Date.now;
+      Date.now = () => now;
+      try {
+        const takeCalls: number[] = [];
+        const ctx = {
+          auth: {
+            getUserIdentity: mock().mockResolvedValue({ subject: "user_1" }),
+          },
+          runQuery: mock().mockResolvedValue({ page: [{ _id: "user_1" }] }),
+          db: {
+            query: mock((table: string) => ({
+              withIndex: mock(() => ({
+                order: mock(() => ({
+                  take: mock((limit: number) => {
+                    takeCalls.push(limit);
+                    return Promise.resolve([]);
+                  }),
+                })),
+              })),
+            })),
+          },
+        } as any;
+        const handler =
+          (getLegacyApiKeyUsageAnalytics as any).handler ??
+          getLegacyApiKeyUsageAnalytics;
+
+        const result = await handler(ctx, { days: 7 });
+
+        expect(result.days).toBe(7);
+        expect(result.windowStartDate).toBe("2026-01-25");
+        expect(takeCalls).toEqual([7, 200]);
+      } finally {
+        Date.now = originalDateNow;
+      }
     });
   });
 

--- a/packages/convex/__tests__/apiKeys.test.ts
+++ b/packages/convex/__tests__/apiKeys.test.ts
@@ -57,6 +57,46 @@ const buildLegacyQuery = (rows: any[]) => ({
   })),
 });
 
+const buildLegacyAnalyticsDb = ({
+  dailyByKey = null,
+  dailyByUser = [],
+  legacyRows,
+  totals = null,
+}: {
+  dailyByKey?: any;
+  dailyByUser?: any[];
+  legacyRows: any[];
+  totals?: any;
+}) => ({
+  insert: mock().mockResolvedValue("analytics_row"),
+  patch: mock().mockResolvedValue(null),
+  query: mock((table: string) => {
+    if (table === "legacyApiKeyUsageDaily") {
+      return {
+        withIndex: mock((indexName: string) => {
+          if (indexName === "by_legacy_key_and_date") {
+            return { first: mock().mockResolvedValue(dailyByKey) };
+          }
+          if (indexName === "by_user_and_date") {
+            return { take: mock().mockResolvedValue(dailyByUser) };
+          }
+          return {
+            order: mock(() => ({ take: mock().mockResolvedValue([]) })),
+          };
+        }),
+      };
+    }
+    if (table === "legacyApiKeyUsageTotalsDaily") {
+      return {
+        withIndex: mock(() => ({
+          first: mock().mockResolvedValue(totals),
+        })),
+      };
+    }
+    return buildLegacyQuery(legacyRows);
+  }),
+});
+
 const buildAuth = (subject = "user_1") => ({
   getUserIdentity: mock().mockResolvedValue({ subject }),
 });
@@ -275,18 +315,16 @@ describe("apiKeys", () => {
       updatedAt: 100,
       userId: "user_1",
     };
+    const db = buildLegacyAnalyticsDb({
+      legacyRows: [
+        {
+          _id: "legacy_key",
+          ...insertedPayload,
+        },
+      ],
+    });
     const ctx = {
-      db: {
-        patch: mock().mockResolvedValue(null),
-        query: mock(() =>
-          buildLegacyQuery([
-            {
-              _id: "legacy_key",
-              ...insertedPayload,
-            },
-          ])
-        ),
-      },
+      db,
       runQuery: mock().mockResolvedValue({ _id: "user_1" }),
     };
 
@@ -301,10 +339,183 @@ describe("apiKeys", () => {
       source: "legacy",
       userId: "user_1",
     });
-    expect(ctx.db.patch).toHaveBeenCalledWith(
+    expect(db.patch).toHaveBeenCalledWith(
       "legacy_key",
       expect.objectContaining({ lastUsedAt: expect.any(Number) })
     );
+    expect(db.insert).toHaveBeenCalledWith(
+      "legacyApiKeyUsageDaily",
+      expect.objectContaining({
+        date: expect.any(String),
+        keyPrefix: "abc123",
+        legacyKeyId: "legacy_key",
+        observedUseCount: 1,
+        userId: "user_1",
+      })
+    );
+    expect(db.insert).toHaveBeenCalledWith(
+      "legacyApiKeyUsageTotalsDaily",
+      expect.objectContaining({
+        observedUseCount: 1,
+        uniqueKeyCount: 1,
+        uniqueUserCount: 1,
+      })
+    );
+  });
+
+  test("legacy usage analytics includes normalized request context", async () => {
+    const token = "teakapi_abc123_secretvalue";
+    const db = buildLegacyAnalyticsDb({
+      legacyRows: [
+        {
+          _id: "legacy_key",
+          access: "full_access",
+          keyHash: await hashLegacyApiKey(token),
+          keyPrefix: "abc123",
+          lastUsedAt: undefined,
+          revokedAt: undefined,
+          userId: "user_1",
+        },
+      ],
+    });
+    const ctx = {
+      db,
+      runQuery: mock().mockResolvedValue({ _id: "user_1" }),
+    };
+
+    await runHandler(validateUserApiKey, ctx, {
+      endpoint: "/v1/cards/:cardId/favorite",
+      method: "PATCH",
+      token,
+    });
+
+    expect(db.insert).toHaveBeenCalledWith(
+      "legacyApiKeyUsageDaily",
+      expect.objectContaining({
+        lastEndpoint: "/v1/cards/:cardId/favorite",
+        lastMethod: "PATCH",
+      })
+    );
+  });
+
+  test("legacy usage analytics is skipped inside the throttle window", async () => {
+    const now = Date.UTC(2026, 0, 2, 12, 0, 0);
+    const originalDateNow = Date.now;
+    Date.now = () => now;
+    try {
+      const token = "teakapi_abc123_secretvalue";
+      const db = buildLegacyAnalyticsDb({
+        legacyRows: [
+          {
+            _id: "legacy_key",
+            access: "full_access",
+            keyHash: await hashLegacyApiKey(token),
+            keyPrefix: "abc123",
+            lastUsedAt: now - 1000,
+            revokedAt: undefined,
+            userId: "user_1",
+          },
+        ],
+      });
+      const ctx = {
+        db,
+        runQuery: mock().mockResolvedValue({ _id: "user_1" }),
+      };
+
+      const result = await runHandler(validateUserApiKey, ctx, { token });
+
+      expect(result?.source).toBe("legacy");
+      expect(db.patch).not.toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(db.query.mock.calls.map((call) => call[0])).toEqual(["apiKeys"]);
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+
+  test("legacy usage analytics records a new UTC day inside the throttle window", async () => {
+    const now = Date.UTC(2026, 0, 2, 0, 1, 0);
+    const originalDateNow = Date.now;
+    Date.now = () => now;
+    try {
+      const token = "teakapi_abc123_secretvalue";
+      const db = buildLegacyAnalyticsDb({
+        legacyRows: [
+          {
+            _id: "legacy_key",
+            access: "full_access",
+            keyHash: await hashLegacyApiKey(token),
+            keyPrefix: "abc123",
+            lastUsedAt: Date.UTC(2026, 0, 1, 23, 59, 0),
+            revokedAt: undefined,
+            userId: "user_1",
+          },
+        ],
+      });
+      const ctx = {
+        db,
+        runQuery: mock().mockResolvedValue({ _id: "user_1" }),
+      };
+
+      await runHandler(validateUserApiKey, ctx, { token });
+
+      expect(db.insert).toHaveBeenCalledWith(
+        "legacyApiKeyUsageDaily",
+        expect.objectContaining({ date: "2026-01-02" })
+      );
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+
+  test("legacy usage analytics counts a second key without double-counting the user", async () => {
+    const now = Date.UTC(2026, 0, 2, 12, 0, 0);
+    const originalDateNow = Date.now;
+    Date.now = () => now;
+    try {
+      const token = "teakapi_abc123_secretvalue";
+      const db = buildLegacyAnalyticsDb({
+        dailyByUser: [{ _id: "existing_user_daily" }],
+        legacyRows: [
+          {
+            _id: "legacy_key_2",
+            access: "full_access",
+            keyHash: await hashLegacyApiKey(token),
+            keyPrefix: "abc123",
+            lastUsedAt: now - 60 * 60 * 1000,
+            revokedAt: undefined,
+            userId: "user_1",
+          },
+        ],
+        totals: {
+          _id: "totals_2026_01_02",
+          date: "2026-01-02",
+          firstUsedAt: now - 10_000,
+          lastUsedAt: now - 10_000,
+          observedUseCount: 3,
+          uniqueKeyCount: 1,
+          uniqueUserCount: 1,
+          updatedAt: now - 10_000,
+        },
+      });
+      const ctx = {
+        db,
+        runQuery: mock().mockResolvedValue({ _id: "user_1" }),
+      };
+
+      await runHandler(validateUserApiKey, ctx, { token });
+
+      expect(db.patch).toHaveBeenCalledWith(
+        "totals_2026_01_02",
+        expect.objectContaining({
+          observedUseCount: 4,
+          uniqueKeyCount: 2,
+          uniqueUserCount: 1,
+        })
+      );
+    } finally {
+      Date.now = originalDateNow;
+    }
   });
 
   test("validate rejects malformed keys without touching storage or components", async () => {
@@ -324,6 +535,25 @@ describe("apiKeys", () => {
     expect(ctx.db.query).not.toHaveBeenCalled();
     expect(ctx.runMutation).not.toHaveBeenCalled();
     expect(ctx.runQuery).not.toHaveBeenCalled();
+  });
+
+  test("validate rejects unmatched legacy keys without analytics writes", async () => {
+    const db = buildLegacyAnalyticsDb({ legacyRows: [] });
+    const ctx = {
+      db,
+      runQuery: mock(),
+    };
+
+    const result = await runHandler(validateUserApiKey, ctx, {
+      endpoint: "/v1/cards/search",
+      method: "GET",
+      token: "teakapi_missing_secret",
+    });
+
+    expect(result).toBeNull();
+    expect(db.patch).not.toHaveBeenCalled();
+    expect(db.insert).not.toHaveBeenCalled();
+    expect(db.query.mock.calls.map((call) => call[0])).toEqual(["apiKeys"]);
   });
 
   test("cutover helper only revokes legacy active keys", async () => {

--- a/packages/convex/__tests__/publicApiHttp.test.ts
+++ b/packages/convex/__tests__/publicApiHttp.test.ts
@@ -216,9 +216,48 @@ describe("publicApiHttp", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(runMutation.mock.calls[0][1]).toEqual({ token });
+    expect(runMutation.mock.calls[0][1]).toEqual({
+      endpoint: "/v1/cards",
+      method: "POST",
+      token,
+    });
     expect(runMutation.mock.calls[1][1]).toEqual({
       rateLimitKey: "key:component:component_key",
+    });
+  });
+
+  test("cardByIdV1 passes normalized favorite endpoint context to API key validation", async () => {
+    const runMutation = mock()
+      .mockResolvedValueOnce({
+        keyId: "key_1",
+        userId: "user_1",
+        access: "full_access",
+        source: "legacy",
+        rateLimitKey: "legacy:key_1",
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        retryAt: Date.now() + 30_000,
+      });
+
+    const response = await runHandler(
+      cardByIdV1,
+      { runMutation, runQuery: mock() },
+      new Request("https://example.com/v1/cards/card_123/favorite", {
+        method: "PATCH",
+        headers: {
+          Authorization: "Bearer teakapi_abc_secret",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ isFavorited: true }),
+      })
+    );
+
+    expect(response.status).toBe(429);
+    expect(runMutation.mock.calls[0][1]).toEqual({
+      endpoint: "/v1/cards/:cardId/favorite",
+      method: "PATCH",
+      token: "teakapi_abc_secret",
     });
   });
 

--- a/packages/convex/__tests__/publicApiHttp.test.ts
+++ b/packages/convex/__tests__/publicApiHttp.test.ts
@@ -261,6 +261,79 @@ describe("publicApiHttp", () => {
     });
   });
 
+  test("static card routes keep their exact endpoint labels", async () => {
+    const cases = [
+      {
+        handler: searchCardsV1,
+        method: "GET",
+        path: "/v1/cards/search",
+        query: mock().mockResolvedValue([]),
+      },
+      {
+        handler: favoriteCardsV1,
+        method: "GET",
+        path: "/v1/cards/favorites",
+        query: mock().mockResolvedValue([]),
+      },
+      {
+        body: {
+          items: [{ cardId: "card_1", isFavorited: true }],
+          operation: "favorite",
+        },
+        handler: bulkCardsV1,
+        method: "POST",
+        mutation: buildAuthorizedMutationMockWithIdempotencySkip().mockResolvedValueOnce(
+          {
+            operation: "favorite",
+            results: [{ cardId: "card_1", index: 0, status: "success" }],
+            summary: { failed: 0, succeeded: 1, total: 1 },
+          }
+        ),
+        path: "/v1/cards/bulk",
+        query: mock(),
+      },
+      {
+        handler: changesCardsV1,
+        method: "GET",
+        path: "/v1/cards/changes",
+        queryString: "?since=1&limit=10",
+        query: mock().mockResolvedValue({
+          deletedIds: [],
+          items: [],
+          pageInfo: { hasMore: false, nextCursor: null },
+        }),
+      },
+    ];
+
+    for (const testCase of cases) {
+      const runMutation = testCase.mutation ?? buildAuthorizedMutationMock();
+      const response = await runHandler(
+        testCase.handler,
+        { runMutation, runQuery: testCase.query },
+        new Request(
+          `https://example.com${testCase.path}${
+            testCase.queryString ?? "?limit=10"
+          }`,
+          {
+            body: testCase.body ? JSON.stringify(testCase.body) : undefined,
+            headers: {
+              Authorization: "Bearer teakapi_abc_secret",
+              ...(testCase.body ? { "Content-Type": "application/json" } : {}),
+            },
+            method: testCase.method,
+          }
+        )
+      );
+
+      expect(response.status).toBe(200);
+      expect(runMutation.mock.calls[0][1]).toEqual({
+        endpoint: testCase.path,
+        method: testCase.method,
+        token: "teakapi_abc_secret",
+      });
+    }
+  });
+
   test("createCardV1 returns 429 when the shared invalid-auth bucket is exhausted", async () => {
     const runMutation = mock().mockResolvedValueOnce({
       ok: false,

--- a/packages/convex/admin.ts
+++ b/packages/convex/admin.ts
@@ -42,6 +42,8 @@ const STAGE_KEYS: ProcessingStageKey[] = [
 const SEVEN_DAYS_IN_MS = 7 * 24 * 60 * 60 * 1000;
 const THIRTY_DAYS_IN_MS = 30 * 24 * 60 * 60 * 1000;
 const MAX_MISSING_CARDS = 50;
+const LEGACY_USAGE_DEFAULT_DAYS = 30;
+const LEGACY_USAGE_MAX_DAYS = 365;
 // Maximum cards to process in admin overview to prevent memory issues
 // For larger datasets, consider denormalizing counters or using pagination
 const ADMIN_OVERVIEW_LIMIT = 10_000;
@@ -92,6 +94,16 @@ const clampPagination = (paginationOpts: {
   ...paginationOpts,
   numItems: Math.min(paginationOpts.numItems, ADMIN_LIST_LIMIT),
 });
+
+const toUtcDate = (timestamp: number) =>
+  new Date(timestamp).toISOString().slice(0, 10);
+
+const normalizeAnalyticsDays = (days?: number) => {
+  if (!(typeof days === "number" && Number.isFinite(days))) {
+    return LEGACY_USAGE_DEFAULT_DAYS;
+  }
+  return Math.max(1, Math.min(LEGACY_USAGE_MAX_DAYS, Math.floor(days)));
+};
 
 type CardWithUrls = Doc<"cards"> & {
   fileUrl?: string;
@@ -157,6 +169,61 @@ export const getAccess = query({
 
     return {
       allowed,
+    };
+  },
+});
+
+export const getLegacyApiKeyUsageAnalytics = query({
+  args: {
+    days: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    await ensureAdmin(ctx);
+
+    const days = normalizeAnalyticsDays(args.days);
+    const windowStartDate = toUtcDate(
+      Date.now() - (days - 1) * 24 * 60 * 60 * 1000
+    );
+
+    const [totals, legacyKeys] = await Promise.all([
+      ctx.db
+        .query("legacyApiKeyUsageTotalsDaily")
+        .withIndex("by_date", (q) => q.gte("date", windowStartDate))
+        .order("desc")
+        .take(days),
+      ctx.db
+        .query("legacyApiKeyUsageDaily")
+        .withIndex("by_date", (q) => q.gte("date", windowStartDate))
+        .order("desc")
+        .take(ADMIN_LIST_LIMIT),
+    ]);
+
+    return {
+      days,
+      windowStartDate,
+      totals: totals.map((row) => ({
+        date: row.date,
+        observedUseCount: row.observedUseCount,
+        uniqueKeyCount: row.uniqueKeyCount,
+        uniqueUserCount: row.uniqueUserCount,
+        firstUsedAt: row.firstUsedAt,
+        lastUsedAt: row.lastUsedAt,
+        updatedAt: row.updatedAt,
+      })),
+      recentLegacyKeys: legacyKeys
+        .sort((left, right) => right.lastUsedAt - left.lastUsedAt)
+        .map((row) => ({
+          date: row.date,
+          legacyKeyId: row.legacyKeyId,
+          userId: row.userId,
+          keyPrefix: row.keyPrefix,
+          observedUseCount: row.observedUseCount,
+          firstUsedAt: row.firstUsedAt,
+          lastUsedAt: row.lastUsedAt,
+          lastMethod: row.lastMethod,
+          lastEndpoint: row.lastEndpoint,
+          updatedAt: row.updatedAt,
+        })),
     };
   },
 });

--- a/packages/convex/apiKeys.ts
+++ b/packages/convex/apiKeys.ts
@@ -88,10 +88,21 @@ const componentKeyActionValidator = v.object({
   keyId: v.string(),
 });
 
+const validateApiKeyArgsValidator = v.object({
+  token: v.string(),
+  method: v.optional(v.string()),
+  endpoint: v.optional(v.string()),
+});
+
 const revokeKeyArgsValidator = v.object({
   keyId: v.string(),
   source: apiKeySourceValidator,
 });
+
+interface LegacyUsageContext {
+  endpoint?: string;
+  method?: string;
+}
 
 const toHex = (bytes: Uint8Array): string =>
   Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
@@ -149,6 +160,14 @@ const getComponentKeysForOwner = async (
 
 const normalizeApiKeyName = (name: string) =>
   name === API_KEY_NAME_LEGACY_DEFAULT ? API_KEY_NAME_DEFAULT : name;
+
+const getUtcDate = (timestamp: number) =>
+  new Date(timestamp).toISOString().slice(0, 10);
+
+const normalizeUsageDimension = (value?: string) => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.slice(0, 120) : undefined;
+};
 
 const mapComponentKey = (key: KeyMetadata) => ({
   id: key.keyId,
@@ -219,7 +238,8 @@ const validateComponentApiKey = async (
 
 const validateLegacyApiKey = async (
   ctx: MutationCtx,
-  token: string
+  token: string,
+  usage?: LegacyUsageContext
 ) => {
   const parts = token.split("_");
   const keyPrefix = parts[1];
@@ -256,13 +276,27 @@ const validateLegacyApiKey = async (
     }
 
     const lastUsedAt = candidate.lastUsedAt;
-    if (
+    const currentDate = getUtcDate(now);
+    const lastUsedDate =
+      lastUsedAt === undefined ? null : getUtcDate(lastUsedAt);
+    const shouldTrackUsage =
       lastUsedAt === undefined ||
-      now - lastUsedAt >= LAST_USED_THROTTLE_MS
-    ) {
+      now - lastUsedAt >= LAST_USED_THROTTLE_MS ||
+      lastUsedDate !== currentDate;
+
+    if (shouldTrackUsage) {
       await ctx.db.patch(candidate._id, {
         lastUsedAt: now,
         updatedAt: now,
+      });
+      await trackLegacyApiKeyUsage(ctx, {
+        date: currentDate,
+        endpoint: normalizeUsageDimension(usage?.endpoint),
+        keyPrefix: candidate.keyPrefix,
+        legacyKeyId: candidate._id,
+        method: normalizeUsageDimension(usage?.method),
+        now,
+        userId: candidate.userId,
       });
     }
 
@@ -276,6 +310,106 @@ const validateLegacyApiKey = async (
   }
 
   return null;
+};
+
+const trackLegacyApiKeyUsage = async (
+  ctx: MutationCtx,
+  args: {
+    date: string;
+    endpoint?: string;
+    keyPrefix: string;
+    legacyKeyId: Id<"apiKeys">;
+    method?: string;
+    now: number;
+    userId: string;
+  }
+) => {
+  const existingDaily = await ctx.db
+    .query("legacyApiKeyUsageDaily")
+    .withIndex("by_legacy_key_and_date", (q) =>
+      q.eq("legacyKeyId", args.legacyKeyId).eq("date", args.date)
+    )
+    .first();
+
+  if (existingDaily) {
+    await ctx.db.patch(existingDaily._id, {
+      observedUseCount: existingDaily.observedUseCount + 1,
+      lastUsedAt: args.now,
+      ...(args.method ? { lastMethod: args.method } : {}),
+      ...(args.endpoint ? { lastEndpoint: args.endpoint } : {}),
+      updatedAt: args.now,
+    });
+    await updateLegacyApiKeyUsageTotals(ctx, args, {
+      uniqueKeyIncrement: 0,
+      uniqueUserIncrement: 0,
+    });
+    return;
+  }
+
+  const existingUserDaily = await ctx.db
+    .query("legacyApiKeyUsageDaily")
+    .withIndex("by_user_and_date", (q) =>
+      q.eq("userId", args.userId).eq("date", args.date)
+    )
+    .take(1);
+
+  await ctx.db.insert("legacyApiKeyUsageDaily", {
+    date: args.date,
+    legacyKeyId: args.legacyKeyId,
+    userId: args.userId,
+    keyPrefix: args.keyPrefix,
+    observedUseCount: 1,
+    firstUsedAt: args.now,
+    lastUsedAt: args.now,
+    ...(args.method ? { lastMethod: args.method } : {}),
+    ...(args.endpoint ? { lastEndpoint: args.endpoint } : {}),
+    updatedAt: args.now,
+  });
+
+  await updateLegacyApiKeyUsageTotals(ctx, args, {
+    uniqueKeyIncrement: 1,
+    uniqueUserIncrement: existingUserDaily.length === 0 ? 1 : 0,
+  });
+};
+
+const updateLegacyApiKeyUsageTotals = async (
+  ctx: MutationCtx,
+  args: {
+    date: string;
+    now: number;
+  },
+  increments: {
+    uniqueKeyIncrement: number;
+    uniqueUserIncrement: number;
+  }
+) => {
+  const existingTotals = await ctx.db
+    .query("legacyApiKeyUsageTotalsDaily")
+    .withIndex("by_date", (q) => q.eq("date", args.date))
+    .first();
+
+  if (existingTotals) {
+    await ctx.db.patch(existingTotals._id, {
+      observedUseCount: existingTotals.observedUseCount + 1,
+      uniqueKeyCount:
+        existingTotals.uniqueKeyCount + increments.uniqueKeyIncrement,
+      uniqueUserCount:
+        existingTotals.uniqueUserCount + increments.uniqueUserIncrement,
+      lastUsedAt: args.now,
+      updatedAt: args.now,
+    });
+    return;
+  }
+
+  await ctx.db.insert("legacyApiKeyUsageTotalsDaily", {
+    date: args.date,
+    observedUseCount: 1,
+    uniqueKeyCount: increments.uniqueKeyIncrement,
+    uniqueUserCount: increments.uniqueUserIncrement,
+    firstUsedAt: args.now,
+    lastUsedAt: args.now,
+    updatedAt: args.now,
+  });
 };
 
 export const createUserApiKey = mutation({
@@ -416,9 +550,7 @@ export const rotateUserApiKey = mutation({
 });
 
 export const validateUserApiKey = internalMutation({
-  args: {
-    token: v.string(),
-  },
+  args: validateApiKeyArgsValidator,
   returns: validatedApiKeyValidator,
   handler: async (ctx, args) => {
     const token = args.token.trim();
@@ -432,7 +564,10 @@ export const validateUserApiKey = internalMutation({
     }
 
     if (isLegacyApiKey(token)) {
-      return validateLegacyApiKey(ctx, token);
+      return validateLegacyApiKey(ctx, token, {
+        endpoint: args.endpoint,
+        method: args.method,
+      });
     }
 
     return null;

--- a/packages/convex/publicApiHttp.ts
+++ b/packages/convex/publicApiHttp.ts
@@ -114,6 +114,17 @@ const parseBearerToken = (request: Request): string | null => {
   return token.trim();
 };
 
+const normalizeApiEndpoint = (requestUrl: string): string => {
+  const pathname = new URL(requestUrl).pathname;
+  if (/^\/v1\/cards\/[^/]+\/favorite$/.test(pathname)) {
+    return "/v1/cards/:cardId/favorite";
+  }
+  if (/^\/v1\/cards\/[^/]+$/.test(pathname)) {
+    return "/v1/cards/:cardId";
+  }
+  return pathname;
+};
+
 const parseLimit = (raw: string | null): number => {
   if (!raw) {
     return DEFAULT_LIMIT;
@@ -397,6 +408,8 @@ const withAuthorizedUser = async (
     validated = await ctx.runMutation(
       (internal as any).apiKeys.validateUserApiKey,
       {
+        endpoint: normalizeApiEndpoint(request.url),
+        method: request.method.toUpperCase(),
         token,
       }
     );

--- a/packages/convex/publicApiHttp.ts
+++ b/packages/convex/publicApiHttp.ts
@@ -114,8 +114,18 @@ const parseBearerToken = (request: Request): string | null => {
   return token.trim();
 };
 
+const STATIC_CARD_ENDPOINTS = new Set([
+  "/v1/cards/bulk",
+  "/v1/cards/changes",
+  "/v1/cards/favorites",
+  "/v1/cards/search",
+]);
+
 const normalizeApiEndpoint = (requestUrl: string): string => {
   const pathname = new URL(requestUrl).pathname;
+  if (STATIC_CARD_ENDPOINTS.has(pathname)) {
+    return pathname;
+  }
   if (/^\/v1\/cards\/[^/]+\/favorite$/.test(pathname)) {
     return "/v1/cards/:cardId/favorite";
   }

--- a/packages/convex/schema.ts
+++ b/packages/convex/schema.ts
@@ -206,6 +206,29 @@ export const apiIdempotencyAnalyticsValidator = v.object({
   errors: v.number(),
 });
 
+export const legacyApiKeyUsageDailyValidator = v.object({
+  date: v.string(),
+  legacyKeyId: v.id("apiKeys"),
+  userId: v.string(),
+  keyPrefix: v.string(),
+  observedUseCount: v.number(),
+  firstUsedAt: v.number(),
+  lastUsedAt: v.number(),
+  lastMethod: v.optional(v.string()),
+  lastEndpoint: v.optional(v.string()),
+  updatedAt: v.number(),
+});
+
+export const legacyApiKeyUsageTotalsDailyValidator = v.object({
+  date: v.string(),
+  observedUseCount: v.number(),
+  uniqueKeyCount: v.number(),
+  uniqueUserCount: v.number(),
+  firstUsedAt: v.number(),
+  lastUsedAt: v.number(),
+  updatedAt: v.number(),
+});
+
 export const nativeAuthSurfaceValidator = v.union(
   v.literal("desktop"),
   v.literal("safari-macos"),
@@ -332,6 +355,13 @@ export default defineSchema({
     "by_date_endpoint",
     ["date", "endpoint"]
   ),
+  legacyApiKeyUsageDaily: defineTable(legacyApiKeyUsageDailyValidator)
+    .index("by_legacy_key_and_date", ["legacyKeyId", "date"])
+    .index("by_user_and_date", ["userId", "date"])
+    .index("by_date", ["date"]),
+  legacyApiKeyUsageTotalsDaily: defineTable(
+    legacyApiKeyUsageTotalsDailyValidator
+  ).index("by_date", ["date"]),
   nativeAuthCodes: defineTable(nativeAuthCodeValidator)
     .index("by_expires_at", ["expiresAt"])
     .index("by_device_state_consumed", ["deviceId", "state", "consumedAt"])


### PR DESCRIPTION
## Summary
- add daily legacy API-key usage analytics tables and counters
- sample successful legacy-key validations on the existing throttled usage cadence
- expose admin-only analytics for the default 30-day deprecation window

## Notes
- public REST/MCP auth stays unchanged
- component keys, malformed tokens, and invalid keys do not write analytics
- no docs/changelog because this is internal operational telemetry

## Verification
- bun test packages/convex/__tests__/apiKeys.test.ts packages/convex/__tests__/publicApiHttp.test.ts packages/convex/__tests__/admin.test.ts
- bun run test --filter=@teak/convex
- bun run typecheck --filter=@teak/convex
- bun run pre-commit
