### PR TITLE
fix(mcp,oauth): harden MCP/API OAuth endpoints and cross-origin sign-in

### DIFF
--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -46,6 +46,37 @@ describe("apps/api proxy", () => {
     expect(payload.mcp.endpoint).toBe("https://api.teakvault.com/mcp");
   });
 
+  test("answers REST CORS preflight before proxying to Convex", async () => {
+    const response = await app.request("/v1/cards", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://app.example",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "authorization,content-type",
+      },
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("Access-Control-Allow-Methods")).toContain(
+      "POST"
+    );
+    expect(response.headers.get("Access-Control-Allow-Headers")).toContain(
+      "Authorization"
+    );
+  });
+
+  test("answers REST CORS preflight for nested card routes", async () => {
+    const response = await app.request("/v1/cards/card_1/favorite", {
+      method: "OPTIONS",
+    });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Methods")).toContain(
+      "PATCH"
+    );
+  });
+
   test("fails fast when CONVEX_HTTP_BASE_URL is missing", async () => {
     process.env.CONVEX_HTTP_BASE_URL = "";
 

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -77,6 +77,38 @@ describe("apps/api proxy", () => {
     );
   });
 
+  test("sets CORS headers on actual (non-preflight) v1 responses", async () => {
+    const response = await app.request("/v1", {
+      headers: { Origin: "https://app.example" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+
+  test("sets CORS headers on proxied card responses", async () => {
+    process.env.CONVEX_HTTP_BASE_URL = "https://example.convex.site";
+
+    globalThis.fetch = mock(
+      () =>
+        new Response(JSON.stringify({ items: [], total: 0 }), {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        })
+    ) as unknown as typeof fetch;
+
+    const response = await app.request("/v1/cards/search?limit=10", {
+      headers: { Origin: "https://app.example" },
+      method: "GET",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("Access-Control-Expose-Headers")).toContain(
+      "RateLimit-Remaining"
+    );
+  });
+
   test("fails fast when CONVEX_HTTP_BASE_URL is missing", async () => {
     process.env.CONVEX_HTTP_BASE_URL = "";
 

--- a/apps/api/src/mcp.test.ts
+++ b/apps/api/src/mcp.test.ts
@@ -488,12 +488,18 @@ describe("apps/api MCP endpoint", () => {
       resource: string;
       authorization_servers: string[];
       bearer_methods_supported: string[];
+      scopes_supported: string[];
       resource_name: string;
     };
     expect(body.resource).toContain("/mcp");
     expect(Array.isArray(body.authorization_servers)).toBe(true);
     expect(body.authorization_servers).toHaveLength(1);
     expect(body.bearer_methods_supported).toEqual(["header"]);
+    expect(body.scopes_supported).toEqual([
+      "profile",
+      "email",
+      "offline_access",
+    ]);
     expect(body.resource_name).toBe("Teak");
   });
 

--- a/apps/api/src/routes/mcp.ts
+++ b/apps/api/src/routes/mcp.ts
@@ -19,7 +19,7 @@ const PROD_PUBLIC_API_URL = "https://api.teakvault.com";
 const PROD_AUTH_ISSUER_URL = "https://app.teakvault.com";
 const DEFAULT_DEV_APP_URL = "http://app.teak.localhost:1355";
 
-const OAUTH_SCOPES_SUPPORTED = ["openid", "profile", "email", "offline_access"];
+const OAUTH_SCOPES_SUPPORTED = ["profile", "email", "offline_access"];
 
 const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",

--- a/apps/api/src/routes/rest.ts
+++ b/apps/api/src/routes/rest.ts
@@ -9,6 +9,19 @@ import {
   V1_ENDPOINTS,
 } from "../shared/v1.js";
 
+const REST_CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "Content-Type, Authorization, Idempotency-Key, X-Request-Id",
+  "Access-Control-Expose-Headers":
+    "X-Request-Id, Idempotency-Key, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
+  "Access-Control-Max-Age": "86400",
+};
+
+const corsPreflight = (): Response =>
+  new Response(null, { status: 204, headers: REST_CORS_HEADERS });
+
 export const registerRestRoutes = (app: Hono): void => {
   app.get("/healthz", (c) =>
     c.json({
@@ -32,6 +45,9 @@ export const registerRestRoutes = (app: Hono): void => {
   );
 
   app.get("/openapi.json", (c) => c.json(openApiSpec));
+
+  app.options("/v1", corsPreflight);
+  app.options("/v1/*", corsPreflight);
 
   app.get("/v1/cards", (c) => proxyToConvex(c.req.raw));
   app.post("/v1/cards", (c) => proxyToConvex(c.req.raw));

--- a/apps/api/src/routes/rest.ts
+++ b/apps/api/src/routes/rest.ts
@@ -1,4 +1,5 @@
 import type { Hono } from "hono";
+import { cors } from "hono/cors";
 import { openApiSpec } from "../openapi.js";
 import { proxyToConvex } from "../shared/proxy.js";
 import {
@@ -9,20 +10,36 @@ import {
   V1_ENDPOINTS,
 } from "../shared/v1.js";
 
-const REST_CORS_HEADERS: Record<string, string> = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
-  "Access-Control-Allow-Headers":
-    "Content-Type, Authorization, Idempotency-Key, X-Request-Id",
-  "Access-Control-Expose-Headers":
-    "X-Request-Id, Idempotency-Key, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After",
-  "Access-Control-Max-Age": "86400",
-};
-
-const corsPreflight = (): Response =>
-  new Response(null, { status: 204, headers: REST_CORS_HEADERS });
+// Public REST clients can call the gateway from any origin (browser extensions,
+// third-party web apps). Applying the CORS middleware ahead of the route
+// handlers answers preflight `OPTIONS` requests AND attaches
+// `Access-Control-Allow-Origin`/expose headers to the actual proxied responses,
+// so cross-origin browsers can read the payload instead of only clearing the
+// preflight.
+const restCors = cors({
+  origin: "*",
+  allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+  allowHeaders: [
+    "Content-Type",
+    "Authorization",
+    "Idempotency-Key",
+    "X-Request-Id",
+  ],
+  exposeHeaders: [
+    "X-Request-Id",
+    "Idempotency-Key",
+    "RateLimit-Limit",
+    "RateLimit-Remaining",
+    "RateLimit-Reset",
+    "Retry-After",
+  ],
+  maxAge: 86_400,
+});
 
 export const registerRestRoutes = (app: Hono): void => {
+  app.use("/v1", restCors);
+  app.use("/v1/*", restCors);
+
   app.get("/healthz", (c) =>
     c.json({
       status: "ok",
@@ -45,9 +62,6 @@ export const registerRestRoutes = (app: Hono): void => {
   );
 
   app.get("/openapi.json", (c) => c.json(openApiSpec));
-
-  app.options("/v1", corsPreflight);
-  app.options("/v1/*", corsPreflight);
 
   app.get("/v1/cards", (c) => proxyToConvex(c.req.raw));
   app.post("/v1/cards", (c) => proxyToConvex(c.req.raw));

--- a/apps/desktop/src/lib/native-auth.ts
+++ b/apps/desktop/src/lib/native-auth.ts
@@ -10,7 +10,7 @@ const JWT_EXPIRY_SKEW_MS = 10_000;
 
 // Desktop OAuth client (matches the trusted client registered server-side).
 const DESKTOP_OAUTH_CLIENT_ID = "teak-desktop";
-const DESKTOP_OAUTH_SCOPE = "openid profile email offline_access";
+const DESKTOP_OAUTH_SCOPE = "profile email offline_access";
 const OAUTH_REDIRECT_HOST = "127.0.0.1";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
@@ -116,7 +116,7 @@ function timingSafeEqual(left: string, right: string): boolean {
   for (let index = 0; index < maxLength; index += 1) {
     const leftCode = left.charCodeAt(index) || 0;
     const rightCode = right.charCodeAt(index) || 0;
-    mismatch |= leftCode ^ rightCode;
+    mismatch += leftCode === rightCode ? 0 : 1;
   }
   return mismatch === 0;
 }

--- a/apps/docs/src/content/changelog/2026-07-03.mdx
+++ b/apps/docs/src/content/changelog/2026-07-03.mdx
@@ -5,3 +5,4 @@ date: "2026-07-03"
 
 - Install Teak for Safari from the Mac App Store to save the page you are viewing directly from the Safari toolbar.
 - API card lists now load reliably when a request scans more than one page of saved cards.
+- Browser sign-in for MCP and API clients now completes more reliably across apps that connect from another origin.

--- a/apps/raycast/src/lib/oauth.ts
+++ b/apps/raycast/src/lib/oauth.ts
@@ -26,7 +26,7 @@ const client = new OAuth.PKCEClient({
 export const teakOAuth = new OAuthService({
   client,
   clientId: "teak-raycast",
-  scope: "openid profile email offline_access",
+  scope: "profile email offline_access",
   authorizeUrl,
   tokenUrl,
   refreshTokenUrl: tokenUrl,

--- a/apps/web/src/__tests__/mcpOAuthEndpoints.test.ts
+++ b/apps/web/src/__tests__/mcpOAuthEndpoints.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  mcpJwks,
+  mcpOAuthPreflight,
+  mcpUserInfo,
+} from "@/lib/mcp-oauth-endpoints";
+import { proxyAuthorizationServerMetadata } from "@/lib/oauth-metadata-proxy";
+
+const originalFetch = globalThis.fetch;
+const originalConvexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+const originalConvexSiteUrl = process.env.NEXT_PUBLIC_CONVEX_SITE_URL;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  process.env.NEXT_PUBLIC_CONVEX_URL = originalConvexUrl;
+  process.env.NEXT_PUBLIC_CONVEX_SITE_URL = originalConvexSiteUrl;
+});
+
+describe("MCP OAuth metadata and endpoints", () => {
+  test("normalizes authorization-server metadata to supported OAuth scopes and live routes", async () => {
+    process.env.NEXT_PUBLIC_CONVEX_SITE_URL = "https://example.convex.site";
+    globalThis.fetch = mock(() =>
+      Response.json({
+        issuer: "https://app.teakvault.com",
+        authorization_endpoint:
+          "https://app.teakvault.com/api/auth/mcp/authorize",
+        token_endpoint: "https://app.teakvault.com/api/auth/mcp/token",
+        registration_endpoint:
+          "https://app.teakvault.com/api/auth/mcp/register",
+        userinfo_endpoint: "https://app.teakvault.com/api/auth/mcp/userinfo",
+        jwks_uri: "https://app.teakvault.com/api/auth/mcp/jwks",
+        scopes_supported: ["openid", "profile", "email", "offline_access"],
+        id_token_signing_alg_values_supported: ["RS256"],
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code", "refresh_token"],
+        token_endpoint_auth_methods_supported: ["none"],
+        code_challenge_methods_supported: ["S256"],
+      })
+    ) as unknown as typeof fetch;
+
+    const response = await proxyAuthorizationServerMetadata();
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.scopes_supported).toEqual([
+      "profile",
+      "email",
+      "offline_access",
+    ]);
+    expect(body.userinfo_endpoint).toBe(
+      "https://app.teakvault.com/api/auth/mcp/userinfo"
+    );
+    expect(body.jwks_uri).toBe("https://app.teakvault.com/api/auth/mcp/jwks");
+    expect(body).not.toHaveProperty("id_token_signing_alg_values_supported");
+  });
+
+  test("serves MCP userinfo from a valid bearer token", async () => {
+    process.env.NEXT_PUBLIC_CONVEX_URL = "https://example.convex.cloud";
+    globalThis.fetch = mock((input: RequestInfo | URL) => {
+      expect(String(input)).toBe("https://example.convex.cloud/api/query");
+      return Response.json({
+        status: "success",
+        value: {
+          sub: "user_1",
+          email: "hello@example.com",
+          email_verified: true,
+          name: "Ada Lovelace",
+        },
+      });
+    }) as unknown as typeof fetch;
+
+    const response = await mcpUserInfo(
+      new Request("https://app.teakvault.com/api/auth/mcp/userinfo", {
+        headers: { Authorization: `Bearer ${"a".repeat(32)}` },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      sub: "user_1",
+      email: "hello@example.com",
+      email_verified: true,
+      name: "Ada Lovelace",
+    });
+  });
+
+  test("rejects MCP userinfo without a bearer token", async () => {
+    const response = await mcpUserInfo(
+      new Request("https://app.teakvault.com/api/auth/mcp/userinfo")
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toBe("Bearer");
+  });
+
+  test("serves MCP JWKS from the Convex auth JWKS source", async () => {
+    process.env.NEXT_PUBLIC_CONVEX_SITE_URL = "https://example.convex.site/";
+    globalThis.fetch = mock((input: RequestInfo | URL) => {
+      expect(String(input)).toBe(
+        "https://example.convex.site/api/auth/convex/jwks"
+      );
+      return Response.json({ keys: [{ kid: "key_1" }] });
+    }) as unknown as typeof fetch;
+
+    const response = await mcpJwks();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ keys: [{ kid: "key_1" }] });
+  });
+
+  test("answers OAuth endpoint preflight with CORS", () => {
+    const response = mcpOAuthPreflight();
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("Access-Control-Allow-Methods")).toContain(
+      "POST"
+    );
+  });
+});

--- a/apps/web/src/app/api/auth/mcp/jwks/route.ts
+++ b/apps/web/src/app/api/auth/mcp/jwks/route.ts
@@ -1,0 +1,11 @@
+import { mcpJwks, mcpOAuthPreflight } from "@/lib/mcp-oauth-endpoints";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return mcpJwks();
+}
+
+export function OPTIONS() {
+  return mcpOAuthPreflight();
+}

--- a/apps/web/src/app/api/auth/mcp/userinfo/route.ts
+++ b/apps/web/src/app/api/auth/mcp/userinfo/route.ts
@@ -1,0 +1,15 @@
+import { mcpOAuthPreflight, mcpUserInfo } from "@/lib/mcp-oauth-endpoints";
+
+export const dynamic = "force-dynamic";
+
+export function GET(request: Request) {
+  return mcpUserInfo(request);
+}
+
+export function POST(request: Request) {
+  return mcpUserInfo(request);
+}
+
+export function OPTIONS() {
+  return mcpOAuthPreflight();
+}

--- a/apps/web/src/lib/mcp-oauth-endpoints.ts
+++ b/apps/web/src/lib/mcp-oauth-endpoints.ts
@@ -1,0 +1,132 @@
+import { ConvexHttpClient } from "convex/browser";
+import { makeFunctionReference } from "convex/server";
+
+const CORS_HEADERS: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Max-Age": "86400",
+};
+
+interface UserInfo {
+  email?: string;
+  email_verified?: boolean;
+  name?: string;
+  sub: string;
+}
+
+const getOAuthUserInfo = makeFunctionReference<
+  "query",
+  { token: string },
+  UserInfo | null
+>("oauthTokens:getOAuthUserInfo");
+
+const getConvexUrl = (): string => {
+  const url = process.env.NEXT_PUBLIC_CONVEX_URL;
+  if (!url) {
+    throw new Error("Missing NEXT_PUBLIC_CONVEX_URL environment variable");
+  }
+  return url;
+};
+
+const getConvexSiteUrl = (): string => {
+  const url = process.env.NEXT_PUBLIC_CONVEX_SITE_URL;
+  if (!url) {
+    throw new Error("Missing NEXT_PUBLIC_CONVEX_SITE_URL environment variable");
+  }
+  return url.replace(/\/$/, "");
+};
+
+const parseBearerToken = (request: Request): string | null => {
+  const authorization = request.headers.get("authorization");
+  if (!authorization) {
+    return null;
+  }
+
+  const [scheme, token] = authorization.trim().split(/\s+/, 2);
+  if (!(scheme && token) || scheme.toLowerCase() !== "bearer") {
+    return null;
+  }
+
+  return token.trim() || null;
+};
+
+const jsonResponse = (
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {}
+): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      ...CORS_HEADERS,
+      ...headers,
+    },
+  });
+
+const unauthorized = (): Response =>
+  jsonResponse(
+    401,
+    {
+      error: "invalid_token",
+      error_description: "Missing, invalid, or expired access token",
+    },
+    { "WWW-Authenticate": "Bearer" }
+  );
+
+const readToken = async (request: Request): Promise<string | null> => {
+  const headerToken = parseBearerToken(request);
+  if (headerToken) {
+    return headerToken;
+  }
+
+  if (request.method !== "POST") {
+    return null;
+  }
+
+  const contentType = request.headers.get("content-type")?.toLowerCase() ?? "";
+  if (!contentType.includes("application/x-www-form-urlencoded")) {
+    return null;
+  }
+
+  const form = new URLSearchParams(await request.text());
+  return form.get("access_token")?.trim() || null;
+};
+
+export async function mcpUserInfo(request: Request): Promise<Response> {
+  const token = await readToken(request);
+  if (!token) {
+    return unauthorized();
+  }
+
+  const client = new ConvexHttpClient(getConvexUrl());
+  const userInfo = await client.query(getOAuthUserInfo, { token });
+  if (!userInfo) {
+    return unauthorized();
+  }
+
+  return jsonResponse(200, userInfo, { "Cache-Control": "no-store" });
+}
+
+export async function mcpJwks(): Promise<Response> {
+  const response = await fetch(`${getConvexSiteUrl()}/api/auth/convex/jwks`, {
+    headers: { Accept: "application/json" },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    return jsonResponse(502, {
+      error: "server_error",
+      error_description: "JWKS is unavailable",
+    });
+  }
+
+  return jsonResponse(200, await response.json(), {
+    "Cache-Control": "no-store",
+  });
+}
+
+export function mcpOAuthPreflight(): Response {
+  return new Response(null, { status: 204, headers: CORS_HEADERS });
+}

--- a/apps/web/src/lib/oauth-metadata-proxy.ts
+++ b/apps/web/src/lib/oauth-metadata-proxy.ts
@@ -1,9 +1,9 @@
 // RFC 8414 requires the authorization-server metadata to be reachable at the
-// issuer root (https://app.teakvault.com/.well-known/...). Better Auth's `mcp`
-// plugin serves that document from the Convex deployment under
-// `/api/auth/.well-known/oauth-authorization-server`, so these root routes are
-// thin same-origin proxies. The metadata already advertises the web-origin
-// endpoints (`.../api/auth/mcp/*`), so no rewriting is needed.
+// issuer root (https://app.teakvault.com/.well-known/...). Better Auth's legacy
+// MCP plugin serves that document from the Convex deployment under
+// `/api/auth/.well-known/oauth-authorization-server`. Normalize it here so the
+// public document only advertises endpoints and scopes this deployment actually
+// supports for the opaque-token MCP/API flow.
 
 const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
@@ -16,6 +16,7 @@ const CORS_HEADERS: Record<string, string> = {
 // `/.well-known/openid-configuration` (OIDC Discovery) resolve to the same
 // authorization-server document; the plugin only exposes the former upstream.
 const UPSTREAM_PATH = "/api/auth/.well-known/oauth-authorization-server";
+const PUBLIC_SCOPES = ["profile", "email", "offline_access"] as const;
 
 const getConvexSiteUrl = (): string => {
   const url = process.env.NEXT_PUBLIC_CONVEX_SITE_URL;
@@ -38,6 +39,58 @@ const jsonResponse = (
       ...headers,
     },
   });
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === "object" && !Array.isArray(value));
+
+const stringArray = (value: unknown): string[] | undefined =>
+  Array.isArray(value) && value.every((item) => typeof item === "string")
+    ? value
+    : undefined;
+
+const normalizeAuthorizationServerMetadata = (
+  metadata: unknown
+): Record<string, unknown> | null => {
+  if (!isRecord(metadata) || typeof metadata.issuer !== "string") {
+    return null;
+  }
+
+  const issuer = metadata.issuer.replace(/\/$/, "");
+  const normalized: Record<string, unknown> = {
+    issuer,
+    authorization_endpoint:
+      typeof metadata.authorization_endpoint === "string"
+        ? metadata.authorization_endpoint
+        : `${issuer}/api/auth/mcp/authorize`,
+    token_endpoint:
+      typeof metadata.token_endpoint === "string"
+        ? metadata.token_endpoint
+        : `${issuer}/api/auth/mcp/token`,
+    registration_endpoint:
+      typeof metadata.registration_endpoint === "string"
+        ? metadata.registration_endpoint
+        : `${issuer}/api/auth/mcp/register`,
+    userinfo_endpoint: `${issuer}/api/auth/mcp/userinfo`,
+    jwks_uri: `${issuer}/api/auth/mcp/jwks`,
+    scopes_supported: PUBLIC_SCOPES,
+    bearer_methods_supported: ["header"],
+  };
+
+  for (const field of [
+    "response_types_supported",
+    "response_modes_supported",
+    "grant_types_supported",
+    "token_endpoint_auth_methods_supported",
+    "code_challenge_methods_supported",
+  ]) {
+    const value = stringArray(metadata[field]);
+    if (value) {
+      normalized[field] = value;
+    }
+  }
+
+  return normalized;
+};
 
 export async function proxyAuthorizationServerMetadata(): Promise<Response> {
   let upstream: Response;
@@ -70,7 +123,15 @@ export async function proxyAuthorizationServerMetadata(): Promise<Response> {
     });
   }
 
-  return jsonResponse(200, metadata);
+  const normalized = normalizeAuthorizationServerMetadata(metadata);
+  if (!normalized) {
+    return jsonResponse(502, {
+      error: "server_error",
+      error_description: "Authorization server metadata is malformed",
+    });
+  }
+
+  return jsonResponse(200, normalized);
 }
 
 export function oauthMetadataPreflight(): Response {

--- a/packages/convex/__tests__/oauthTokens.test.ts
+++ b/packages/convex/__tests__/oauthTokens.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { describe, expect, mock, test } from "bun:test";
 import {
+  getOAuthUserInfo,
   isWellFormedOAuthToken,
   validateOAuthAccessToken,
 } from "../oauthTokens";
@@ -112,5 +113,57 @@ describe("validateOAuthAccessToken", () => {
     );
     expect(result).toBeNull();
     expect(runQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe("getOAuthUserInfo", () => {
+  const token = "b".repeat(32);
+
+  test("returns standard userinfo claims for a live token", async () => {
+    const runQuery = mock()
+      .mockResolvedValueOnce({
+        _id: "oauthAccessToken_1",
+        accessTokenExpiresAt: Date.now() + 60_000,
+        clientId: "teak-raycast",
+        userId: "user_1",
+      })
+      .mockResolvedValueOnce({
+        _id: "user_1",
+        email: "hello@example.com",
+        emailVerified: true,
+        name: "Ada Lovelace",
+      });
+
+    const result = await runHandler(getOAuthUserInfo, { runQuery }, { token });
+
+    expect(result).toEqual({
+      sub: "user_1",
+      email: "hello@example.com",
+      email_verified: true,
+      name: "Ada Lovelace",
+    });
+  });
+
+  test("returns null for expired or malformed tokens", async () => {
+    const expiredQuery = mock().mockResolvedValueOnce({
+      _id: "oauthAccessToken_1",
+      accessTokenExpiresAt: Date.now() - 1,
+      clientId: "teak-raycast",
+      userId: "user_1",
+    });
+
+    expect(
+      await runHandler(getOAuthUserInfo, { runQuery: expiredQuery }, { token })
+    ).toBeNull();
+
+    const malformedQuery = mock();
+    expect(
+      await runHandler(
+        getOAuthUserInfo,
+        { runQuery: malformedQuery },
+        { token: "short" }
+      )
+    ).toBeNull();
+    expect(malformedQuery).not.toHaveBeenCalled();
   });
 });

--- a/packages/convex/oauthTokens.ts
+++ b/packages/convex/oauthTokens.ts
@@ -1,6 +1,11 @@
 import { v } from "convex/values";
 import { components } from "./_generated/api";
-import { internalMutation, type MutationCtx } from "./_generated/server";
+import {
+  internalMutation,
+  type MutationCtx,
+  type QueryCtx,
+  query,
+} from "./_generated/server";
 
 // Better Auth's `mcp`/oidc authorization server mints opaque access and refresh
 // tokens with `generateRandomString(32, ...)`. Today the mcp plugin uses the
@@ -38,6 +43,16 @@ const validatedOAuthTokenValidator = v.union(
   v.null()
 );
 
+const oauthUserInfoValidator = v.union(
+  v.object({
+    email: v.optional(v.string()),
+    email_verified: v.optional(v.boolean()),
+    name: v.optional(v.string()),
+    sub: v.string(),
+  }),
+  v.null()
+);
+
 // The Convex adapter stores dates as numbers, so the raw component document
 // exposes `accessTokenExpiresAt` as a number. Type the fields we read defensively.
 interface OAuthAccessTokenRecord {
@@ -47,8 +62,15 @@ interface OAuthAccessTokenRecord {
   userId?: string | null;
 }
 
+interface AuthUserRecord {
+  _id: string;
+  email?: string | null;
+  emailVerified?: boolean | null;
+  name?: string | null;
+}
+
 const findOAuthAccessToken = (
-  ctx: MutationCtx,
+  ctx: MutationCtx | QueryCtx,
   accessToken: string
 ): Promise<OAuthAccessTokenRecord | null> =>
   ctx.runQuery(components.betterAuth.adapter.findOne, {
@@ -58,14 +80,20 @@ const findOAuthAccessToken = (
     ],
   }) as Promise<OAuthAccessTokenRecord | null>;
 
+const findAuthUser = (
+  ctx: MutationCtx | QueryCtx,
+  userId: string
+): Promise<AuthUserRecord | null> =>
+  ctx.runQuery(components.betterAuth.adapter.findOne, {
+    model: "user",
+    where: [{ field: "_id", operator: "eq", value: userId }],
+  }) as Promise<AuthUserRecord | null>;
+
 const userExists = async (
   ctx: MutationCtx,
   userId: string
 ): Promise<boolean> => {
-  const user = await ctx.runQuery(components.betterAuth.adapter.findOne, {
-    model: "user",
-    where: [{ field: "_id", operator: "eq", value: userId }],
-  });
+  const user = await findAuthUser(ctx, userId);
   return Boolean(user);
 };
 
@@ -116,6 +144,46 @@ export const validateOAuthAccessToken = internalMutation({
       rateLimitKey: `oauth:${clientId}:${userId}`,
       source: "oauth" as const,
       userId,
+    };
+  },
+});
+
+export const getOAuthUserInfo = query({
+  args: { token: v.string() },
+  returns: oauthUserInfoValidator,
+  handler: async (ctx, args) => {
+    const token = args.token.trim();
+    if (!isWellFormedOAuthToken(token)) {
+      return null;
+    }
+
+    const record = await findOAuthAccessToken(ctx, token);
+    if (!record) {
+      return null;
+    }
+
+    const expiresAt = record.accessTokenExpiresAt;
+    if (typeof expiresAt !== "number" || expiresAt <= Date.now()) {
+      return null;
+    }
+
+    const userId = record.userId;
+    if (typeof userId !== "string" || !userId) {
+      return null;
+    }
+
+    const user = await findAuthUser(ctx, userId);
+    if (!user) {
+      return null;
+    }
+
+    return {
+      sub: userId,
+      ...(typeof user.email === "string" ? { email: user.email } : {}),
+      ...(typeof user.emailVerified === "boolean"
+        ? { email_verified: user.emailVerified }
+        : {}),
+      ...(typeof user.name === "string" ? { name: user.name } : {}),
     };
   },
 });


### PR DESCRIPTION
Hardens the MCP/API OAuth surface so browser-based sign-in from external origins (Raycast, desktop, MCP clients) completes reliably, and published metadata only advertises supported scopes/endpoints. Changes: - Normalize authorization-server metadata to advertise only supported scopes (profile, email, offline_access) and live MCP endpoints; return 502 on malformed upstream metadata. - Add web MCP endpoints: /api/auth/mcp/userinfo and /api/auth/mcp/jwks, backed by a new oauthTokens:getOAuthUserInfo Convex query, with CORS preflight. - Add REST CORS preflight for /v1 and /v1/* before proxying to Convex. - Drop unused openid scope from desktop and Raycast OAuth clients. - Fix desktop timing-safe comparison accumulation. Testing: bun run test passes; typecheck/lint/build pass. Added tests for web MCP endpoints, API CORS preflight, and Convex userinfo. Changelog updated.