### PR TITLE
feat(import): add Raindrop CSV import

### DIFF
--- a/apps/docs/src/content/changelog/2026-06-30.mdx
+++ b/apps/docs/src/content/changelog/2026-06-30.mdx
@@ -1,0 +1,7 @@
+---
+title: "June 2026: import from Raindrop"
+date: "2026-06-30"
+---
+
+- You can now import your Raindrop bookmarks from Settings on web and desktop. Choose your Raindrop CSV export and Teak brings in each link with its notes, tags, folder, favorite, and saved date.
+- Imports start as soon as you choose the file, skip duplicate links, and show created, skipped, and failed totals when finished.

--- a/packages/convex/__tests__/import/raindrop.test.ts
+++ b/packages/convex/__tests__/import/raindrop.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { parseRaindropCsv } from "../../import/raindrop";
+
+describe("backend raindrop CSV parser", () => {
+  test("maps url, title, note, tags, folder, created, and favorite", () => {
+    const createdAt = Date.parse("2023-05-15T10:30:00.000Z");
+    const csv = [
+      "id,title,note,excerpt,url,folder,tags,created,cover,highlights,favorite",
+      `1,Example Site,A great resource,An excerpt,https://example.com,Design/Tools,"design, tools",2023-05-15T10:30:00.000Z,https://img.example/cover.png,,true`,
+    ].join("\n");
+    const parsed = parseRaindropCsv(csv);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].card).toMatchObject({
+      type: "link",
+      content: "Example Site",
+      url: "https://example.com",
+      notes: "A great resource",
+      tags: ["Design", "Tools", "design", "tools"],
+      isFavorited: true,
+      createdAt,
+    });
+  });
+
+  test("preserves commas inside quoted note and tags fields", () => {
+    const csv = [
+      "url,title,note,folder,tags,created,favorite",
+      `https://safe.test,"Title, with comma","Note, with comma",Inbox,"a, b, c",1700000000,false`,
+    ].join("\n");
+    const parsed = parseRaindropCsv(csv);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].card).toMatchObject({
+      content: "Title, with comma",
+      notes: "Note, with comma",
+      tags: ["Inbox", "a", "b", "c"],
+      url: "https://safe.test",
+      createdAt: 1_700_000_000_000,
+    });
+    expect(parsed[0].card?.isFavorited).toBeUndefined();
+  });
+
+  test("parses created as unix seconds and ISO timestamps", () => {
+    const iso = Date.parse("2022-01-02T03:04:05.000Z");
+    const csv = [
+      "url,created",
+      "https://unix.test,1700000000",
+      "https://iso.test,2022-01-02T03:04:05.000Z",
+    ].join("\n");
+    const parsed = parseRaindropCsv(csv);
+    expect(parsed[0].card?.createdAt).toBe(1_700_000_000_000);
+    expect(parsed[1].card?.createdAt).toBe(iso);
+  });
+
+  test("falls back to url when the title is blank", () => {
+    const csv = ["url,title", "https://no-title.test,"].join("\n");
+    const parsed = parseRaindropCsv(csv);
+    expect(parsed[0].card?.content).toBe("https://no-title.test");
+  });
+
+  test("rejects unsafe URLs without dropping the next valid row", () => {
+    const csv = [
+      "url,title",
+      "javascript:alert(1),Bad",
+      "https://safe.test,Safe",
+    ].join("\n");
+    const parsed = parseRaindropCsv(csv);
+    expect(parsed[0].error).toContain("unsafe");
+    expect(parsed[0].card).toBeUndefined();
+    expect(parsed[1].card?.url).toBe("https://safe.test");
+  });
+
+  test("skips blank rows and matches headers case-insensitively", () => {
+    const csv = ["URL,Title", "https://example.test,Example", "", "   "].join(
+      "\n"
+    );
+    const parsed = parseRaindropCsv(csv);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].card?.url).toBe("https://example.test");
+  });
+
+  test("throws when the url column is missing", () => {
+    expect(() => parseRaindropCsv("title,note\nHello,World")).toThrow(
+      "missing a url column"
+    );
+  });
+});

--- a/packages/convex/_generated/api.d.ts
+++ b/packages/convex/_generated/api.d.ts
@@ -48,6 +48,7 @@ import type * as idempotencyAnalytics from "../idempotencyAnalytics.js";
 import type * as import_bookmarks from "../import/bookmarks.js";
 import type * as import_constants from "../import/constants.js";
 import type * as import_r2Client from "../import/r2Client.js";
