### PR TITLE
Fix API production SDK import

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/api",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "private": true,
   "type": "module",
   "scripts": {
@@ -17,7 +17,6 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@sentry/node": "^10.53.1",
     "@teak/convex": "workspace:*",
-    "@teak/sdk": "workspace:*",
     "dotenv": "^17.4.2",
     "hono": "^4.12.19",
     "zod": "^4.4.3"

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -1,6 +1,16 @@
-import { CARD_SORTS, CARD_TYPES } from "@teak/sdk";
 import { resolveTeakDevApiUrl } from "./shared/devUrl.js";
 
+const CARD_TYPES = [
+  "text",
+  "link",
+  "image",
+  "video",
+  "audio",
+  "document",
+  "palette",
+  "quote",
+] as const;
+const CARD_SORTS = ["newest", "oldest"] as const;
 const apiKeySecurity = [{ bearerAuth: [] }];
 
 const cardProperties = {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak-cli",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "description": "Command line client for Teak.",
   "type": "module",
   "bin": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@teak/desktop",
   "productName": "Teak",
   "private": true,
-  "version": "1.0.50",
+  "version": "1.0.51",
   "type": "module",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/docs",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "scripts": {
     "build": "astro build",
     "dev": "PORTLESS_PORT=1355 portless docs.teak astro dev",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teak/extension",
   "description": "Teak - Your Personal Knowledge Hub. Save, organize, and rediscover web content, text selections, and ideas effortlessly.",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "author": "Praveen Juge (hi@praveenjuge.com)",
   "homepage": "https://teakvault.com",
   "type": "module",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/mobile",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "main": "expo-router/entry",
   "scripts": {
     "build": "expo export --platform web --clear",

--- a/apps/raycast/package.json
+++ b/apps/raycast/package.json
@@ -1,7 +1,7 @@
 {
   "name": "teak-raycast",
   "title": "Teak",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "private": true,
   "license": "MIT",
   "description": "Save ideas fast, search your Teak cards, and access favorites directly from Raycast.",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/web",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/bun.lock
+++ b/bun.lock
@@ -15,14 +15,13 @@
     },
     "apps/api": {
       "name": "@teak/api",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "dependencies": {
         "@hono/mcp": "^0.2.5",
         "@hono/node-server": "^2.0.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@sentry/node": "^10.53.1",
         "@teak/convex": "workspace:*",
-        "@teak/sdk": "workspace:*",
         "dotenv": "^17.4.2",
         "hono": "^4.12.19",
         "zod": "^4.4.3",
@@ -35,7 +34,7 @@
     },
     "apps/cli": {
       "name": "teak-cli",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "bin": {
         "teak": "./dist/index.js",
       },
@@ -49,7 +48,7 @@
     },
     "apps/desktop": {
       "name": "@teak/desktop",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.0",
         "@teak/convex": "workspace:*",
@@ -81,7 +80,7 @@
     },
     "apps/docs": {
       "name": "@teak/docs",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "dependencies": {
         "@astrojs/check": "^0.9.9",
         "@astrojs/sitemap": "^3.7.3",
@@ -98,7 +97,7 @@
     },
     "apps/extension": {
       "name": "@teak/extension",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "dependencies": {
         "@convex-dev/better-auth": "0.12.2",
         "@tailwindcss/vite": "^4.3.0",
@@ -121,7 +120,7 @@
     },
     "apps/mobile": {
       "name": "@teak/mobile",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "dependencies": {
         "@better-auth/expo": "1.6.11",
         "@convex-dev/better-auth": "0.12.2",
@@ -174,7 +173,7 @@
     },
     "apps/raycast": {
       "name": "teak-raycast",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "dependencies": {
         "@raycast/api": "^1.104.19",
         "@raycast/utils": "^2.2.7",
@@ -188,7 +187,7 @@
     },
     "apps/web": {
       "name": "@teak/web",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "dependencies": {
         "@convex-dev/better-auth": "^0.12.2",
         "@polar-sh/checkout": "^0.2.1",
@@ -225,7 +224,7 @@
     },
     "packages/convex": {
       "name": "@teak/convex",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "dependencies": {
         "@ai-sdk/groq": "^3.0.39",
         "@aws-sdk/client-s3": "3.1069.0",
@@ -264,7 +263,7 @@
     },
     "packages/sdk": {
       "name": "@teak/sdk",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "typescript": "^6.0.3",
@@ -272,7 +271,7 @@
     },
     "packages/ui": {
       "name": "@teak/ui",
-      "version": "1.0.50",
+      "version": "1.0.51",
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "private": true,
   "packageManager": "bun@1.3.5",
   "workspaces": [

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/convex",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "type": "module",
   "exports": {
     ".": "./index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/sdk",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/ui",
-  "version": "1.0.50",
+  "version": "1.0.51",
   "private": true,
   "exports": {
     "./logo": "./src/logo.tsx",


### PR DESCRIPTION
## Summary
- remove the API runtime import of @teak/sdk from the OpenAPI generator
- inline the OpenAPI card type/sort enums so Vercel functions do not resolve TS-only SDK source at runtime
- remove @teak/sdk from @teak/api dependencies
- bump all package versions to 1.0.51 for a fresh release/deploy

## Validation
- bun install
- bun run test --filter=@teak/api
- bun run typecheck --filter=@teak/api
- bun run build --filter=@teak/api
- bun run build --filter=@teak/web
- bun run typecheck --filter=@teak/web
- bun run pre-commit
- Vercel logs identified production 500 as ERR_MODULE_NOT_FOUND for @teak/sdk/src/index.ts