### PR TITLE
[codex] Fix production integration QA findings

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,6 +7,7 @@
     "lint": "astro check && biome check astro.config.ts src/**/*.ts src/**/*.css *.json",
     "preview": "astro preview",
     "start": "astro preview",
+    "test": "bun test src/lib --coverage --dots",
     "typecheck": "astro check"
   },
   "dependencies": {
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.2",
+    "@types/bun": "^1.3.14",
     "open-cli": "9.0.0",
     "tailwindcss": "^4.3.2",
     "typescript": "^6.0.3",

--- a/apps/docs/src/content/changelog/2026-07.mdx
+++ b/apps/docs/src/content/changelog/2026-07.mdx
@@ -10,6 +10,7 @@ date: "2026-07-05"
 - Install Teak for Safari from the Mac App Store to save pages directly from the Safari toolbar.
 - API card lists now load reliably when a request scans more than one page of saved cards, and deleted cards stay hidden from direct API lookups.
 - Browser sign-in for MCP and API clients completes more reliably across apps that connect from another origin.
+- MCP clients now consistently discover Teak's public server address during browser sign-in.
 - The browser extension now signs you in through the web app, the same one-step browser sign-in used by the desktop app and Raycast.
 - Managing your subscription from Settings now opens reliably in Safari and other browsers.
 - Teak now has a command-line app for saving, searching, editing, favoriting, deleting, syncing, and listing tags from your terminal.

--- a/apps/docs/src/content/docs/docs/api.mdx
+++ b/apps/docs/src/content/docs/docs/api.mdx
@@ -19,6 +19,8 @@ Teak also exposes a remote MCP server:
 - Local development: `https://reminiscent-kangaroo-59.convex.site/mcp`
 
 See the dedicated [MCP docs](./mcp) for tool contracts and JSON-RPC examples.
+API discovery always returns the canonical production MCP URL, including when
+the API is served through its managed backend proxy.
 
 ## Authentication
 

--- a/apps/docs/src/content/docs/docs/mcp.mdx
+++ b/apps/docs/src/content/docs/docs/mcp.mdx
@@ -45,6 +45,9 @@ Unauthenticated requests receive `401` with a `WWW-Authenticate` header pointing
 - Also supported: `/mcp/`
 - Server mode: stateless JSON response mode
 
+OAuth protected-resource discovery advertises the canonical production endpoint
+shown above, so MCP clients validate and connect to the same public resource.
+
 ## Available Tools
 
 - `teak_v1_create_card`

--- a/apps/docs/src/lib/securityHeaders.test.ts
+++ b/apps/docs/src/lib/securityHeaders.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import vercelConfig from "../../vercel.json";
+
+const headers = new Map(
+  vercelConfig.headers.flatMap((route) =>
+    route.headers.map(({ key, value }) => [key, value] as const)
+  )
+);
+
+describe("documentation site security headers", () => {
+  test("prevents framing and MIME sniffing", () => {
+    expect(headers.get("Content-Security-Policy")).toContain(
+      "frame-ancestors 'none'"
+    );
+    expect(headers.get("X-Frame-Options")).toBe("DENY");
+    expect(headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  test("limits referrers, browser capabilities, and downgrade risk", () => {
+    expect(headers.get("Referrer-Policy")).toBe(
+      "strict-origin-when-cross-origin"
+    );
+    expect(headers.get("Permissions-Policy")).toContain("camera=()");
+    expect(headers.get("Strict-Transport-Security")).toContain(
+      "includeSubDomains"
+    );
+  });
+});

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
     "baseUrl": ".",
+    "types": ["bun"],
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,5 +1,36 @@
 {
   "buildCommand": "bun run build",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "frame-ancestors 'none'"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), geolocation=(), microphone=()"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        }
+      ]
+    }
+  ],
   "installCommand": "bun install",
   "framework": null,
   "outputDirectory": "dist",

--- a/apps/raycast/src/__tests__/cardDetailModel.test.ts
+++ b/apps/raycast/src/__tests__/cardDetailModel.test.ts
@@ -1,12 +1,16 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import type { RaycastCard } from "../lib/api";
-import {
+import { createRaycastApiMock } from "./raycastApiMock";
+
+mock.module("@raycast/api", () => createRaycastApiMock(false));
+
+const {
   getCardTitle,
   getDetailStatusChips,
   getHeroMediaUrl,
   getOpenableUrl,
   isHttpUrl,
-} from "../lib/cardDetailModel";
+} = await import("../lib/cardDetailModel");
 
 const baseCard: RaycastCard = {
   appUrl: "https://app.teakvault.com/?card=card_123456",

--- a/apps/raycast/src/__tests__/constants.test.ts
+++ b/apps/raycast/src/__tests__/constants.test.ts
@@ -1,8 +1,7 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { createRaycastApiMock } from "./raycastApiMock";
 
-mock.module("@raycast/api", () => ({
-  environment: { isDevelopment: true },
-}));
+mock.module("@raycast/api", () => createRaycastApiMock(true));
 
 const loadLocalConstants = () =>
   import(`../lib/constants?local=${crypto.randomUUID()}`);
@@ -45,9 +44,7 @@ describe("raycast OAuth token base URL", () => {
     restoreEnv("TEAK_DEV_CONVEX_SITE_URL", originalTokenEnv);
     restoreEnv("NEXT_PUBLIC_CONVEX_SITE_URL", originalSiteEnv);
     // Restore the file-level development mock for any following tests.
-    mock.module("@raycast/api", () => ({
-      environment: { isDevelopment: true },
-    }));
+    mock.module("@raycast/api", () => createRaycastApiMock(true));
   });
 
   test("ignores NEXT_PUBLIC_CONVEX_SITE_URL and uses the default deployment", async () => {
@@ -82,9 +79,7 @@ describe("raycast OAuth token base URL", () => {
   });
 
   test("uses the production app origin outside development", async () => {
-    mock.module("@raycast/api", () => ({
-      environment: { isDevelopment: false },
-    }));
+    mock.module("@raycast/api", () => createRaycastApiMock(false));
 
     const { getOAuthTokenBaseUrl } = await loadLocalConstants();
     expect(getOAuthTokenBaseUrl()).toBe("https://app.teakvault.com");

--- a/apps/raycast/src/__tests__/raycastApiMock.ts
+++ b/apps/raycast/src/__tests__/raycastApiMock.ts
@@ -1,0 +1,15 @@
+interface RaycastApiMockOverrides {
+  getPreferenceValues?: () => unknown;
+}
+
+export const createRaycastApiMock = (
+  isDevelopment: boolean,
+  overrides: RaycastApiMockOverrides = {},
+) => ({
+  environment: { isDevelopment },
+  getPreferenceValues: overrides.getPreferenceValues ?? (() => ({})),
+  OAuth: {
+    PKCEClient: class {},
+    RedirectMethod: { App: "app", AppURI: "appURI", Web: "web" },
+  },
+});

--- a/apps/raycast/src/__tests__/request.test.ts
+++ b/apps/raycast/src/__tests__/request.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { parseCardsResponse } from "../lib/apiParsers";
+import { createRaycastApiMock } from "./raycastApiMock";
 
 const getPreferenceValuesMock = mock(() => ({ apiKey: "valid-test-key" }));
 const authorizeMock = mock(() => Promise.resolve("oauth-access-token"));
@@ -7,14 +8,11 @@ const removeTokensMock = mock(() => Promise.resolve());
 const getTokensMock = mock(() => Promise.resolve(undefined));
 
 const mockRaycastApi = (isDevelopment: boolean) => {
-  mock.module("@raycast/api", () => ({
-    environment: { isDevelopment },
-    getPreferenceValues: getPreferenceValuesMock,
-    OAuth: {
-      PKCEClient: class {},
-      RedirectMethod: { App: "app", AppURI: "appURI", Web: "web" },
-    },
-  }));
+  mock.module("@raycast/api", () =>
+    createRaycastApiMock(isDevelopment, {
+      getPreferenceValues: getPreferenceValuesMock,
+    }),
+  );
 };
 
 // OAuthService is instantiated at module load of ../lib/oauth; provide a stub
@@ -75,12 +73,11 @@ const createCardsResponse = (
   });
 };
 
-const createEmptyResponse = (status: number): Response => {
-  return new Response(null, {
+const createEmptyResponse = (status: number): Response =>
+  new Response(null, {
     status,
     headers: { "Content-Type": "application/json" },
   });
-};
 
 const originalFetch = globalThis.fetch;
 const originalRequestTimeout = process.env.TEAK_API_REQUEST_TIMEOUT_MS;
@@ -170,13 +167,14 @@ describe("raycast request handling", () => {
   test("maps timed out requests to NETWORK_ERROR", async () => {
     process.env.TEAK_API_REQUEST_TIMEOUT_MS = "5";
 
-    globalThis.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) => {
-      return new Promise((_, reject) => {
-        init?.signal?.addEventListener("abort", () => {
-          reject(new Error("Request aborted"));
-        });
-      });
-    }) as unknown as typeof fetch;
+    globalThis.fetch = mock(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise((_, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new Error("Request aborted"));
+          });
+        }),
+    ) as unknown as typeof fetch;
 
     try {
       await searchCards({ limit: 1 });

--- a/apps/web/src/tests/auth.e2e.ts
+++ b/apps/web/src/tests/auth.e2e.ts
@@ -42,21 +42,21 @@ test.describe("Authentication Flows", () => {
 
       // Check for footer links
       await expect(
-        page.getByRole("link", { name: /forgot your password/i })
+        page.getByRole("link", { name: /^forgot\?$/i })
       ).toBeVisible();
       await expect(
-        page.getByRole("link", { name: /register with email/i })
+        page.getByRole("link", { name: /new user\? register/i })
       ).toBeVisible();
     });
 
     test("should navigate to register page", async ({ page }) => {
-      await page.getByRole("link", { name: /register with email/i }).click();
+      await page.getByRole("link", { name: /new user\? register/i }).click();
       await expect(page).toHaveURL(/\/register/);
-      await expect(page.getByText("Register", { exact: true })).toBeVisible();
+      await expect(page.getByText("Get started on Teak")).toBeVisible();
     });
 
     test("should navigate to forgot password page", async ({ page }) => {
-      await page.getByRole("link", { name: /forgot your password/i }).click();
+      await page.getByRole("link", { name: /^forgot\?$/i }).click();
       await expect(page).toHaveURL(/\/forgot-password/);
     });
 
@@ -90,7 +90,7 @@ test.describe("Authentication Flows", () => {
 
       // Check that we're on the register page
       await expect(page).toHaveURL(/\/register/);
-      await expect(page.getByText("Register", { exact: true })).toBeVisible();
+      await expect(page.getByText("Get started on Teak")).toBeVisible();
 
       // Check for social signup buttons
       await expect(
@@ -187,7 +187,7 @@ test.describe("Authentication Flows", () => {
       await expect(page).toHaveURL("/");
 
       // Check that we're logged in by looking for authenticated content
-      await expect(page.getByPlaceholder(/Write or add a link/i)).toBeVisible();
+      await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
     });
 
     test("should show error for invalid credentials", async ({ page }) => {

--- a/apps/web/src/tests/onboarding.e2e.ts
+++ b/apps/web/src/tests/onboarding.e2e.ts
@@ -111,7 +111,7 @@ test.describe("Onboarding Journey", () => {
     await authHelper.signInWithEmailAndPassword(TEST_EMAIL!, TEST_PASSWORD!);
 
     // Check for key UI elements
-    await expect(page.getByPlaceholder(/Write or add a link/i)).toBeVisible();
+    await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
 
     // Check for search bar
     await expect(page.getByPlaceholder("Search for anything...")).toBeVisible();

--- a/apps/web/src/tests/settings.e2e.ts
+++ b/apps/web/src/tests/settings.e2e.ts
@@ -50,7 +50,7 @@ test.describe("Settings Navigation and Management", () => {
 
       // Should be on home page
       await expect(page).toHaveURL("/");
-      await expect(page.getByPlaceholder(/Write or add a link/i)).toBeVisible();
+      await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
     });
   });
 
@@ -296,8 +296,8 @@ test.describe("Settings Navigation and Management", () => {
 
       // Should have delete account link/button
       const deleteLink = page
-        .getByRole("button", { name: /delete account/i })
-        .or(page.getByRole("link", { name: /delete account/i }));
+        .getByRole("button", { name: /delete your account/i })
+        .or(page.getByRole("link", { name: /delete your account/i }));
 
       await expect(deleteLink.first()).toBeVisible();
     });
@@ -307,7 +307,9 @@ test.describe("Settings Navigation and Management", () => {
       await uiHelper.goToSettings();
 
       // Click delete account
-      const deleteLink = page.getByRole("button", { name: /delete account/i });
+      const deleteLink = page.getByRole("button", {
+        name: /delete your account/i,
+      });
       await deleteLink.first().click();
 
       // Should show confirmation dialog
@@ -318,10 +320,7 @@ test.describe("Settings Navigation and Management", () => {
       await expect(page.getByLabel(/delete account/i)).toBeVisible();
 
       // Cancel for cleanup
-      const cancelButton = page.getByRole("button", { name: /cancel/i });
-      if ((await cancelButton.count()) > 0) {
-        await cancelButton.first().click();
-      }
+      await page.locator('[data-slot="dialog-close"]').click();
     });
 
     test("should require confirmation for account deletion", async ({
@@ -331,13 +330,15 @@ test.describe("Settings Navigation and Management", () => {
       await uiHelper.goToSettings();
 
       // Click delete account
-      const deleteLink = page.getByRole("button", { name: /delete account/i });
+      const deleteLink = page.getByRole("button", {
+        name: /delete your account/i,
+      });
       await deleteLink.first().click();
 
       // Try to delete without confirmation
       const deleteButton = page
-        .getByRole("button", { name: /delete account/i })
-        .or(page.locator("[data-delete-account-confirm]"));
+        .getByRole("dialog")
+        .getByRole("button", { name: /^delete account$/i });
 
       // Should be disabled without proper confirmation
       const isDisabled = await deleteButton
@@ -350,10 +351,7 @@ test.describe("Settings Navigation and Management", () => {
       }
 
       // Cancel for cleanup
-      const cancelButton = page.getByRole("button", { name: /cancel/i });
-      if ((await cancelButton.count()) > 0) {
-        await cancelButton.first().click();
-      }
+      await page.locator('[data-slot="dialog-close"]').click();
     });
   });
 

--- a/apps/web/src/tests/test-helpers.ts
+++ b/apps/web/src/tests/test-helpers.ts
@@ -70,7 +70,7 @@ export class AuthHelper {
 
       // Wait for the main page element to be visible
       await this.page
-        .getByPlaceholder(/Write or add a link/i)
+        .getByPlaceholder(/Write a note/i)
         .waitFor({ state: "visible", timeout: DEFAULT_TIMEOUT });
       return;
     } catch {
@@ -104,7 +104,7 @@ export class AuthHelper {
 
     // Wait for the main page element to be visible
     await this.page
-      .getByPlaceholder(/Write or add a link/i)
+      .getByPlaceholder(/Write a note/i)
       .waitFor({ state: "visible", timeout: DEFAULT_TIMEOUT });
   }
 
@@ -148,7 +148,7 @@ export class AuthHelper {
 
       // Wait for the main page element to be visible
       await this.page
-        .getByPlaceholder(/Write or add a link/i)
+        .getByPlaceholder(/Write a note/i)
         .waitFor({ state: "visible", timeout: DEFAULT_TIMEOUT });
     } catch (error) {
       // Provide more context for debugging
@@ -227,7 +227,7 @@ export class UiHelper {
    * Get the main composer textarea
    */
   getComposer(): Locator {
-    return this.page.getByPlaceholder(/Write or add a link/i);
+    return this.page.getByPlaceholder(/Write a note/i);
   }
 
   /**
@@ -372,7 +372,7 @@ export class UiHelper {
     await this.page.goto("/");
     // Wait for page to be ready by checking for a key element
     await this.page
-      .getByPlaceholder(/Write or add a link/i)
+      .getByPlaceholder(/Write a note/i)
       .waitFor({ state: "visible", timeout: DEFAULT_TIMEOUT });
   }
 

--- a/bun.lock
+++ b/bun.lock
@@ -71,6 +71,7 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.2",
+        "@types/bun": "^1.3.14",
         "open-cli": "9.0.0",
         "tailwindcss": "^4.3.2",
         "typescript": "^6.0.3",
@@ -1694,6 +1695,8 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
 
     "@types/chrome": ["@types/chrome@0.1.43", "", { "dependencies": { "@types/filesystem": "*", "@types/har-format": "*" } }, "sha512-ukH/HhmR6ht+UTX3PLUWJxgJ/RQcK2Foj4lBzsF24SIWsXgqhGuXqjd8FFuwioPP7d/JUKLM4g8GZxw3F4HTcA=="],
@@ -2073,6 +2076,8 @@
     "builder-util": ["builder-util@26.15.3", "", { "dependencies": { "@types/debug": "^4.1.6", "builder-util-runtime": "9.7.0", "chalk": "^4.1.2", "cross-spawn": "^7.0.6", "debug": "^4.3.4", "fs-extra": "^10.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "js-yaml": "^4.1.0", "sanitize-filename": "^1.6.3", "source-map-support": "^0.5.19", "stat-mode": "^1.0.0", "temp-file": "^3.4.0", "tiny-async-pool": "1.3.0" } }, "sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw=="],
 
     "builder-util-runtime": ["builder-util-runtime@9.7.0", "", { "dependencies": { "debug": "^4.3.4", "sax": "^1.2.4" } }, "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/packages/convex/__tests__/mcp.test.ts
+++ b/packages/convex/__tests__/mcp.test.ts
@@ -48,19 +48,22 @@ const mcpRequest = (
   });
 
 const initializeMcp = (ctx: any) =>
-  handleMcpV1Request(ctx, mcpRequest({
-    jsonrpc: "2.0",
-    id: 1,
-    method: "initialize",
-    params: {
-      protocolVersion: "2025-06-18",
-      capabilities: {},
-      clientInfo: {
-        name: "teak-convex-tests",
-        version: "1.0.0",
+  handleMcpV1Request(
+    ctx,
+    mcpRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: {
+          name: "teak-convex-tests",
+          version: "1.0.0",
+        },
       },
-    },
-  }));
+    })
+  );
 
 describe("Convex MCP endpoint", () => {
   test("returns 401 with OAuth protected-resource challenge for missing auth", async () => {
@@ -91,7 +94,9 @@ describe("Convex MCP endpoint", () => {
     process.env.SITE_URL = "https://app.teakvault.com";
 
     const response = await handleOauthProtectedResourceV1Request(
-      new Request("https://api.teakvault.com/.well-known/oauth-protected-resource")
+      new Request(
+        "https://api.teakvault.com/.well-known/oauth-protected-resource"
+      )
     );
 
     expect(response.status).toBe(200);
@@ -115,6 +120,19 @@ describe("Convex MCP endpoint", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({
       resource: "https://reminiscent-kangaroo-59.convex.site/mcp",
+    });
+  });
+
+  test("uses the public API origin for production Convex metadata", async () => {
+    const response = await handleOauthProtectedResourceV1Request(
+      new Request(
+        "https://uncommon-ladybug-882.convex.site/.well-known/oauth-protected-resource"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      resource: "https://api.teakvault.com/mcp",
     });
   });
 
@@ -233,7 +251,7 @@ describe("Convex MCP endpoint", () => {
       body?: unknown;
       query?: Record<string, unknown>;
     }> = [];
-    const executor = mock(async (operation: Parameters<PublicApiToolExecutor>[0]) => {
+    const executor = mock((operation: Parameters<PublicApiToolExecutor>[0]) => {
       captured.push({
         path: operation.path,
         method: operation.method,
@@ -243,12 +261,14 @@ describe("Convex MCP endpoint", () => {
       });
 
       if (operation.method === "DELETE") {
-        return new Response(null, { status: 204 });
+        return Promise.resolve(new Response(null, { status: 204 }));
       }
-      return new Response(JSON.stringify({ status: "created", cardId: "card_1" }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
+      return Promise.resolve(
+        new Response(JSON.stringify({ status: "created", cardId: "card_1" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
     }) as PublicApiToolExecutor;
     for (const toolCall of [
       {
@@ -306,13 +326,13 @@ describe("Convex MCP endpoint", () => {
       "teak_v1_delete_card",
       { cardId: "card_1" },
       mcpRequest({ jsonrpc: "2.0", id: 3, method: "tools/call" }),
-      mock(async () => new Response(null, { status: 204 })) as PublicApiToolExecutor
+      mock(
+        async () => new Response(null, { status: 204 })
+      ) as PublicApiToolExecutor
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content?.[0]?.text.toLowerCase()).toContain(
-      "confirm"
-    );
+    expect(result.content?.[0]?.text.toLowerCase()).toContain("confirm");
   });
 
   test("maps v1 errors to MCP isError payloads", async () => {

--- a/packages/convex/__tests__/publicApiGateway.test.ts
+++ b/packages/convex/__tests__/publicApiGateway.test.ts
@@ -51,6 +51,18 @@ describe("Convex public API metadata", () => {
     });
   });
 
+  test("keeps the public MCP URL behind the production Convex proxy", async () => {
+    const response = await runHandler(
+      discoveryV1,
+      {},
+      new Request("https://uncommon-ladybug-882.convex.site/v1")
+    );
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.mcp.endpoint).toBe("https://api.teakvault.com/mcp");
+  });
+
   test("answers REST CORS preflight", async () => {
     const response = await runHandler(
       v1CorsPreflight,

--- a/packages/convex/__tests__/workflows/steps/categorization/coverage.test.ts
+++ b/packages/convex/__tests__/workflows/steps/categorization/coverage.test.ts
@@ -1,15 +1,22 @@
 // @ts-nocheck
 import { expect, mock, test } from "bun:test";
 
+const providers = await import(
+  "../../../../../convex/workflows/steps/categorization/providers"
+);
+const originalEnrichProvider = providers.enrichProvider;
+
 // Mock providers to return content even if provider is missing (to test dead code)
 mock.module(
   "../../../../../convex/workflows/steps/categorization/providers",
   () => ({
-    enrichProvider: (provider: any) => {
+    ...providers,
+    enrichProvider: (...args: Parameters<typeof providers.enrichProvider>) => {
+      const [provider] = args;
       if (!provider) {
         return { raw: { test: "data" } };
       }
-      return null;
+      return originalEnrichProvider(...args);
     },
   })
 );

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -22,7 +22,7 @@
   "types": "./index.ts",
   "scripts": {
     "dev": "convex dev",
-    "test": "bun test __tests__ --coverage --dots",
+    "test": "GOOGLE_CLIENT_ID=test GOOGLE_CLIENT_SECRET=test SITE_URL=http://app.teak.localhost:1355 bun test __tests__ --coverage --dots",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/convex/publicApiMeta.ts
+++ b/packages/convex/publicApiMeta.ts
@@ -1,6 +1,7 @@
 import { httpAction } from "./_generated/server";
 import {
   isLocalDevelopmentHostname,
+  resolveTeakDevApiUrl,
   resolveTeakDevAppUrl,
 } from "./devUrls";
 
@@ -44,14 +45,6 @@ const normalizeBaseUrl = (raw: string): string => raw.replace(/\/+$/, "");
 const isLocalApiHost = (hostname: string): boolean =>
   isLocalDevelopmentHostname(hostname);
 
-const isConvexSiteHost = (hostname: string): boolean =>
-  hostname.endsWith(".convex.site");
-
-export const getMcpEndpointFromRequestUrl = (requestUrl: string): string => {
-  const incoming = new URL(requestUrl);
-  return `${incoming.origin}/mcp`;
-};
-
 const getPublicApiUrl = (requestUrl: string): string => {
   const fromEnv = process.env.PUBLIC_API_URL?.trim();
   if (fromEnv) {
@@ -59,10 +52,14 @@ const getPublicApiUrl = (requestUrl: string): string => {
   }
 
   const { hostname, origin } = new URL(requestUrl);
-  return isLocalApiHost(hostname) || isConvexSiteHost(hostname)
+  const devApiOrigin = resolveTeakDevApiUrl(process.env);
+  return isLocalApiHost(hostname) || origin === devApiOrigin
     ? origin
     : PROD_PUBLIC_API_URL;
 };
+
+export const getMcpEndpointFromRequestUrl = (requestUrl: string): string =>
+  `${getPublicApiUrl(requestUrl)}/mcp`;
 
 const getAuthIssuerUrl = (requestUrl: string): string => {
   const fromEnv =
@@ -130,23 +127,27 @@ export const healthzV1 = httpAction(async () =>
   )
 );
 
-export const discoveryV1 = httpAction(async (_ctx, request) => {
+export const discoveryV1 = httpAction((_ctx, request) => {
   if (request.method === "OPTIONS") {
-    return v1CorsPreflightResponse();
+    return Promise.resolve(v1CorsPreflightResponse());
   }
 
-  return withPublicApiGatewayHeaders(
-    json(200, {
-      version: API_VERSION,
-      endpoints: V1_ENDPOINTS,
-      auth: API_AUTH_HINT,
-      mcp: {
-        endpoint: getMcpEndpointFromRequestUrl(request.url),
-        transport: MCP_TRANSPORT,
+  return Promise.resolve(
+    withPublicApiGatewayHeaders(
+      json(200, {
+        version: API_VERSION,
+        endpoints: V1_ENDPOINTS,
         auth: API_AUTH_HINT,
-      },
-    })
+        mcp: {
+          endpoint: getMcpEndpointFromRequestUrl(request.url),
+          transport: MCP_TRANSPORT,
+          auth: API_AUTH_HINT,
+        },
+      })
+    )
   );
 });
 
-export const v1CorsPreflight = httpAction(async () => v1CorsPreflightResponse());
+export const v1CorsPreflight = httpAction(async () =>
+  v1CorsPreflightResponse()
+);

--- a/packages/ui/src/components/forms/__tests__/AddCardForm.test.tsx
+++ b/packages/ui/src/components/forms/__tests__/AddCardForm.test.tsx
@@ -96,6 +96,17 @@ mock.module("@teak/convex", () => ({
       getCurrentUser: {},
       getCardCreationStatus: {},
     },
+    dataImport: {
+      getImportFailureSamples: {},
+      getLatestImport: {},
+    },
+    importUpload: {
+      cancelImport: {},
+      completeImportUpload: {},
+      createImportUpload: {},
+      getImportReportUrl: {},
+      resumeImportUpload: {},
+    },
   },
 }));
 


### PR DESCRIPTION
## Summary

- keep MCP and OAuth protected-resource discovery on the canonical public API origin when requests arrive through the production Convex proxy
- update stale web Playwright selectors to match the current authentication, composer, and account-deletion UI
- make the Convex, UI, and Raycast test suites deterministic when Bun module mocks persist across files
- add production security headers and regression coverage for the documentation site
- document the canonical discovery behavior and add a user-facing changelog entry

## Root causes

- public discovery derived the MCP URL directly from the incoming managed-backend origin
- Playwright assertions still targeted copy and controls removed by later UI changes
- partial `mock.module()` definitions polluted subsequent Bun test files because module overrides persist for the process lifetime
- docs deployment configuration did not define defense-in-depth response headers

## Validation

- `bun run test` — 1,959 passed, 0 failed across all nine test workspaces
- `bun run pre-commit` — 20 affected build/typecheck/lint tasks passed
- targeted API/MCP regression tests — 18 passed
- docs security tests — 2 passed
- Convex package tests — 1,221 passed
- UI package tests — 77 passed
- Raycast package tests — 57 passed
- web production build passed with required public build-time URLs

The local production QA harness is intentionally excluded from this PR.