+import type * as import_raindrop from "../import/raindrop.js";
 import type * as import_runImport from "../import/runImport.js";
 import type * as import_validate from "../import/validate.js";
 import type * as importUpload from "../importUpload.js";
@@ -171,6 +172,7 @@ declare const fullApi: ApiFromModules<{
   "import/bookmarks": typeof import_bookmarks;
   "import/constants": typeof import_constants;
   "import/r2Client": typeof import_r2Client;
+  "import/raindrop": typeof import_raindrop;
   "import/runImport": typeof import_runImport;
   "import/validate": typeof import_validate;
   importUpload: typeof importUpload;

--- a/packages/convex/import/constants.ts
+++ b/packages/convex/import/constants.ts
@@ -1,6 +1,7 @@
 export const IMPORT_PART_BYTES = 64 * 1024 * 1024;
 export const IMPORT_UPLOAD_TTL_MS = 24 * 60 * 60 * 1000;
 export const MAX_BOOKMARK_BYTES = 20 * 1024 * 1024;
+export const MAX_RAINDROP_BYTES = 20 * 1024 * 1024;
 export const MAX_ARCHIVE_BYTES = 5 * 1024 * 1024 * 1024;
 export const MAX_IMPORT_CARDS = 10_000;
 export const MAX_IMPORT_FILE_BYTES = 20 * 1024 * 1024;
@@ -23,4 +24,4 @@ export const TERMINAL_IMPORT_STATUSES = [
   "canceled",
 ] as const;
 
-export type ImportMode = "bookmarks" | "archive";
+export type ImportMode = "bookmarks" | "archive" | "raindrop";

--- a/packages/convex/import/raindrop.ts
+++ b/packages/convex/import/raindrop.ts
@@ -1,0 +1,194 @@
+import { sanitizeExternalUrl } from "../shared/utils/safeUrl";
+import type { ParsedBookmarkItem } from "./bookmarks";
+import { parseImportedTimestamp } from "./validate";
+
+/**
+ * Minimal RFC-4180 CSV parser. Handles quoted fields, embedded commas and
+ * newlines, `""` escaping, and CRLF/LF/CR line endings. Returns rows of raw
+ * (untrimmed) cell strings. Dependency-free, matching the repo's hand-rolled
+ * parsing style in `bookmarks.ts`.
+ */
+export function parseCsvRows(input: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  let index = 0;
+  const length = input.length;
+
+  const endField = () => {
+    row.push(field);
+    field = "";
+  };
+  const endRow = () => {
+    endField();
+    rows.push(row);
+    row = [];
+  };
+
+  while (index < length) {
+    const char = input[index];
+    if (inQuotes) {
+      if (char === '"') {
+        if (input[index + 1] === '"') {
+          field += '"';
+          index += 2;
+          continue;
+        }
+        inQuotes = false;
+        index += 1;
+        continue;
+      }
+      field += char;
+      index += 1;
+      continue;
+    }
+    if (char === '"') {
+      inQuotes = true;
+      index += 1;
+      continue;
+    }
+    if (char === ",") {
+      endField();
+      index += 1;
+      continue;
+    }
+    if (char === "\r") {
+      if (input[index + 1] === "\n") {
+        index += 1;
+      }
+      endRow();
+      index += 1;
+      continue;
+    }
+    if (char === "\n") {
+      endRow();
+      index += 1;
+      continue;
+    }
+    field += char;
+    index += 1;
+  }
+  if (field.length > 0 || row.length > 0) {
+    endRow();
+  }
+  return rows;
+}
+
+function isEmptyRow(row: string[]): boolean {
+  return row.every((cell) => cell.trim() === "");
+}
+
+/**
+ * Parses a Raindrop `created` value. Raindrop exports an ISO 8601 timestamp,
+ * but an all-digits value is treated as unix seconds (mirroring the `add_date`
+ * handling in `bookmarks.ts`).
+ */
+function parseRaindropCreated(raw: string): number | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return;
+  }
+  if (/^\d+$/.test(trimmed)) {
+    const seconds = Number(trimmed);
+    return Number.isFinite(seconds) && seconds > 0
+      ? parseImportedTimestamp(seconds * 1000)
+      : undefined;
+  }
+  return parseImportedTimestamp(trimmed);
+}
+
+function isTruthyFavorite(raw: string): boolean {
+  const value = raw.trim().toLowerCase();
+  return value === "true" || value === "1" || value === "yes";
+}
+
+function collectTags(folder: string, tags: string): string[] {
+  const collected: string[] = [];
+  // Folder nesting becomes individual tags, matching the bookmark importer.
+  for (const segment of folder.split("/")) {
+    const tag = segment.trim();
+    if (tag) {
+      collected.push(tag);
+    }
+  }
+  for (const segment of tags.split(",")) {
+    const tag = segment.trim();
+    if (tag) {
+      collected.push(tag);
+    }
+  }
+  return [...new Set(collected)];
+}
+
+/**
+ * Parses a Raindrop.io CSV export into the shared bookmark item shape so it
+ * reuses the same downstream normalization as the HTML bookmark importer.
+ *
+ * Columns are matched by header name (case-insensitive), so both the full
+ * export (`id, title, note, excerpt, url, folder, tags, created, cover,
+ * highlights, favorite`) and the import-compatible subset are supported. The
+ * `url` column is required; `id`, `excerpt`, `cover`, and `highlights` are
+ * ignored.
+ */
+export function parseRaindropCsv(csv: string): ParsedBookmarkItem[] {
+  // Strip a leading UTF-8 BOM if present.
+  const normalized = csv.charCodeAt(0) === 0xfe_ff ? csv.slice(1) : csv;
+  const rows = parseCsvRows(normalized);
+  if (rows.length === 0) {
+    throw new Error("Raindrop CSV is empty");
+  }
+
+  const header = rows[0];
+  const columns = new Map<string, number>();
+  header.forEach((name, index) => {
+    const key = name.trim().toLowerCase();
+    if (key && !columns.has(key)) {
+      columns.set(key, index);
+    }
+  });
+  if (!columns.has("url")) {
+    throw new Error("Raindrop CSV is missing a url column");
+  }
+
+  const cell = (row: string[], column: string): string => {
+    const index = columns.get(column);
+    if (index === undefined) {
+      return "";
+    }
+    return (row[index] ?? "").trim();
+  };
+
+  const output: ParsedBookmarkItem[] = [];
+  for (let rowIndex = 1; rowIndex < rows.length; rowIndex += 1) {
+    const row = rows[rowIndex];
+    if (isEmptyRow(row)) {
+      continue;
+    }
+    const rawUrl = cell(row, "url");
+    const url = sanitizeExternalUrl(rawUrl);
+    const title = cell(row, "title");
+    if (!url) {
+      output.push({
+        label: title || rawUrl || "Raindrop bookmark",
+        error: "Raindrop bookmark URL is unsafe",
+      });
+      continue;
+    }
+    const tags = collectTags(cell(row, "folder"), cell(row, "tags"));
+    const notes = cell(row, "note");
+    output.push({
+      label: title || url,
+      card: {
+        type: "link",
+        content: title || url,
+        url,
+        tags: tags.length ? tags : undefined,
+        notes: notes || undefined,
+        isFavorited: isTruthyFavorite(cell(row, "favorite")) || undefined,
+        createdAt: parseRaindropCreated(cell(row, "created")),
+      },
+    });
+  }
+  return output;
+}

