### PR TITLE
Fix release workflow dispatch

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -88,6 +88,4 @@ jobs:
       - name: Publish to npm
         if: steps.check.outputs.should_publish == 'true'
         working-directory: apps/cli
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 concurrency:
   group: desktop-release-${{ github.ref }}

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 concurrency:
   group: extension-release-${{ github.ref }}

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   tag-version:
@@ -57,13 +58,28 @@ jobs:
           NODE
 
       - name: Create version tag
+        id: tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ steps.version.outputs.tag }}
         run: |
           if git rev-parse "$TAG_NAME" >/dev/null 2>&1 || gh release view "$TAG_NAME" >/dev/null 2>&1; then
             echo "$TAG_NAME already exists."
+            echo "created=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git tag "$TAG_NAME"
           git push origin "$TAG_NAME"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch release workflows
+        if: steps.tag.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh workflow run cli-release.yml --ref "$TAG_NAME"
+          gh workflow run desktop-release.yml --ref "$TAG_NAME"
+          gh workflow run extension-release.yml --ref "$TAG_NAME"
+          gh workflow run safari-extension-release.yml --ref "$TAG_NAME" -f "version=${VERSION}"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/api",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak-cli",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "description": "Command line client for Teak.",
   "type": "module",
   "bin": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@teak/desktop",
   "productName": "Teak",
   "private": true,
-  "version": "1.0.48",
+  "version": "1.0.49",
   "type": "module",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/docs",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "scripts": {
     "build": "astro build",
     "dev": "PORTLESS_PORT=1355 portless docs.teak astro dev",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teak/extension",
   "description": "Teak - Your Personal Knowledge Hub. Save, organize, and rediscover web content, text selections, and ideas effortlessly.",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "author": "Praveen Juge (hi@praveenjuge.com)",
   "homepage": "https://teakvault.com",
   "type": "module",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/mobile",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "main": "expo-router/entry",
   "scripts": {
     "build": "expo export --platform web --clear",

--- a/apps/raycast/package.json
+++ b/apps/raycast/package.json
@@ -1,7 +1,7 @@
 {
   "name": "teak-raycast",
   "title": "Teak",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "private": true,
   "license": "MIT",
   "description": "Save ideas fast, search your Teak cards, and access favorites directly from Raycast.",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/web",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/api": {
       "name": "@teak/api",
-      "version": "1.0.48",
+      "version": "1.0.49",
       "dependencies": {
         "@hono/mcp": "^0.2.5",
         "@hono/node-server": "^2.0.2",
@@ -35,7 +35,7 @@
     },
     "apps/cli": {
       "name": "teak-cli",
-      "version": "1.0.48",
+      "version": "1.0.49",
       "bin": {
         "teak": "./dist/index.js",
       },
@@ -49,7 +49,7 @@
     },
     "apps/desktop": {
       "name": "@teak/desktop",
-      "version": "1.0.48",
+      "version": "1.0.49",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.0",
         "@teak/convex": "workspace:*",
@@ -81,7 +81,7 @@
     },
     "apps/docs": {
       "name": "@teak/docs",
-      "version": "1.0.48",
+      "version": "1.0.49",
       "dependencies": {
         "@astrojs/check": "^0.9.9",
         "@astrojs/sitemap": "^3.7.3",
@@ -98,7 +98,7 @@
     },
     "apps/extension": {
       "name": "@teak/extension",
-      "version": "1.0.48",
+      "version": "1.0.49",
       "dependencies": {
         "@convex-dev/better-auth": "0.12.2",
         "@tailwindcss/vite": "^4.3.0",
@@ -121,7 +121,7 @@
     },
     "apps/mobile": {
       "name": "@teak/mobile",
-      "version": "1.0.48",
+      "version": "1.0.49",
       "dependencies": {
         "@better-auth/expo": "1.6.11",
         "@convex-dev/better-auth": "0.12.2",
@@ -174,7 +174,7 @@
     },
     "apps/raycast": {
       "name": "teak-raycast",
-      "version": "1.0.48",
+      "version": "1.0.49",
       "dependencies": {
         "@raycast/api": "^1.104.19",
         "@raycast/utils": "^2.2.7",
@@ -188,7 +188,7 @@
     },
     "apps/web": {
       "name": "@teak/web",
-      "version": "1.0.48",
+      "version": "1.0.49",
       "dependencies": {
         "@convex-dev/better-auth": "^0.12.2",
         "@polar-sh/checkout": "^0.2.1",
@@ -225,7 +225,7 @@
     },
     "packages/convex": {
       "name": "@teak/convex",
-      "version": "1.0.48",
+      "version": "1.0.49",
       "dependencies": {
         "@ai-sdk/groq": "^3.0.39",
         "@aws-sdk/client-s3": "3.1069.0",
@@ -264,7 +264,7 @@
     },
     "packages/sdk": {
       "name": "@teak/sdk",
-      "version": "1.0.48",
+      "version": "1.0.49",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "typescript": "^6.0.3",
@@ -272,7 +272,7 @@
     },
     "packages/ui": {
       "name": "@teak/ui",
-      "version": "1.0.48",
+      "version": "1.0.49",
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "private": true,
   "packageManager": "bun@1.3.5",
   "workspaces": [

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/convex",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "type": "module",
   "exports": {
     ".": "./index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/sdk",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/ui",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "private": true,
   "exports": {
     "./logo": "./src/logo.tsx",


### PR DESCRIPTION
## Summary
- dispatch release workflows explicitly after the version tag job creates a tag
- allow desktop and extension release workflows to run via workflow_dispatch on the tag ref
- remove the empty npm token env so the CLI release uses npm trusted publishing
- bump package versions to 1.0.49 to exercise the corrected publish path

## Validation
- bun install --frozen-lockfile
- bun run test --filter=teak-cli
- bun run typecheck --filter=teak-cli
- bun run build:cli
- npm pack ./apps/cli --dry-run
- bun run pre-commit
- npm publish teak-cli@1.0.48 bootstrap
- npm trust github teak-cli --repo praveenjuge/teak --file cli-release.yml --allow-publish --yes