### PR TITLE
Fix CLI auth uploads and npm metadata

### DIFF
--- a/.agents/skills/teak/SKILL.md
+++ b/.agents/skills/teak/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: teak
+description: Use when an agent needs to save, search, retrieve, update, favorite, delete, or sync Teak cards through the Teak CLI, public API, MCP server, or TypeScript SDK.
+---
+
+# Teak Agent Skill
+
+Teak is a personal knowledge hub for saving and rediscovering ideas, links, files, notes, quotes, palettes, and references. Use this skill when a user asks an agent to work with their Teak library or wire Teak into another workflow.
+
+## Choose The Right Interface
+
+- Prefer the CLI for local agent workflows, one-off automation, shell scripts, and user-facing commands.
+- Prefer MCP when the current agent can call MCP tools directly and should expose Teak operations as tool calls.
+- Prefer the API for integrations from non-TypeScript runtimes, backend services, or HTTP clients.
+- Prefer the TypeScript SDK for Node.js or TypeScript apps that want typed helpers around the public API.
+
+## Install And Authenticate
+
+Install the CLI:
+
+```bash
+npm install -g teak-cli
+```
+
+Sign in with browser OAuth:
+
+```bash
+teak login
+teak auth status
+```
+
+For CI, servers, or headless agents, use an API key instead of browser login:
+
+```bash
+export TEAK_API_KEY="teakapi_..."
+teak --json cards list --limit 10
+```
+
+Never print, persist, or commit Teak API keys or OAuth tokens. Prefer environment variables or the user's secret manager. If a command fails with authentication errors, ask the user to run `teak login` or provide an API key through a secure channel.
+
+## CLI Workflows
+
+Save text:
+
+```bash
+teak add "Interesting design note" --tags design,research
+```
+
+Save a link:
+
+```bash
+teak add --url https://example.com --tags reference
+```
+
+Save a file:
+
+```bash
+teak add --file ./screenshot.png --notes "Homepage inspiration" --tags design
+```
+
+Search and inspect cards:
+
+```bash
+teak search "homepage inspiration" --limit 10
+teak cards get <card-id>
+```
+
+Update, favorite, and delete:
+
+```bash
+teak cards update <card-id> --tags design,approved
+teak fav <card-id>
+teak rm <card-id>
+```
+
+Use `--json` for reliable parsing:
+
+```bash
+teak --json cards list --type link --limit 20
+teak --json cards changes --since 0 --limit 50
+teak --json tags
+```
+
+For destructive operations, confirm intent before deleting cards unless the user explicitly asked for cleanup. Deleting via the CLI moves cards to trash.
+
+## Public API
+
+Base URL:
+
+```text
+https://api.teakvault.com
+```
+
+Common endpoints:
+
+```text
+GET    /v1
+GET    /v1/cards
+POST   /v1/cards
+POST   /v1/uploads
+GET    /v1/cards/search
+GET    /v1/cards/favorites
+GET    /v1/cards/:cardId
+PATCH  /v1/cards/:cardId
+DELETE /v1/cards/:cardId
+PATCH  /v1/cards/:cardId/favorite
+GET    /v1/cards/changes
+GET    /v1/tags
+```
+
+Authenticate with:
+
+```text
+Authorization: Bearer <OAuth access token or teakapi_ API key>
+```
+
+Use idempotency keys for retryable create requests from automation:
+
+```bash
+curl https://api.teakvault.com/v1/cards \
+  -H "Authorization: Bearer $TEAK_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: unique-workflow-step-id" \
+  -d '{"content":"Saved by an agent","tags":["agent"]}'
+```
+
+For uploads, first create an upload, PUT the bytes to the returned `uploadUrl`, then create a card with `fileKey`, `fileName`, `fileSize`, `mimeType`, and `cardType`.
+
+## MCP
+
+MCP endpoint:
+
+```text
+https://api.teakvault.com/mcp
+```
+
+OAuth metadata:
+
+```text
+https://app.teakvault.com/.well-known/oauth-authorization-server
+https://api.teakvault.com/.well-known/oauth-protected-resource
+```
+
+Use MCP for agents that can connect to streamable HTTP MCP servers. The server supports OAuth bearer tokens and Teak API keys. Confirm the tool list in the client before assuming a tool name; typical operations map to creating, searching, listing, updating, favoriting, and deleting cards.
+
+## TypeScript SDK
+
+Install the SDK package from the Teak workspace or published package when available, then create a client:
+
+```ts
+import { createTeakClient, staticTokenProvider } from "@teak/sdk";
+
+const teak = createTeakClient({
+  baseUrl: "https://api.teakvault.com",
+  tokenProvider: staticTokenProvider(process.env.TEAK_API_KEY!),
+});
+
+const created = await teak.cards.create({
+  content: "Saved from an agent workflow",
+  source: "agent",
+  tags: ["agent"],
+});
+```
+
+Use the SDK for paginated listing, search, favorite toggles, direct uploads, and error handling. Catch SDK errors by `code` and surface actionable messages to the user.
+
+## Agent Operating Rules
+
+- Validate user-provided file paths and URLs before passing them to Teak.
+- Do not upload files larger than 20 MB.
+- Treat link, file, and note content as user data; do not summarize private content in logs unless the user asked.
+- Prefer JSON output for automation and parse fields such as `cardId`, `pageInfo.nextCursor`, and `deletedIds`.
+- Clean up temporary test cards after smoke tests.
+- When testing production, create cards with a unique marker and delete them before finishing.
+- If an operation is ambiguous, ask whether the user wants a new card, an update to an existing card, or a search.
+- After changing Teak API, MCP, SDK, or CLI behavior, update the corresponding docs and run real local and production smoke tests.
+
+## Useful Links
+
+- CLI docs: https://teakvault.com/docs/cli
+- API docs: https://teakvault.com/docs/api
+- MCP docs: https://teakvault.com/docs/mcp
+- Apps: https://teakvault.com/apps

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,9 +63,13 @@ teak/
 │   ├── extension/   # Chrome extension (Wxt)
 │   ├── safari-extension/ # Native macOS Safari extension app
 │   ├── raycast/     # Raycast extension