--- a/packages/convex/import/runImport.ts
+++ b/packages/convex/import/runImport.ts
@@ -12,16 +12,18 @@ import yauzl from "yauzl";
 import { internal } from "../_generated/api";
 import { internalAction } from "../_generated/server";
 import { buildR2UserPrefix } from "../storage/r2";
-import { parseBookmarksHtml } from "./bookmarks";
+import { type ParsedBookmarkItem, parseBookmarksHtml } from "./bookmarks";
 import {
   IMPORT_INDEX_BATCH,
+  type ImportMode,
   MAX_BOOKMARK_BYTES,
   MAX_IMPORT_EXPANDED_BYTES,
   MAX_IMPORT_FILE_BYTES,
   MAX_IMPORT_JSON_BYTES,
-  type ImportMode,
+  MAX_RAINDROP_BYTES,
 } from "./constants";
 import { createImportS3Client, getImportR2Config } from "./r2Client";
+import { parseRaindropCsv } from "./raindrop";
 import {
   assertImportCardCount,
   isSafeArchivePath,
@@ -258,6 +260,29 @@ async function storeItems(ctx: any, jobId: string, items: any[]) {
   }
 }
 
+async function indexParsedBookmarks(
+  ctx: any,
+  jobId: string,
+  parsed: ParsedBookmarkItem[],
+  mode: ImportMode
+) {
+  assertImportCardCount(parsed.length, mode);
+  const seen = new Set<string>();
+  const items = parsed.map((item, sourceIndex) =>
+    item.card
+      ? normalizeIndexItem(item.card, sourceIndex, new Map(), seen)
+      : {
+          sourceIndex,
+          status: "failed" as const,
+          type: "text" as const,
+          content: item.label,
+          failureCode: "INVALID_BOOKMARK",
+          failureReason: item.error,
+        }
+  );
+  await storeItems(ctx, jobId, items);
+}
+
 export const indexImportSource = internalAction({
   args: { jobId: v.id("importJobs") },
   returns: v.object({ ok: v.boolean(), failureClass: v.optional(v.string()) }),
@@ -269,33 +294,32 @@ export const indexImportSource = internalAction({
     const config = getImportR2Config();
     const client = createImportS3Client(config);
     try {
-      if (job.mode === "bookmarks") {
-        if (job.fileSize > MAX_BOOKMARK_BYTES) {
-          throw new Error("Bookmark file exceeds 20 MiB");
+      if (job.mode === "bookmarks" || job.mode === "raindrop") {
+        const isRaindrop = job.mode === "raindrop";
+        const maxBytes = isRaindrop ? MAX_RAINDROP_BYTES : MAX_BOOKMARK_BYTES;
+        if (job.fileSize > maxBytes) {
+          throw new Error(
+            isRaindrop
+              ? "Raindrop CSV exceeds 20 MiB"
+              : "Bookmark file exceeds 20 MiB"
+          );
         }
         const response = await client.send(
           new GetObjectCommand({ Bucket: config.bucket, Key: job.sourceKey })
         );
         const bytes = await response.Body?.transformToByteArray();
         if (!bytes || bytes.byteLength !== job.fileSize) {
-          throw new Error("Bookmark source could not be read");
+          throw new Error(
+            isRaindrop
+              ? "Raindrop source could not be read"
+              : "Bookmark source could not be read"
+          );
         }
-        const parsed = parseBookmarksHtml(Buffer.from(bytes).toString("utf8"));
-        assertImportCardCount(parsed.length, job.mode as ImportMode);
-        const seen = new Set<string>();
-        const items = parsed.map((item, sourceIndex) =>
-          item.card
-            ? normalizeIndexItem(item.card, sourceIndex, new Map(), seen)
-            : {
-                sourceIndex,
-                status: "failed" as const,
-                type: "text" as const,
-                content: item.label,
-                failureCode: "INVALID_BOOKMARK",
-                failureReason: item.error,
-              }
-        );
-        await storeItems(ctx, jobId, items);
+        const text = Buffer.from(bytes).toString("utf8");
+        const parsed = isRaindrop
+          ? parseRaindropCsv(text)
+          : parseBookmarksHtml(text);
+        await indexParsedBookmarks(ctx, jobId, parsed, job.mode as ImportMode);
       } else {
         const zip = await openZip(
           client,

--- a/packages/convex/import/validate.ts
+++ b/packages/convex/import/validate.ts
@@ -1,8 +1,8 @@
 import { sanitizeExternalUrl } from "../shared/utils/safeUrl";
 import {
+  type ImportMode,
   MAX_IMPORT_CARDS,
   MAX_IMPORT_FILE_BYTES,
-  type ImportMode,
 } from "./constants";
 
 export const IMPORT_CARD_TYPES = [
@@ -211,11 +211,14 @@ export function validateImportCard(raw: unknown): ImportCardInput {
 }
 
 export function assertImportCardCount(count: number, mode: ImportMode): void {
-  if (count > MAX_IMPORT_CARDS) {
-    throw new Error(
-      mode === "bookmarks"
-        ? "Bookmark file exceeds 10,000 bookmarks"
-        : "Archive exceeds 10,000 cards"
-    );
+  if (count <= MAX_IMPORT_CARDS) {
+    return;
   }
+  if (mode === "bookmarks") {
+    throw new Error("Bookmark file exceeds 10,000 bookmarks");
+  }
+  if (mode === "raindrop") {
+    throw new Error("Raindrop CSV exceeds 10,000 bookmarks");
+  }
+  throw new Error("Archive exceeds 10,000 cards");
 }

--- a/packages/convex/importUpload.ts
+++ b/packages/convex/importUpload.ts
@@ -19,6 +19,7 @@ import {
   IMPORT_UPLOAD_TTL_MS,
   MAX_ARCHIVE_BYTES,
   MAX_BOOKMARK_BYTES,
+  MAX_RAINDROP_BYTES,
 } from "./import/constants";
 import { createImportS3Client, getImportR2Config } from "./import/r2Client";
 import { importModeValidator } from "./schema";
@@ -46,7 +47,7 @@ async function requireUserId(ctx: {
 }
 
 function validateSource(
-  mode: "bookmarks" | "archive",
+  mode: "bookmarks" | "archive" | "raindrop",
   fileName: string,
   fileSize: number
 ) {
@@ -71,22 +72,46 @@ function validateSource(
       message: "Choose a bookmarks HTML file",
     });
   }
+  if (mode === "raindrop" && !extension.endsWith(".csv")) {
+    throw new ConvexError({
+      code: "INVALID_FILE",
+      message: "Choose a Raindrop CSV file",
+    });
+  }
   if (mode === "archive" && !extension.endsWith(".zip")) {
     throw new ConvexError({
       code: "INVALID_FILE",
       message: "Choose a Teak ZIP archive",
     });
   }
-  const limit = mode === "bookmarks" ? MAX_BOOKMARK_BYTES : MAX_ARCHIVE_BYTES;
+  let limit = MAX_ARCHIVE_BYTES;
+  if (mode === "bookmarks") {
+    limit = MAX_BOOKMARK_BYTES;
+  } else if (mode === "raindrop") {
+    limit = MAX_RAINDROP_BYTES;
+  }
   if (fileSize > limit) {
+    let message = "Teak archives are limited to 5 GiB";
+    if (mode === "bookmarks") {
+      message = "Bookmark files are limited to 20 MiB";
+    } else if (mode === "raindrop") {
+      message = "Raindrop CSV files are limited to 20 MiB";
+    }
     throw new ConvexError({
       code: "FILE_TOO_LARGE",
-      message:
-        mode === "bookmarks"
-          ? "Bookmark files are limited to 20 MiB"
-          : "Teak archives are limited to 5 GiB",
+      message,
     });
   }
+}
+
+function contentTypeForMode(mode: "bookmarks" | "archive" | "raindrop") {
+  if (mode === "bookmarks") {
+    return "text/html";
+  }
+  if (mode === "raindrop") {
+    return "text/csv";
+  }
+  return "application/zip";
 }
 
 function totalParts(fileSize: number) {
@@ -186,8 +211,7 @@ export const createImportUpload = action({
         new CreateMultipartUploadCommand({
           Bucket: config.bucket,
           Key: sourceKey,
-          ContentType:
-            args.mode === "bookmarks" ? "text/html" : "application/zip",
+          ContentType: contentTypeForMode(args.mode),
         })
       );
       if (!created.UploadId) {

--- a/packages/convex/schema.ts
+++ b/packages/convex/schema.ts
@@ -277,7 +277,8 @@ export const importStatusValidator = v.union(
 
 export const importModeValidator = v.union(
   v.literal("bookmarks"),
-  v.literal("archive")
+  v.literal("archive"),
+  v.literal("raindrop")
 );
 
 export const importItemStatusValidator = v.union(

--- a/packages/ui/src/components/settings/ImportDialog.tsx
+++ b/packages/ui/src/components/settings/ImportDialog.tsx
@@ -2,7 +2,7 @@
 
 import { api } from "@teak/convex";
 import { useAction, useQuery } from "convex/react";
-import { Archive, Bookmark, Copy, Download } from "lucide-react";
+import { Archive, Bookmark, Copy, Download, Droplet } from "lucide-react";
 import { type ChangeEvent, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "../ui/button";
@@ -192,6 +192,7 @@ export function ImportDialog({
     | undefined;
   const bookmarkInput = useRef<HTMLInputElement>(null);
   const archiveInput = useRef<HTMLInputElement>(null);
+  const raindropInput = useRef<HTMLInputElement>(null);
   const controllers = useRef(new Set<AbortController>());
   const [uploadPercent, setUploadPercent] = useState<number>();
   const [transporting, setTransporting] = useState(false);
@@ -200,7 +201,7 @@ export function ImportDialog({
 
   const selectFile = async (
     event: ChangeEvent<HTMLInputElement>,
-    mode: "bookmarks" | "archive"
+    mode: "bookmarks" | "archive" | "raindrop"
   ) => {
     const file = event.target.files?.[0];
     event.target.value = "";
@@ -317,6 +318,22 @@ export function ImportDialog({
               </span>
             </span>
           </button>
+          <button
+            className="flex w-full items-center gap-3 p-3 text-left hover:bg-muted/50 disabled:opacity-50"
+            disabled={choosingDisabled}
+            onClick={() => raindropInput.current?.click()}
+            type="button"
+          >
+            <Droplet className="size-4" />
+            <span>
+              <span className="block font-medium text-sm">
+                Import from Raindrop
+              </span>
+              <span className="block text-muted-foreground text-xs">
+                Raindrop CSV exports, up to 20 MiB
+              </span>
+            </span>
+          </button>
         </div>
         <input
           accept=".html,.htm,text/html"
@@ -330,6 +347,13 @@ export function ImportDialog({
           className="hidden"
           onChange={(event) => void selectFile(event, "archive")}
           ref={archiveInput}
+          type="file"
+        />
+        <input
+          accept=".csv,text/csv"
+          className="hidden"
+          onChange={(event) => void selectFile(event, "raindrop")}
+          ref={raindropInput}
           type="file"
         />
         {job?.status === "uploading" && !transporting ? (

--- a/packages/ui/src/components/settings/__tests__/ImportSection.contract.test.tsx
+++ b/packages/ui/src/components/settings/__tests__/ImportSection.contract.test.tsx
@@ -39,19 +39,21 @@ const { ImportSection } = await import("../ImportSection");
 describe("ImportSection", () => {
   test("keeps settings compact with one Import row and no open dialog", () => {
     const markup = renderToStaticMarkup(<ImportSection />);
-    expect(markup.match(/>Import</g)).toHaveLength(2);
+    expect(markup.match(/>Import</g)).toHaveLength(1);
     expect(markup).not.toContain("Import Bookmarks");
     expect(markup).not.toContain("Import Teak Archive");
+    expect(markup).not.toContain("Import from Raindrop");
   });
 });
 
 describe("ImportDialog", () => {
-  test("renders both backend import modes", () => {
+  test("renders all backend import modes", () => {
     const markup = renderToStaticMarkup(
       <ImportDialog onOpenChange={mock()} open={true} />
     );
     expect(markup).toContain("Import Bookmarks");
     expect(markup).toContain("Import Teak Archive");
+    expect(markup).toContain("Import from Raindrop");
     expect(markup).toContain("Teak handles the import in the background");
   });
 


### PR DESCRIPTION
## Summary

Adds a **Raindrop** import option alongside the existing bookmarks and Teak archive imports. Raindrop CSV exports are parsed into the shared bookmark item shape so they reuse the same downstream normalization, dedupe, and indexing pipeline as the HTML bookmark importer.

## Changes

- New dependency-free RFC-4180 CSV parser plus a Raindrop mapper that maps `url`, `title`, `note`, `tags`, `folder`, `created`, and `favorite` into link cards. Folder nesting becomes tags (matching the bookmark importer); unsafe URLs are rejected per-row without dropping the next valid row.
- Refactored `runImport` to share an `indexParsedBookmarks` helper across the bookmark and Raindrop modes.
- Upload validation for the new mode: `.csv` extension, 20 MiB cap, `text/csv` content type.
- Extended the schema import-mode validator and added the Raindrop entry to the import dialog.
- Tests for the parser (CSV edge cases: quoted commas, unix/ISO timestamps, BOM, blank rows, missing url column) and the dialog contract.

## Testing

- `bun run test` — all suites pass
- `bun run typecheck` — pass
- `bun run lint` — pass

## Docs

- Adds a public changelog entry (`apps/docs/src/content/changelog/2026-06-30.mdx`) describing the user-facing Raindrop import.
