### PR TITLE
Read CLI version from package metadata

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/api",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak-cli",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "description": "Command line client for Teak.",
   "type": "module",
   "bin": {

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { formatCardLine, mimeFor, parseSort, typeForMime } from ".";
 import { resolveAddInput } from "./files";
+import { VERSION } from "./runtime";
 
 describe("teak cli formatting", () => {
   test("formats stable one-line cards", () => {
@@ -35,5 +36,10 @@ describe("teak cli formatting", () => {
   test("rejects invalid sort values", () => {
     expect(parseSort("oldest")).toBe("oldest");
     expect(() => parseSort("newestt")).toThrow("sort must be newest or oldest");
+  });
+
+  test("uses package version for CLI output", async () => {
+    const manifest = await Bun.file("package.json").json();
+    expect(VERSION).toBe(manifest.version);
   });
 });

--- a/apps/cli/src/runtime.ts
+++ b/apps/cli/src/runtime.ts
@@ -18,7 +18,18 @@ import {
 } from "@teak/sdk";
 import { InvalidArgumentError } from "commander";
 
-export const VERSION = "1.0.48";
+const readPackageVersion = () => {
+  try {
+    const manifest = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8")
+    ) as { version?: unknown };
+    return typeof manifest.version === "string" ? manifest.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+};
+
+export const VERSION = readPackageVersion();
 export const EXIT = { api: 1, auth: 3, notFound: 4, rateLimited: 5, usage: 2 };
 
 const DEFAULT_API_URL = "https://api.teakvault.com";

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@teak/desktop",
   "productName": "Teak",
   "private": true,
-  "version": "1.0.49",
+  "version": "1.0.50",
   "type": "module",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/docs",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "scripts": {
     "build": "astro build",
     "dev": "PORTLESS_PORT=1355 portless docs.teak astro dev",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teak/extension",
   "description": "Teak - Your Personal Knowledge Hub. Save, organize, and rediscover web content, text selections, and ideas effortlessly.",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "author": "Praveen Juge (hi@praveenjuge.com)",
   "homepage": "https://teakvault.com",
   "type": "module",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/mobile",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "main": "expo-router/entry",
   "scripts": {
     "build": "expo export --platform web --clear",

--- a/apps/raycast/package.json
+++ b/apps/raycast/package.json
@@ -1,7 +1,7 @@
 {
   "name": "teak-raycast",
   "title": "Teak",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "private": true,
   "license": "MIT",
   "description": "Save ideas fast, search your Teak cards, and access favorites directly from Raycast.",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/web",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/api": {
       "name": "@teak/api",
-      "version": "1.0.49",
+      "version": "1.0.50",
       "dependencies": {
         "@hono/mcp": "^0.2.5",
         "@hono/node-server": "^2.0.2",
@@ -35,7 +35,7 @@
     },
     "apps/cli": {
       "name": "teak-cli",
-      "version": "1.0.49",
+      "version": "1.0.50",
       "bin": {
         "teak": "./dist/index.js",
       },
@@ -49,7 +49,7 @@
     },
     "apps/desktop": {
       "name": "@teak/desktop",
-      "version": "1.0.49",
+      "version": "1.0.50",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.0",
         "@teak/convex": "workspace:*",
@@ -81,7 +81,7 @@
     },
     "apps/docs": {
       "name": "@teak/docs",
-      "version": "1.0.49",
+      "version": "1.0.50",
       "dependencies": {
         "@astrojs/check": "^0.9.9",
         "@astrojs/sitemap": "^3.7.3",
@@ -98,7 +98,7 @@
     },
     "apps/extension": {
       "name": "@teak/extension",
-      "version": "1.0.49",
+      "version": "1.0.50",
       "dependencies": {
         "@convex-dev/better-auth": "0.12.2",
         "@tailwindcss/vite": "^4.3.0",
@@ -121,7 +121,7 @@
     },
     "apps/mobile": {
       "name": "@teak/mobile",
-      "version": "1.0.49",
+      "version": "1.0.50",
       "dependencies": {
         "@better-auth/expo": "1.6.11",
         "@convex-dev/better-auth": "0.12.2",
@@ -174,7 +174,7 @@
     },
     "apps/raycast": {
       "name": "teak-raycast",
-      "version": "1.0.49",
+      "version": "1.0.50",
       "dependencies": {
         "@raycast/api": "^1.104.19",
         "@raycast/utils": "^2.2.7",
@@ -188,7 +188,7 @@
     },
     "apps/web": {
       "name": "@teak/web",
-      "version": "1.0.49",
+      "version": "1.0.50",
       "dependencies": {
         "@convex-dev/better-auth": "^0.12.2",
         "@polar-sh/checkout": "^0.2.1",
@@ -225,7 +225,7 @@
     },
     "packages/convex": {
       "name": "@teak/convex",
-      "version": "1.0.49",
+      "version": "1.0.50",
       "dependencies": {
         "@ai-sdk/groq": "^3.0.39",
         "@aws-sdk/client-s3": "3.1069.0",
@@ -264,7 +264,7 @@
     },
     "packages/sdk": {
       "name": "@teak/sdk",
-      "version": "1.0.49",
+      "version": "1.0.50",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "typescript": "^6.0.3",
@@ -272,7 +272,7 @@
     },
     "packages/ui": {
       "name": "@teak/ui",
-      "version": "1.0.49",
+      "version": "1.0.50",
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "private": true,
   "packageManager": "bun@1.3.5",
   "workspaces": [

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/convex",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "type": "module",
   "exports": {
     ".": "./index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/sdk",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/ui",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "private": true,
   "exports": {
     "./logo": "./src/logo.tsx",


### PR DESCRIPTION
## Summary
- derive the CLI version from package.json at runtime instead of a hardcoded constant
- add a test that catches package/binary version drift
- bump all package versions to 1.0.50 so the corrected binary publishes as a fresh npm version

## Validation
- bun install --frozen-lockfile
- bun run test --filter=teak-cli
- bun run typecheck --filter=teak-cli
- bun run build:cli
- node apps/cli/dist/index.js --version
- npm pack ./apps/cli --dry-run
- bun run pre-commit