+│   ├── cli/         # npm command line client
 │   └── docs/        # Documentation site (Astro + Starlight)
+├── .agents/
+│   └── skills/      # Agent Skills exposed through skills.sh-compatible repos
 ├── packages/
 │   ├── convex/      # Convex backend (functions, workflows, schema, shared utils)
+│   ├── sdk/         # Shared public API client for CLI and integrations
 │   └── ui/          # Shared UI package (components, hooks, screens, feedback)
 ├── turbo.json       # Turborepo pipeline config
 └── package.json     # Root package + workspaces
@@ -107,6 +111,8 @@ teak/
 - Any API contract change in `apps/api` or `packages/convex/http.ts` must update `apps/docs/src/content/docs/docs/api.mdx` in the same PR.
 - Any MCP endpoint change in `apps/api/src/routes/mcp.ts` must update `apps/docs/src/content/docs/docs/mcp.mdx` in the same PR.
 - Any Raycast command/auth change in `apps/raycast` must update `apps/docs/src/content/docs/docs/raycast.mdx` in the same PR.
+- Any CLI command/auth/publish change in `apps/cli` or `packages/sdk` must update `apps/docs/src/content/docs/docs/cli.mdx` when user-facing behavior changes.
+- Any public Agent Skill change in `.agents/skills` must update `apps/docs/src/content/docs/docs/skills.mdx` and `apps/docs/src/pages/apps.astro` when install or capability details change.
 
 ## Git Commit Rules
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Save inspiration in one click and find it in two seconds — no more lost bookma
 | 🧩 **Browser** | One-click saves while you browse | [Chrome →](https://chromewebstore.google.com/detail/teak/negnmfifahnnagnbnfppmlgfajngdpob) · [Safari →](https://apps.apple.com/us/app/teak-for-safari/id6770003409?mt=12) |
 | ⚡ **Raycast** | Save and search from your keyboard | [Install →](https://www.raycast.com/praveenjuge/teak-raycast) |
 | 🧰 **CLI** | Save, search, and manage cards from your terminal | `npm i -g teak-cli` |
+| 🤖 **Agent Skill** | Teach AI agents how to use Teak through CLI, API, MCP, and SDK workflows | `npx skills add praveenjuge/teak --skill teak` |
 | 🔌 **API & MCP** | Programmatic and AI client access | [API docs →](https://teakvault.com/docs/api) |
 
 ## Monorepo
@@ -40,6 +41,8 @@ teak/
 │   ├── raycast/    # Raycast extension
 │   ├── cli/        # npm command line client
 │   └── docs/       # Documentation site (Astro + Starlight)
+├── .agents/
+│   └── skills/     # Agent Skills published through skills.sh-compatible repos
 ├── packages/
 │   ├── convex/     # Convex backend
 │   ├── sdk/        # Shared API client

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/api",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,48 @@
+# Teak CLI
+
+Command-line client for [Teak](https://teakvault.com), the personal knowledge hub for saving and rediscovering ideas, links, files, notes, and references.
+
+## Install
+
+```bash
+npm install -g teak-cli
+```
+
+```bash
+teak --version
+```
+
+## Sign In
+
+```bash
+teak login
+```
+
+The CLI opens Teak in your browser and stores the resulting session securely in macOS Keychain when available. You can also use an API key:
+
+```bash
+teak --api-key teakapi_... cards list
+```
+
+## Common Commands
+
+```bash
+teak add "Design note from today's review" --tags design,research
+teak add --url https://example.com --tags reference
+teak add --file ./screenshot.png --notes "Homepage inspiration"
+teak search "homepage inspiration"
+teak cards list --type link --limit 20
+teak cards get <card-id>
+teak cards update <card-id> --tags design,approved
+teak fav <card-id>
+teak rm <card-id>
+teak tags
+```
+
+Use `--json` on any command for script-friendly output.
+
+## Docs
+
+- CLI guide: [teakvault.com/docs/cli](https://teakvault.com/docs/cli)
+- API docs: [teakvault.com/docs/api](https://teakvault.com/docs/api)
+- MCP docs: [teakvault.com/docs/mcp](https://teakvault.com/docs/mcp)

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,13 +1,24 @@
 {
   "name": "teak-cli",
-  "version": "1.0.51",
-  "description": "Command line client for Teak.",
+  "version": "1.0.52",
+  "description": "Command-line client for Teak, the personal knowledge hub for saving and rediscovering ideas.",
   "type": "module",
   "bin": {
     "teak": "./dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md"
+  ],
+  "keywords": [
+    "teak",
+    "cli",
+    "knowledge-base",
+    "bookmark-manager",
+    "notes",
+    "mcp",
+    "api-client",
+    "productivity"
   ],
   "engines": {
     "node": ">=20"
@@ -33,5 +44,10 @@
     "url": "git+https://github.com/praveenjuge/teak.git",
     "directory": "apps/cli"
   },
+  "homepage": "https://teakvault.com/docs/cli",
+  "bugs": {
+    "url": "https://github.com/praveenjuge/teak/issues"
+  },
+  "author": "Praveen Juge <hello@praveenjuge.com>",
   "license": "MIT"
 }

--- a/apps/cli/src/index.test.ts
+++ b/apps/cli/src/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { formatCardLine, mimeFor, parseSort, typeForMime } from ".";
 import { resolveAddInput } from "./files";
-import { VERSION } from "./runtime";
+import { CLI_OAUTH_SCOPE, VERSION, createAuthorizeUrl } from "./runtime";
 
 describe("teak cli formatting", () => {
   test("formats stable one-line cards", () => {
@@ -41,5 +41,20 @@ describe("teak cli formatting", () => {
   test("uses package version for CLI output", async () => {
     const manifest = await Bun.file("package.json").json();
     expect(VERSION).toBe(manifest.version);
+  });
+
+  test("requests refresh-capable OAuth scope during login", () => {
+    const url = createAuthorizeUrl(
+      { authUrl: "https://app.teakvault.com" },
+      {
+        codeChallenge: "challenge",
+        redirectUri: "http://127.0.0.1:14210/oauth/callback",
+        state: "state",
+      }
+    );
+
+    expect(url.searchParams.get("client_id")).toBe("teak-cli");
+    expect(url.searchParams.get("scope")).toBe(CLI_OAUTH_SCOPE);
+    expect(url.searchParams.get("scope")).toContain("offline_access");
   });
 });

--- a/apps/cli/src/runtime.ts
+++ b/apps/cli/src/runtime.ts
@@ -34,6 +34,7 @@ export const EXIT = { api: 1, auth: 3, notFound: 4, rateLimited: 5, usage: 2 };
 
 const DEFAULT_API_URL = "https://api.teakvault.com";
 const DEFAULT_AUTH_URL = "https://app.teakvault.com";
+export const CLI_OAUTH_SCOPE = "profile email offline_access";
 const SERVICE = "com.teakvault.cli";
 const ACCOUNT = "default";
 
@@ -282,6 +283,25 @@ const openBrowser = (url: string) => {
   spawn(command, args, { detached: true, stdio: "ignore" }).unref();
 };
 
+export const createAuthorizeUrl = (
+  options: ClientOptions,
+  params: {
+    codeChallenge: string;
+    redirectUri: string;
+    state: string;
+  }
+) => {
+  const authUrl = new URL(authorizeEndpoint(options));
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("client_id", "teak-cli");
+  authUrl.searchParams.set("redirect_uri", params.redirectUri);
+  authUrl.searchParams.set("code_challenge", params.codeChallenge);
+  authUrl.searchParams.set("code_challenge_method", "S256");
+  authUrl.searchParams.set("scope", CLI_OAUTH_SCOPE);
+  authUrl.searchParams.set("state", params.state);
+  return authUrl;
+};
+
 export const login = async (options: ClientOptions & { browser?: boolean }) => {
   const verifier = b64url(randomBytes(32));
   const state = b64url(randomBytes(24));
@@ -327,13 +347,11 @@ export const login = async (options: ClientOptions & { browser?: boolean }) => {
             }
           });
           server.listen(port, "127.0.0.1", () => {
-            const authUrl = new URL(authorizeEndpoint(options));
-            authUrl.searchParams.set("response_type", "code");
-            authUrl.searchParams.set("client_id", "teak-cli");
-            authUrl.searchParams.set("redirect_uri", redirectUri);
-            authUrl.searchParams.set("code_challenge", sha256(verifier));
-            authUrl.searchParams.set("code_challenge_method", "S256");
-            authUrl.searchParams.set("state", state);
+            const authUrl = createAuthorizeUrl(options, {
+              codeChallenge: sha256(verifier),
+              redirectUri,
+              state,
+            });
             process.stdout.write(`${authUrl.toString()}\n`);
             if (options.browser !== false) {
               openBrowser(authUrl.toString());

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@teak/desktop",
   "productName": "Teak",
   "private": true,
-  "version": "1.0.51",
+  "version": "1.0.52",
   "type": "module",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/apps/docs/astro.config.ts
+++ b/apps/docs/astro.config.ts
@@ -72,6 +72,7 @@ export default defineConfig({
             { label: "Browser Extension", slug: "docs/extension" },
             { label: "Raycast Extension", slug: "docs/raycast" },
             { label: "Command Line", slug: "docs/cli" },
+            { label: "Agent Skill", slug: "docs/skills" },
           ],
         },
         {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/docs",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "scripts": {
     "build": "astro build",
     "dev": "PORTLESS_PORT=1355 portless docs.teak astro dev",

--- a/apps/docs/src/components/AppsGrid.astro
+++ b/apps/docs/src/components/AppsGrid.astro
@@ -11,6 +11,7 @@ const DESKTOP_DOWNLOAD_URL =
 const API_DOCS_URL = "/docs/api";
 const MCP_DOCS_URL = "/docs/mcp";
 const CLI_DOCS_URL = "/docs/cli";
+const SKILLS_DOCS_URL = "/docs/skills";
 const RAYCAST_STORE_URL = "https://www.raycast.com/praveenjuge/teak-raycast";
 const RAYCAST_INSTALL_BUTTON_URL =
   "https://www.raycast.com/praveenjuge/teak-raycast/install_button@2x.png?v=1.1";
@@ -126,6 +127,16 @@ const platformCards: PlatformCard[] = [
     href: CLI_DOCS_URL,
     actionType: "button",
     label: "View CLI Docs",
+  },
+  {
+    name: "Agent Skill",
+    copy: "Install the Teak skill from skills.sh so agents know how to use Teak through CLI, API, MCP, and SDK workflows.",
+    iconAlt: "Model Context Protocol icon",
+    iconClass: "dark:invert",
+    iconSrc: "/platform-icons/mcp.svg",
+    href: SKILLS_DOCS_URL,
+    actionType: "button",
+    label: "Install Skill",
   },
 ];
 ---

--- a/apps/docs/src/content/changelog/2026-07.mdx
+++ b/apps/docs/src/content/changelog/2026-07.mdx
@@ -14,3 +14,4 @@ date: "2026-07-05"
 - Managing your subscription from Settings now opens reliably in Safari and other browsers.
 - Teak now has a command-line app for saving, searching, editing, favoriting, deleting, syncing, and listing tags from your terminal.
 - The API can now create file cards through direct uploads, so command-line workflows can save images, videos, audio, and documents.
+- The command-line app now signs in reliably from npm installs, includes setup docs directly on the npm package page, and ships an Agent Skill for AI assistants that work with Teak.

--- a/apps/docs/src/content/docs/docs/skills.mdx
+++ b/apps/docs/src/content/docs/docs/skills.mdx
@@ -1,0 +1,39 @@
+---
+title: Agent Skill
+description: Install the Teak Agent Skill for Codex, Claude Code, Cursor, and other skills-compatible agents
+---
+
+The Teak Agent Skill gives AI agents a reliable playbook for using Teak through the CLI, API, MCP server, and TypeScript SDK.
+
+## Install
+
+```bash
+npx skills add praveenjuge/teak --skill teak
+```
+
+The skill installs from Teak's public GitHub repository and works with skills-compatible agents such as Codex, Claude Code, Cursor, GitHub Copilot, Windsurf, and others.
+
+## What It Teaches Agents
+
+- When to use the Teak CLI, public API, MCP server, or SDK.
+- How to authenticate with browser sign-in or a Teak API key.
+- How to save text, links, files, tags, and notes.
+- How to search, inspect, update, favorite, delete, and sync cards.
+- How to use production-safe smoke-test markers and clean up test cards.
+- How to avoid leaking API keys, OAuth tokens, or private saved content.
+
+## Use
+
+After installing, ask your agent to use the Teak skill:
+
+```text
+Use the Teak skill to save this research link with the tags ai and reference.
+```
+
+Agents that support implicit skill activation can also choose it automatically when a task mentions Teak cards, the Teak CLI, Teak MCP, or the Teak API.
+
+## Related Docs
+
+- [Command Line](/docs/cli/)
+- [API](/docs/api/)
+- [MCP](/docs/mcp/)

--- a/apps/docs/src/pages/apps.astro
+++ b/apps/docs/src/pages/apps.astro
@@ -4,12 +4,12 @@ import HomeLayout from "../layouts/HomeLayout.astro";
 ---
 
 <HomeLayout
-  title="Teak Apps | Desktop, Web, API, MCP, iOS, Chrome, Safari, Raycast, and CLI"
-  description="Use Teak on desktop, web, API, MCP, iPhone, Chrome, Safari, Raycast, and the command line. Capture ideas anywhere and reopen them instantly on every device."
+  title="Teak Apps | Desktop, Web, API, MCP, iOS, Chrome, Safari, Raycast, CLI, and Agent Skill"
+  description="Use Teak on desktop, web, API, MCP, iPhone, Chrome, Safari, Raycast, the command line, and agent skills. Capture ideas anywhere and reopen them instantly on every device."
   canonical="https://teakvault.com/apps"
   ogTitle="Teak Apps"
-  ogDescription="Use Teak on desktop, web, API, MCP, iPhone, Chrome, Safari, Raycast, and the command line. Capture ideas anywhere and reopen them instantly on every device."
-  keywords="teak desktop app, teak apps, teak api, teak mcp, teak cli, teak ios, teak chrome extension, teak safari extension, teak raycast extension, teak web app, visual bookmarking apps, cross platform inspiration"
+  ogDescription="Use Teak on desktop, web, API, MCP, iPhone, Chrome, Safari, Raycast, the command line, and agent skills. Capture ideas anywhere and reopen them instantly on every device."
+  keywords="teak desktop app, teak apps, teak api, teak mcp, teak cli, teak agent skill, skills.sh teak, teak ios, teak chrome extension, teak safari extension, teak raycast extension, teak web app, visual bookmarking apps, cross platform inspiration"
 >
   <main class="px-4 py-16">
     <section class="mx-auto flex max-w-md flex-col items-center gap-4 text-center">
@@ -17,9 +17,9 @@ import HomeLayout from "../layouts/HomeLayout.astro";
         Teak, everywhere you create
       </h1>
       <p class="text-lg text-muted-foreground">
-        Desktop, web, API, iPhone, Chrome, Safari, Raycast, and CLI stay
-        perfectly in sync so the inspiration you save once is waiting on every
-        device.
+        Desktop, web, API, iPhone, Chrome, Safari, Raycast, CLI, and agent
+        skills stay perfectly in sync so the inspiration you save once is
+        waiting on every device.
       </p>
     </section>
     <AppsGrid />

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teak/extension",
   "description": "Teak - Your Personal Knowledge Hub. Save, organize, and rediscover web content, text selections, and ideas effortlessly.",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "author": "Praveen Juge (hi@praveenjuge.com)",
   "homepage": "https://teakvault.com",
   "type": "module",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/mobile",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "main": "expo-router/entry",
   "scripts": {
     "build": "expo export --platform web --clear",

--- a/apps/raycast/package.json
+++ b/apps/raycast/package.json
@@ -1,7 +1,7 @@
 {
   "name": "teak-raycast",
   "title": "Teak",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "private": true,
   "license": "MIT",
   "description": "Save ideas fast, search your Teak cards, and access favorites directly from Raycast.",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/web",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/api": {
       "name": "@teak/api",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "dependencies": {
         "@hono/mcp": "^0.2.5",
         "@hono/node-server": "^2.0.2",
@@ -34,7 +34,7 @@
     },
     "apps/cli": {
       "name": "teak-cli",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "bin": {
         "teak": "./dist/index.js",
       },
@@ -48,7 +48,7 @@
     },
     "apps/desktop": {
       "name": "@teak/desktop",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.0",
         "@teak/convex": "workspace:*",
@@ -80,7 +80,7 @@
     },
     "apps/docs": {
       "name": "@teak/docs",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "dependencies": {
         "@astrojs/check": "^0.9.9",
         "@astrojs/sitemap": "^3.7.3",
@@ -97,7 +97,7 @@
     },
     "apps/extension": {
       "name": "@teak/extension",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "dependencies": {
         "@convex-dev/better-auth": "0.12.2",
         "@tailwindcss/vite": "^4.3.0",
@@ -120,7 +120,7 @@
     },
     "apps/mobile": {
       "name": "@teak/mobile",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "dependencies": {
         "@better-auth/expo": "1.6.11",
         "@convex-dev/better-auth": "0.12.2",
@@ -173,7 +173,7 @@
     },
     "apps/raycast": {
       "name": "teak-raycast",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "dependencies": {
         "@raycast/api": "^1.104.19",
         "@raycast/utils": "^2.2.7",
@@ -187,7 +187,7 @@
     },
     "apps/web": {
       "name": "@teak/web",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "dependencies": {
         "@convex-dev/better-auth": "^0.12.2",
         "@polar-sh/checkout": "^0.2.1",
@@ -224,7 +224,7 @@
     },
     "packages/convex": {
       "name": "@teak/convex",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "dependencies": {
         "@ai-sdk/groq": "^3.0.39",
         "@aws-sdk/client-s3": "3.1069.0",
@@ -263,7 +263,7 @@
     },
     "packages/sdk": {
       "name": "@teak/sdk",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "typescript": "^6.0.3",
@@ -271,7 +271,7 @@
     },
     "packages/ui": {
       "name": "@teak/ui",
-      "version": "1.0.51",
+      "version": "1.0.52",
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "private": true,
   "packageManager": "bun@1.3.5",
   "workspaces": [

--- a/packages/convex/__tests__/publicApiHttp.test.ts
+++ b/packages/convex/__tests__/publicApiHttp.test.ts
@@ -310,12 +310,13 @@ describe("publicApiHttp", () => {
         cardId: "card_file",
         status: "created",
       });
-    const runAction = mock().mockResolvedValueOnce(null);
-    const runQuery = mock().mockResolvedValueOnce({
-      contentType: "image/png",
-      size: 123,
-    });
-
+    const runAction = mock()
+      .mockResolvedValueOnce({
+        contentType: "image/png",
+        size: 123,
+      })
+      .mockResolvedValueOnce(null);
+    const runQuery = mock();
     const response = await runHandler(
       createCardV1,
       { runAction, runMutation, runQuery },
@@ -342,13 +343,13 @@ describe("publicApiHttp", () => {
       status: "created",
     });
     expect(runAction.mock.calls[0][1]).toMatchObject({
+      key: "users/user_1/file/image.png",
+    });
+    expect(runAction.mock.calls[1][1]).toMatchObject({
       bucket: "test-r2-bucket",
       key: "users/user_1/file/image.png",
     });
-    expect(runQuery.mock.calls[0][1]).toMatchObject({
-      bucket: "test-r2-bucket",
-      key: "users/user_1/file/image.png",
-    });
+    expect(runQuery).not.toHaveBeenCalled();
     expect(runMutation.mock.calls[3][1]).toMatchObject({
       cardType: "image",
       fileKey: "users/user_1/file/image.png",
@@ -360,6 +361,41 @@ describe("publicApiHttp", () => {
       tags: ["reference"],
       userId: "user_1",
     });
+  });
+
+  test("createCardV1 rejects fileKey uploads when direct metadata omits size", async () => {
+    const token = `teakapi_secret_live_a1b2c3d4_${"f".repeat(64)}`;
+    const runMutation = buildAuthorizedMutationMockWithIdempotencySkip();
+    const runAction = mock().mockResolvedValueOnce({
+      contentType: "image/png",
+    });
+
+    const response = await runHandler(
+      createCardV1,
+      { runAction, runMutation, runQuery: mock() },
+      new Request("https://example.com/v1/cards", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          cardType: "image",
+          fileKey: "users/user_1/file/image.png",
+          fileName: "image.png",
+          fileSize: 123,
+          mimeType: "image/png",
+          tags: ["reference"],
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      code: "INVALID_INPUT",
+      error: "Uploaded file metadata is unavailable",
+    });
+    expect(runMutation).toHaveBeenCalledTimes(3);
   });
 
   test("createCardV1 rejects fileKey uploads when the object is missing", async () => {
@@ -397,15 +433,14 @@ describe("publicApiHttp", () => {
   test("createCardV1 rejects fileKey uploads when stored metadata differs", async () => {
     const token = `teakapi_secret_live_a1b2c3d4_${"f".repeat(64)}`;
     const runMutation = buildAuthorizedMutationMockWithIdempotencySkip();
-    const runAction = mock().mockResolvedValueOnce(null);
-    const runQuery = mock().mockResolvedValueOnce({
+    const runAction = mock().mockResolvedValueOnce({
       contentType: "image/png",
       size: 456,
     });
 
     const response = await runHandler(
       createCardV1,
-      { runAction, runMutation, runQuery },
+      { runAction, runMutation, runQuery: mock() },
       new Request("https://example.com/v1/cards", {
         method: "POST",
         headers: {
@@ -433,15 +468,14 @@ describe("publicApiHttp", () => {
   test("createCardV1 rejects fileKey uploads when stored object is too large", async () => {
     const token = `teakapi_secret_live_a1b2c3d4_${"f".repeat(64)}`;
     const runMutation = buildAuthorizedMutationMockWithIdempotencySkip();
-    const runAction = mock().mockResolvedValueOnce(null);
-    const runQuery = mock().mockResolvedValueOnce({
+    const runAction = mock().mockResolvedValueOnce({
       contentType: "image/png",
       size: MAX_FILE_SIZE + 1,
     });
 
     const response = await runHandler(
       createCardV1,
-      { runAction, runMutation, runQuery },
+      { runAction, runMutation, runQuery: mock() },
       new Request("https://example.com/v1/cards", {
         method: "POST",
         headers: {

--- a/packages/convex/_generated/api.d.ts
+++ b/packages/convex/_generated/api.d.ts
@@ -67,6 +67,7 @@ import type * as oauthClients from "../oauthClients.js";
 import type * as oauthTokens from "../oauthTokens.js";
 import type * as publicApi from "../publicApi.js";
 import type * as publicApiHttp from "../publicApiHttp.js";
+import type * as publicApiUploadMetadata from "../publicApiUploadMetadata.js";
 import type * as publicApiUploads from "../publicApiUploads.js";
 import type * as raycast from "../raycast.js";
 import type * as sentry from "../sentry.js";
@@ -196,6 +197,7 @@ declare const fullApi: ApiFromModules<{
   oauthTokens: typeof oauthTokens;
   publicApi: typeof publicApi;
   publicApiHttp: typeof publicApiHttp;
+  publicApiUploadMetadata: typeof publicApiUploadMetadata;
   publicApiUploads: typeof publicApiUploads;
   raycast: typeof raycast;
   sentry: typeof sentry;

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/convex",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "type": "module",
   "exports": {
     ".": "./index.ts",

--- a/packages/convex/publicApiHttp.ts
+++ b/packages/convex/publicApiHttp.ts
@@ -866,7 +866,12 @@ const verifyUploadedFile = async (
   }
 
   const config = r2ComponentConfig();
+  let headMetadata: { contentType?: string; size?: number };
   try {
+    headMetadata = await ctx.runAction(
+      (internal as any).publicApiUploadMetadata.headUploadedObject,
+      { key: payload.fileKey }
+    );
     await ctx.runAction(components.r2.lib.syncMetadata, {
       key: payload.fileKey,
       ...config,
@@ -878,19 +883,14 @@ const verifyUploadedFile = async (
     });
   }
 
-  const metadata = await ctx.runQuery(components.r2.lib.getMetadata, {
-    key: payload.fileKey,
-    ...config,
-  });
-
-  if (!metadata || typeof metadata.size !== "number") {
+  if (typeof headMetadata.size !== "number") {
     throw new ConvexError({
       code: "INVALID_INPUT",
       message: "Uploaded file metadata is unavailable",
     });
   }
 
-  if (metadata.size > MAX_FILE_SIZE) {
+  if (headMetadata.size > MAX_FILE_SIZE) {
     throw new ConvexError({
       code: "INVALID_INPUT",
       message: `Uploaded file must not exceed ${MAX_FILE_SIZE} bytes`,
@@ -898,12 +898,12 @@ const verifyUploadedFile = async (
   }
 
   const storedMimeType =
-    typeof metadata.contentType === "string"
-      ? metadata.contentType.trim().toLowerCase()
+    typeof headMetadata.contentType === "string"
+      ? headMetadata.contentType.trim().toLowerCase()
       : undefined;
   const requestedMimeType = payload.mimeType?.trim().toLowerCase();
 
-  if (payload.fileSize !== undefined && payload.fileSize !== metadata.size) {
+  if (payload.fileSize !== undefined && payload.fileSize !== headMetadata.size) {
     throw new ConvexError({
       code: "INVALID_INPUT",
       message: "Uploaded file size does not match the stored object",
@@ -921,7 +921,7 @@ const verifyUploadedFile = async (
     });
   }
 
-  return { storedFileSize: metadata.size, storedMimeType };
+  return { storedFileSize: headMetadata.size, storedMimeType };
 };
 
 const handleCreateCardRequest = async (

--- a/packages/convex/publicApiUploadMetadata.ts
+++ b/packages/convex/publicApiUploadMetadata.ts
@@ -1,0 +1,36 @@
+"use node";
+
+import { HeadObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { v } from "convex/values";
+import { internalAction } from "./_generated/server";
+import { r2ComponentConfig } from "./storage/r2";
+
+const createR2Client = (config: ReturnType<typeof r2ComponentConfig>) =>
+  new S3Client({
+    credentials: {
+      accessKeyId: config.accessKeyId,
+      secretAccessKey: config.secretAccessKey,
+    },
+    endpoint: config.endpoint,
+    region: "auto",
+    requestChecksumCalculation: "WHEN_REQUIRED",
+  });
+
+export const headUploadedObject = internalAction({
+  args: { key: v.string() },
+  returns: v.object({
+    contentType: v.optional(v.string()),
+    size: v.optional(v.number()),
+  }),
+  handler: async (_ctx, { key }) => {
+    const config = r2ComponentConfig();
+    const response = await createR2Client(config).send(
+      new HeadObjectCommand({ Bucket: config.bucket, Key: key })
+    );
+
+    return {
+      contentType: response.ContentType,
+      size: response.ContentLength,
+    };
+  },
+});

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/sdk",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -60,4 +60,29 @@ describe("@teak/sdk", () => {
       code: "TIMEOUT",
     } satisfies Partial<TeakApiError>);
   });
+
+  test("sends direct upload content length when known", async () => {
+    const seenHeaders: Record<string, string | null> = {};
+    const client = createTeakClient({
+      baseUrl: "https://api.example",
+      tokenProvider: { getAccessToken: () => "token" },
+      fetch: ((_url, init) => {
+        const headers = new Headers(init?.headers);
+        seenHeaders.contentLength = headers.get("content-length");
+        seenHeaders.contentType = headers.get("content-type");
+        return Promise.resolve(new Response(null, { status: 200 }));
+      }) as typeof fetch,
+    });
+
+    await client.uploads.putFile(
+      "https://upload.example",
+      new Uint8Array([1, 2, 3]),
+      "image/png"
+    );
+
+    expect(seenHeaders).toEqual({
+      contentLength: "3",
+      contentType: "image/png",
+    });
+  });
 });

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -194,6 +194,22 @@ export const normalizeLimit = (limit?: number): number => {
   return Math.max(1, Math.min(Math.trunc(limit ?? 50), 100));
 };
 
+const byteLengthForBody = (bytes: BodyInit): number | null => {
+  if (bytes instanceof ArrayBuffer) {
+    return bytes.byteLength;
+  }
+  if (ArrayBuffer.isView(bytes)) {
+    return bytes.byteLength;
+  }
+  if (typeof Blob !== "undefined" && bytes instanceof Blob) {
+    return bytes.size;
+  }
+  if (typeof bytes === "string") {
+    return new TextEncoder().encode(bytes).byteLength;
+  }
+  return null;
+};
+
 export const buildCardsSearchParams = (input: {
   createdAfter?: number;
   createdBefore?: number;
@@ -469,9 +485,14 @@ export const createTeakClient = (options: {
           asUpload
         ),
       putFile: async (uploadUrl: string, bytes: BodyInit, mimeType: string) => {
+        const headers = new Headers({ "Content-Type": mimeType });
+        const byteLength = byteLengthForBody(bytes);
+        if (byteLength !== null) {
+          headers.set("Content-Length", String(byteLength));
+        }
         const response = await fetchImpl(uploadUrl, {
           body: bytes,
-          headers: { "Content-Type": mimeType },
+          headers,
           method: "PUT",
         });
         if (!response.ok) {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/ui",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "private": true,
   "exports": {
     "./logo": "./src/logo.tsx",


### PR DESCRIPTION
## Summary
- request refresh-capable OAuth scope during `teak login` so npm installs can complete browser sign-in
- add npm package metadata and a package README for `teak-cli`
- send content length for SDK direct uploads and verify uploaded R2 objects with a server-side HEAD before card creation
- add the Teak Agent Skill plus docs/apps/README/AGENTS references
- bump all package versions to 1.0.52

## Validation
- bun run pre-commit
- bun run test --filter=@teak/convex
- bun run typecheck --filter=@teak/convex
- bun run test --filter=@teak/api
- bun run typecheck --filter=@teak/api
- bun run test --filter=@teak/sdk
- bun run test --filter=teak-cli
- bun run build --filter=teak-cli
- npm pack ./apps/cli --dry-run --json
- npx --yes skills add . --list --full-depth
- local built CLI OAuth login against production succeeded
- production CLI smoke covered auth, list/search/create/get/update/favorite/bulk/delete; file upload will be re-run after this API fix deploys
