### PR TITLE
Migrate API and MCP to apex routes

### DIFF
--- a/.agents/skills/teak/SKILL.md
+++ b/.agents/skills/teak/SKILL.md
@@ -88,7 +88,7 @@ For destructive operations, confirm intent before deleting cards unless the user
 Base URL:
 
 ```text
-https://api.teakvault.com
+https://teakvault.com/api
 ```
 
 Common endpoints:
@@ -117,7 +117,7 @@ Authorization: Bearer <OAuth access token or teakapi_ API key>
 Use idempotency keys for retryable create requests from automation:
 
 ```bash
-curl https://api.teakvault.com/v1/cards \
+curl https://teakvault.com/api/v1/cards \
   -H "Authorization: Bearer $TEAK_API_KEY" \
   -H "Content-Type: application/json" \
   -H "Idempotency-Key: unique-workflow-step-id" \
@@ -131,14 +131,14 @@ For uploads, first create an upload, PUT the bytes to the returned `uploadUrl`, 
 MCP endpoint:
 
 ```text
-https://api.teakvault.com/mcp
+https://teakvault.com/mcp
 ```
 
 OAuth metadata:
 
 ```text
 https://app.teakvault.com/.well-known/oauth-authorization-server
-https://api.teakvault.com/.well-known/oauth-protected-resource
+https://teakvault.com/.well-known/oauth-protected-resource/mcp
 ```
 
 Use MCP for agents that can connect to streamable HTTP MCP servers. The server supports OAuth bearer tokens and Teak API keys. Confirm the tool list in the client before assuming a tool name; typical operations map to creating, searching, listing, updating, favoriting, and deleting cards.
@@ -151,7 +151,7 @@ Install the SDK package from the Teak workspace or published package when availa
 import { createTeakClient, staticTokenProvider } from "@teak/sdk";
 
 const teak = createTeakClient({
-  baseUrl: "https://api.teakvault.com",
+  baseUrl: "https://teakvault.com/api",
   tokenProvider: staticTokenProvider(process.env.TEAK_API_KEY!),
 });
 

--- a/.github/workflows/api-smoke.yml
+++ b/.github/workflows/api-smoke.yml
@@ -1,0 +1,17 @@
+# Passes after the docs deployment has published the apex API/MCP rewrites.
+name: API and MCP Smoke
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Smoke API and MCP URLs
+        run: bash scripts/smoke-urls.sh

--- a/.github/workflows/api-smoke.yml
+++ b/.github/workflows/api-smoke.yml
@@ -6,6 +6,9 @@ on:
     - cron: "0 */6 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak-cli",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "description": "Command-line client for Teak, the personal knowledge hub for saving and rediscovering ideas.",
   "type": "module",
   "bin": {

--- a/apps/cli/src/runtime.ts
+++ b/apps/cli/src/runtime.ts
@@ -32,7 +32,7 @@ const readPackageVersion = () => {
 export const VERSION = readPackageVersion();
 export const EXIT = { api: 1, auth: 3, notFound: 4, rateLimited: 5, usage: 2 };
 
-const DEFAULT_API_URL = "https://api.teakvault.com";
+const DEFAULT_API_URL = "https://teakvault.com/api";
 const DEFAULT_AUTH_URL = "https://app.teakvault.com";
 export const CLI_OAUTH_SCOPE = "profile email offline_access";
 const SERVICE = "com.teakvault.cli";

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@teak/desktop",
   "productName": "Teak",
   "private": true,
-  "version": "1.0.53",
+  "version": "1.0.54",
   "type": "module",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/apps/docs/astro.config.ts
+++ b/apps/docs/astro.config.ts
@@ -2,6 +2,11 @@ import sitemap from "@astrojs/sitemap";
 import starlight from "@astrojs/starlight";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig, fontProviders } from "astro/config";
+import starlightLlmsTxt from "starlight-llms-txt";
+
+const devConvexSite =
+  process.env.TEAK_DEV_API_URL?.trim() ||
+  "https://reminiscent-kangaroo-59.convex.site";
 
 export default defineConfig({
   site: "https://teakvault.com",
@@ -42,6 +47,7 @@ export default defineConfig({
       },
       components: {
         Head: "./src/components/StarlightHead.astro",
+        PageTitle: "./src/components/StarlightPageTitle.astro",
       },
       logo: {
         dark: "./src/assets/logo-dark.svg",
@@ -61,6 +67,16 @@ export default defineConfig({
         },
       ],
       customCss: ["./src/styles/starlight.css"],
+      plugins: [
+        starlightLlmsTxt({
+          projectName: "Teak",
+          description:
+            "Teak is a personal knowledge hub for saving, finding, and syncing cards. Use the REST API at https://teakvault.com/api/v1, the MCP server at https://teakvault.com/mcp, and bearer auth with OAuth access tokens or teakapi_ API keys.",
+          details:
+            "Integration essentials: API discovery is available at https://teakvault.com/api, OpenAPI is at https://teakvault.com/api/openapi.json, MCP OAuth protected-resource metadata is at https://teakvault.com/.well-known/oauth-protected-resource/mcp, and legacy https://api.teakvault.com URLs continue to work.",
+          promote: ["docs/ai-agents", "docs/api", "docs/mcp", "docs/cli"],
+        }),
+      ],
       sidebar: [
         { label: "Welcome to Teak", slug: "docs" },
         { label: "Features", slug: "docs/features" },
@@ -84,6 +100,7 @@ export default defineConfig({
               slug: "docs/mcp",
               badge: { text: "New", variant: "success" },
             },
+            { label: "Teak for AI Agents", slug: "docs/ai-agents" },
             { label: "Development Guide", slug: "docs/development" },
             {
               label: "Self-Hosting",
@@ -129,6 +146,24 @@ export default defineConfig({
   ],
   vite: {
     plugins: [tailwindcss() as any],
+    server: {
+      proxy: {
+        "/api": {
+          target: devConvexSite,
+          changeOrigin: true,
+          rewrite: (path) =>
+            path === "/api" ? "/v1" : path.replace(/^\/api/, ""),
+        },
+        "/mcp": {
+          target: devConvexSite,
+          changeOrigin: true,
+        },
+        "/.well-known/oauth-protected-resource": {
+          target: devConvexSite,
+          changeOrigin: true,
+        },
+      },
+    },
   },
   security: {
     csp: true,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/docs",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "scripts": {
     "build": "astro build",
     "dev": "PORTLESS_PORT=1355 portless docs.teak astro dev",
@@ -20,6 +20,7 @@
     "@tailwindcss/vite": "^4.3.2",
     "@types/bun": "^1.3.14",
     "open-cli": "9.0.0",
+    "starlight-llms-txt": "0.11.0",
     "tailwindcss": "^4.3.2",
     "typescript": "^6.0.3",
     "vite": "^8.1.1"

--- a/apps/docs/public/.well-known/mcp.json
+++ b/apps/docs/public/.well-known/mcp.json
@@ -1,0 +1,18 @@
+{
+  "name": "Teak",
+  "description": "Remote MCP server for saving, searching, syncing, and managing Teak cards.",
+  "endpoint": "https://teakvault.com/mcp",
+  "transport": "streamable-http",
+  "auth": {
+    "type": "bearer",
+    "authorizationServer": "https://app.teakvault.com",
+    "protectedResource": "https://teakvault.com/.well-known/oauth-protected-resource/mcp",
+    "methods": ["OAuth browser sign-in", "teakapi_ API keys"]
+  },
+  "links": {
+    "docs": "https://teakvault.com/docs/mcp",
+    "api": "https://teakvault.com/docs/api",
+    "openapi": "https://teakvault.com/api/openapi.json",
+    "llms": "https://teakvault.com/llms.txt"
+  }
+}

--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -1,4 +1,23 @@
 User-agent: *
 Allow: /
 
+# AI agents and crawlers are welcome. Start at /llms.txt for docs context.
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
 Sitemap: https://teakvault.com/sitemap-index.xml

--- a/apps/docs/src/components/StarlightHead.astro
+++ b/apps/docs/src/components/StarlightHead.astro
@@ -1,7 +1,49 @@
 ---
 import { Font } from "astro:assets";
 import Default from "@astrojs/starlight/components/Head.astro";
+import { buildPageSchemas, SITE_URL } from "../lib/jsonld";
+
+const route = Astro.locals.starlightRoute;
+const pageUrl = new URL(Astro.url.pathname, SITE_URL).toString().replace(/\/$/, "");
+const markdownUrl = `${pageUrl}.md`;
+const isAiAgentsPage = route.entry.id === "docs/ai-agents";
+const schemas = buildPageSchemas({
+  title: route.entry.data.title,
+  description: route.entry.data.description,
+  url: pageUrl,
+  faqs: isAiAgentsPage
+    ? [
+        {
+          question: "How do AI agents use Teak?",
+          answer:
+            "AI agents can connect to Teak through the hosted MCP server, the REST API, the OpenAPI document, the command-line app, or the Teak Agent Skill.",
+        },
+        {
+          question: "What is the Teak MCP endpoint?",
+          answer:
+            "The production MCP endpoint is https://teakvault.com/mcp and supports browser OAuth sign-in plus teakapi_ API keys.",
+        },
+        {
+          question: "Does Teak work as a ChatGPT connector?",
+          answer:
+            "Yes. Teak exposes ChatGPT-compatible search and fetch MCP tools so ChatGPT connectors and Deep Research can find and open saved cards.",
+        },
+      ]
+    : undefined,
+});
+
+function buildJsonLd(schema: object[]) {
+  return JSON.stringify({
+    "@context": "https://schema.org",
+    "@graph": schema.map((item) => {
+      const { "@context": _, ...rest } = item as Record<string, unknown>;
+      return rest;
+    }),
+  });
+}
 ---
 
 <Default {...Astro.props}><slot /></Default>
 <Font cssVariable="--font-sn-pro" preload />
+<link rel="alternate" type="text/markdown" href={markdownUrl} />
+<script is:inline type="application/ld+json" set:html={buildJsonLd(schemas)} />

--- a/apps/docs/src/components/StarlightHead.astro
+++ b/apps/docs/src/components/StarlightHead.astro
@@ -5,7 +5,8 @@ import { buildPageSchemas, SITE_URL } from "../lib/jsonld";
 
 const route = Astro.locals.starlightRoute;
 const pageUrl = new URL(Astro.url.pathname, SITE_URL).toString().replace(/\/$/, "");
-const markdownUrl = `${pageUrl}.md`;
+const markdownUrl =
+  route.entry.id === "docs" ? `${SITE_URL}/docs/index.md` : `${pageUrl}.md`;
 const isAiAgentsPage = route.entry.id === "docs/ai-agents";
 const schemas = buildPageSchemas({
   title: route.entry.data.title,

--- a/apps/docs/src/components/StarlightPageTitle.astro
+++ b/apps/docs/src/components/StarlightPageTitle.astro
@@ -1,0 +1,86 @@
+---
+const PAGE_TITLE_ID = "_top";
+const title = Astro.locals.starlightRoute.entry.data.title;
+const pathname = Astro.url.pathname.replace(/\/$/, "");
+const markdownPath = `${pathname}.md`;
+const markdownUrl = new URL(markdownPath, "https://teakvault.com").toString();
+const prompt = `Read ${markdownUrl} and help me integrate Teak.`;
+const claudeUrl = `https://claude.ai/new?q=${encodeURIComponent(prompt)}`;
+const chatgptUrl = `https://chatgpt.com/?q=${encodeURIComponent(prompt)}`;
+---
+
+<div class="teak-page-title">
+  <h1 id={PAGE_TITLE_ID}>{title}</h1>
+  <div class="teak-doc-actions" data-markdown-path={markdownPath}>
+    <button type="button" data-copy-markdown>Copy Markdown</button>
+    <a href={claudeUrl} target="_blank" rel="noreferrer">Open in Claude</a>
+    <a href={chatgptUrl} target="_blank" rel="noreferrer">Open in ChatGPT</a>
+  </div>
+</div>
+
+<script>
+  for (const actions of document.querySelectorAll<HTMLElement>(".teak-doc-actions")) {
+    const button = actions.querySelector<HTMLButtonElement>("[data-copy-markdown]");
+    const path = actions.dataset.markdownPath;
+    if (!(button && path)) continue;
+
+    const originalLabel = button.textContent ?? "Copy Markdown";
+    button.addEventListener("click", async () => {
+      try {
+        const response = await fetch(path);
+        if (!response.ok) throw new Error("Markdown fetch failed");
+        await navigator.clipboard.writeText(await response.text());
+        button.textContent = "Copied";
+        setTimeout(() => {
+          button.textContent = originalLabel;
+        }, 1800);
+      } catch {
+        button.textContent = "Copy failed";
+        setTimeout(() => {
+          button.textContent = originalLabel;
+        }, 1800);
+      }
+    });
+  }
+</script>
+
+<style>
+  @layer starlight.core {
+    .teak-page-title {
+      margin-top: 1rem;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: var(--sl-text-h1);
+      line-height: var(--sl-line-height-headings);
+      font-weight: 600;
+      color: var(--sl-color-white);
+    }
+
+    .teak-doc-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-top: 0.85rem;
+    }
+
+    .teak-doc-actions :is(a, button) {
+      border: 1px solid var(--sl-color-gray-5);
+      border-radius: 0.375rem;
+      background: var(--sl-color-black);
+      color: var(--sl-color-gray-2);
+      cursor: pointer;
+      font: inherit;
+      font-size: var(--sl-text-sm);
+      line-height: 1;
+      padding: 0.5rem 0.65rem;
+      text-decoration: none;
+    }
+
+    .teak-doc-actions :is(a, button):hover {
+      border-color: var(--sl-color-accent);
+      color: var(--sl-color-white);
+    }
+  }
+</style>

--- a/apps/docs/src/components/StarlightPageTitle.astro
+++ b/apps/docs/src/components/StarlightPageTitle.astro
@@ -1,8 +1,10 @@
 ---
 const PAGE_TITLE_ID = "_top";
-const title = Astro.locals.starlightRoute.entry.data.title;
+const route = Astro.locals.starlightRoute;
+const title = route.entry.data.title;
 const pathname = Astro.url.pathname.replace(/\/$/, "");
-const markdownPath = `${pathname}.md`;
+const markdownPath =
+  route.entry.id === "docs" ? "/docs/index.md" : `${pathname}.md`;
 const markdownUrl = new URL(markdownPath, "https://teakvault.com").toString();
 const prompt = `Read ${markdownUrl} and help me integrate Teak.`;
 const claudeUrl = `https://claude.ai/new?q=${encodeURIComponent(prompt)}`;

--- a/apps/docs/src/content/changelog/2026-07.mdx
+++ b/apps/docs/src/content/changelog/2026-07.mdx
@@ -16,3 +16,6 @@ date: "2026-07-05"
 - Teak now has a command-line app for saving, searching, editing, favoriting, deleting, syncing, and listing tags from your terminal.
 - The API can now create file cards through direct uploads, so command-line workflows can save images, videos, audio, and documents.
 - The command-line app now signs in reliably from npm installs, includes setup docs directly on the npm package page, and ships an Agent Skill for AI assistants that work with Teak.
+- The API and MCP server now have simpler addresses at teakvault.com/api and teakvault.com/mcp. Existing api.teakvault.com links and API keys keep working, so no action is needed.
+- MCP clients can now browse cards, look up a card, list tags, sync changes, run bulk edits, and create file-upload links.
+- Teak now works as a ChatGPT connector with search and fetch support, and the docs include AI-agent pages, markdown copies, and llms.txt files for easier setup.

--- a/apps/docs/src/content/docs/docs/ai-agents.mdx
+++ b/apps/docs/src/content/docs/docs/ai-agents.mdx
@@ -1,0 +1,70 @@
+---
+title: Teak for AI Agents
+description: Connect AI agents to Teak with MCP, ChatGPT connectors, REST, CLI, and llms.txt
+---
+
+Teak gives AI agents a private memory layer for saved links, notes, files, tags, and design references. Agents can use the hosted MCP server at `https://teakvault.com/mcp`, the REST API at `https://teakvault.com/api/v1`, or the command-line app, with browser OAuth or `teakapi_` API keys for authentication.
+
+## What can agents do with Teak?
+
+Agents can save new cards, search existing cards, fetch a card by ID, list tags, sync changes, run bulk updates, favorite or delete cards, and create upload URLs for file cards. The MCP server and REST API share the same card operations, so behavior is consistent across tools.
+
+## How do I connect Claude?
+
+```bash
+claude mcp add --transport http teak https://teakvault.com/mcp
+```
+
+Start the MCP connection in Claude and complete browser sign-in when prompted. API keys also work for clients that let you set an `Authorization: Bearer <token>` header.
+
+## How do I connect ChatGPT or Deep Research?
+
+Use `https://teakvault.com/mcp` as the remote MCP server URL. Teak exposes the plain `search` and `fetch` tools expected by ChatGPT connectors:
+
+- `search` finds matching cards and returns IDs, titles, and Teak app URLs.
+- `fetch` opens a specific card and returns readable text plus metadata.
+
+## How do I use the REST API?
+
+Use the production base URL:
+
+```text
+https://teakvault.com/api/v1
+```
+
+Start with discovery and the OpenAPI document:
+
+```text
+https://teakvault.com/api
+https://teakvault.com/api/openapi.json
+```
+
+Existing `https://api.teakvault.com` URLs still work, but new integrations should use the apex paths above.
+
+## What should coding agents read first?
+
+- `https://teakvault.com/llms.txt` for the compact documentation map
+- `https://teakvault.com/llms-full.txt` for the full docs context
+- `https://teakvault.com/docs/api.md` for the REST API contract
+- `https://teakvault.com/docs/mcp.md` for MCP setup and tools
+- `https://teakvault.com/.well-known/mcp.json` for remote MCP discovery metadata
+
+## Can agents use the command line?
+
+Yes. Install the Teak CLI and sign in:
+
+```bash
+npx teak-cli@latest login
+```
+
+Then use commands such as:
+
+```bash
+teak cards search design
+teak cards create "https://teakvault.com"
+teak tags
+```
+
+## Is there an Agent Skill?
+
+Yes. Teak ships a public Agent Skill for assistants that support skills-based workflows. Use it when an agent needs to save, search, retrieve, update, favorite, delete, or sync Teak cards through the CLI, API, SDK, or MCP server.

--- a/apps/docs/src/content/docs/docs/api.mdx
+++ b/apps/docs/src/content/docs/docs/api.mdx
@@ -3,24 +3,29 @@ title: API
 description: Public Teak API for creating, querying, and syncing cards
 ---
 
-Teak provides a public API at `https://api.teakvault.com/v1`.
+Teak provides a public API at `https://teakvault.com/api/v1`.
+
+> The API moved from `api.teakvault.com` to `teakvault.com/api`. Existing
+> `api.teakvault.com` URLs and API keys keep working, but new integrations
+> should use the simpler `teakvault.com/api` address.
 
 ## Base URLs
 
-- Production: `https://api.teakvault.com/v1`
-- Local development: `https://reminiscent-kangaroo-59.convex.site/v1`
-- OpenAPI: `https://api.teakvault.com/openapi.json`
+- Production: `https://teakvault.com/api/v1`
+- Local development: `http://docs.teak.localhost:1355/api/v1`
+- OpenAPI: `https://teakvault.com/api/openapi.json`
+- Legacy production: `https://api.teakvault.com/v1`
 
 ## MCP Endpoint
 
 Teak also exposes a remote MCP server:
 
-- Production: `https://api.teakvault.com/mcp`
-- Local development: `https://reminiscent-kangaroo-59.convex.site/mcp`
+- Production: `https://teakvault.com/mcp`
+- Local development: `http://docs.teak.localhost:1355/mcp`
+- Legacy production: `https://api.teakvault.com/mcp`
 
 See the dedicated [MCP docs](./mcp) for tool contracts and JSON-RPC examples.
-API discovery always returns the canonical production MCP URL, including when
-the API is served through its managed backend proxy.
+API discovery always returns the canonical production MCP URL.
 
 ## Authentication
 

--- a/apps/docs/src/content/docs/docs/development.mdx
+++ b/apps/docs/src/content/docs/docs/development.mdx
@@ -43,8 +43,8 @@ import { Steps, FileTree } from "@astrojs/starlight/components";
 
 - Web App: http://app.teak.localhost:1355
 - Admin: http://app.teak.localhost:1355/admin
-- Public API: https://reminiscent-kangaroo-59.convex.site/v1
-- MCP Endpoint: https://reminiscent-kangaroo-59.convex.site/mcp
+- Public API: http://docs.teak.localhost:1355/api/v1
+- MCP Endpoint: http://docs.teak.localhost:1355/mcp
 - Convex Dashboard: opens after `bunx convex dev`
 - Mobile: Expo Go or simulator
 - Extension: Chrome dev mode
@@ -150,7 +150,7 @@ bun run clean            # Clear Turborepo caches
 
 ### Public API and MCP
 
-The public REST API, MCP endpoint, discovery routes, OpenAPI spec, and SDK live in `packages/convex`. Start Convex to serve the HTTP routes from the deployment's `.convex.site` URL.
+The public REST API, MCP endpoint, discovery routes, OpenAPI spec, and SDK live in `packages/convex`. Start Convex to serve the HTTP routes, then use the docs dev proxy for local API and MCP URLs.
 
 Example:
 
@@ -158,10 +158,22 @@ Example:
 bun run dev:convex
 ```
 
-The same Convex HTTP surface exposes the REST API at `/v1`, MCP at `/mcp`, `GET /healthz`, `GET /openapi.json`, and OAuth protected-resource metadata.
+The docs dev server proxies `/api`, `/mcp`, and OAuth protected-resource metadata to the Convex dev deployment. That gives local docs, examples, and smoke tests the same path shape as production: `/api/v1` and `/mcp`.
+
+### MCP Registry
+
+The repo includes `server.json` for the MCP registry under the `com.teakvault/mcp` namespace. Publishing is manual because the namespace requires DNS verification for `teakvault.com`:
+
+```bash
+npm install -g mcp-publisher
+mcp-publisher login dns
+mcp-publisher publish
+```
+
+Follow the CLI prompt to add the DNS TXT record, then publish once verification passes.
 
 ### Environment Variables
 
 See **[Self-Hosting → Environment settings](./self-hosting#environment-settings)** for every env var required across web, mobile, extension, and the Convex backend.
 
-Optional local overrides: `TEAK_DEV_APP_URL` (default: `http://app.teak.localhost:1355`), `TEAK_DEV_API_URL` (default: `https://reminiscent-kangaroo-59.convex.site`), `TEAK_DEV_DOCS_URL` (default: `http://docs.teak.localhost:1355`).
+Optional local overrides: `TEAK_DEV_APP_URL` (default: `http://app.teak.localhost:1355`), `TEAK_DEV_API_URL` (only needed when your Convex dev site differs from the repo default), `TEAK_DEV_DOCS_URL` (default: `http://docs.teak.localhost:1355`).

--- a/apps/docs/src/content/docs/docs/mcp.mdx
+++ b/apps/docs/src/content/docs/docs/mcp.mdx
@@ -3,12 +3,18 @@ title: MCP
 description: Remote MCP server for Teak card operations
 ---
 
-Teak provides a remote MCP server at `https://api.teakvault.com/mcp`.
+Teak provides a remote MCP server at `https://teakvault.com/mcp`.
+
+> The MCP server moved from `api.teakvault.com/mcp` to `teakvault.com/mcp`.
+> Existing `api.teakvault.com` MCP connections keep working, but new clients
+> should use the apex URL.
 
 ## Base URLs
 
-- Production: `https://api.teakvault.com/mcp`
-- Local development: `https://reminiscent-kangaroo-59.convex.site/mcp`
+- Production: `https://teakvault.com/mcp`
+- Local development: `http://docs.teak.localhost:1355/mcp`
+- Legacy production: `https://api.teakvault.com/mcp`
+- Discovery manifest: `https://teakvault.com/.well-known/mcp.json`
 
 ## Authentication
 
@@ -21,7 +27,7 @@ Spec-compliant MCP clients authenticate with a browser-based OAuth flow. On firs
 For example, with Claude:
 
 ```bash
-claude mcp add --transport http teak https://api.teakvault.com/mcp
+claude mcp add --transport http teak https://teakvault.com/mcp
 ```
 
 Then start the MCP connection (for example, run `/mcp` in Claude) and complete the browser sign-in when prompted.
@@ -36,7 +42,7 @@ Authorization: Bearer teakapi_secret_live_a1b2c3d4_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 Generate and manage API keys in Teak Settings: `https://app.teakvault.com/settings`.
 
-Unauthenticated requests receive `401` with a `WWW-Authenticate` header pointing to the OAuth protected-resource metadata at `/.well-known/oauth-protected-resource`, which clients use to begin the browser sign-in flow.
+Unauthenticated requests receive `401` with a `WWW-Authenticate` header pointing to the OAuth protected-resource metadata at `https://teakvault.com/.well-known/oauth-protected-resource/mcp`, which clients use to begin the browser sign-in flow.
 
 ## Transport
 
@@ -53,6 +59,12 @@ shown above, so MCP clients validate and connect to the same public resource.
 - `teak_v1_create_card`
   - Input: `{ content: string }`
   - Output: `{ status: "created", cardId: string, appUrl: string }`
+- `teak_v1_list_cards`
+  - Input: `{ limit?: number, cursor?: string, type?: string, favorited?: boolean, tag?: string, sort?: "newest" | "oldest", createdAfter?: number, createdBefore?: number }`
+  - Output: `{ items: Card[], pageInfo: { hasMore: boolean, nextCursor: string | null } }`
+- `teak_v1_get_card`
+  - Input: `{ cardId: string }`
+  - Output: full card object
 - `teak_v1_search_cards`
   - Input: `{ q?: string, limit?: number }`
   - Output: `{ items: Card[], total: number }`
@@ -68,6 +80,25 @@ shown above, so MCP clients validate and connect to the same public resource.
 - `teak_v1_delete_card`
   - Input: `{ cardId: string, confirm: true }`
   - Output: `{ status: "deleted", cardId: string }`
+- `teak_v1_list_tags`
+  - Input: `{}`
+  - Output: `{ items: { name: string, count: number }[] }`
+- `teak_v1_get_card_changes`
+  - Input: `{ since: number, cursor?: string, limit?: number }`
+  - Output: `{ items: Card[], deletedIds: string[], pageInfo: { hasMore: boolean, nextCursor: string | null } }`
+- `teak_v1_bulk_cards`
+  - Input: `{ operation: "create" | "update" | "favorite" | "delete", items: object[], confirm?: true }`
+  - Output: bulk operation results; delete batches require `confirm: true`
+- `teak_v1_create_upload`
+  - Input: `{ fileName: string, mimeType: string, fileSize: number }`
+  - Output: `{ uploadUrl: string, fileKey: string, method: "PUT", maxFileSize: number, expiresIn: number }`
+
+## ChatGPT Connectors
+
+Teak also exposes the plain `search` and `fetch` tools expected by ChatGPT connectors and Deep Research:
+
+- `search` accepts `{ query: string }` and returns `{ results: [{ id, title, url }] }`.
+- `fetch` accepts `{ id: string }` and returns `{ id, title, text, url, metadata }`.
 
 ## Error Format
 

--- a/apps/docs/src/content/docs/docs/self-hosting.mdx
+++ b/apps/docs/src/content/docs/docs/self-hosting.mdx
@@ -127,12 +127,13 @@ VITE_WEB_URL=https://app.yourdomain.com           # Desktop only; defaults to ht
 ### Public API and MCP
 
 ```bash
-PUBLIC_API_URL=https://api.yourdomain.com        # Optional: public API origin used in MCP discovery
+PUBLIC_API_URL=https://api.yourdomain.com        # Optional: public API origin used in discovery
+PUBLIC_MCP_URL=https://api.yourdomain.com/mcp    # Optional: defaults to PUBLIC_API_URL + /mcp
 AUTH_ISSUER_URL=https://app.yourdomain.com       # Optional: OAuth issuer override for MCP discovery
 TEAK_DEV_API_URL=https://deployment.convex.site  # Optional local override
 ```
 
-Convex serves the authenticated `/v1` REST API, `/mcp` MCP endpoint, `/healthz`, `/openapi.json`, and OAuth protected-resource metadata from the deployment's `.convex.site` domain. Teak production keeps `https://api.teakvault.com` compatible through the edge rewrite in `packages/convex/vercel.json`.
+Convex serves the authenticated `/v1` REST API, `/mcp` MCP endpoint, `/healthz`, `/openapi.json`, and OAuth protected-resource metadata from the deployment's `.convex.site` domain. Teak production exposes those routes through apex rewrites at `https://teakvault.com/api` and `https://teakvault.com/mcp`, while the retained `https://api.teakvault.com` rewrite keeps older integrations working.
 
 ## Where to get the values
 

--- a/apps/docs/src/lib/jsonld.ts
+++ b/apps/docs/src/lib/jsonld.ts
@@ -27,6 +27,34 @@ export const websiteSchema = {
   publisher: { "@id": `${SITE_URL}/#organization` },
 } as const;
 
+export const softwareApplicationSchema = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "@id": `${SITE_URL}/#software`,
+  name: SITE_NAME,
+  applicationCategory: "ProductivityApplication",
+  operatingSystem: "macOS, iOS, Web, Chrome, Raycast",
+  url: SITE_URL,
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+  publisher: { "@id": `${SITE_URL}/#organization` },
+} as const;
+
+export const webApiSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebAPI",
+  "@id": `${SITE_URL}/api/#webapi`,
+  name: "Teak API",
+  description:
+    "REST API and MCP server for saving, searching, syncing, and managing Teak cards.",
+  documentation: `${SITE_URL}/docs/api`,
+  endpointUrl: `${SITE_URL}/api/v1`,
+  provider: { "@id": `${SITE_URL}/#organization` },
+} as const;
+
 /**
  * Auto-generate common JSON-LD schemas from page metadata.
  * Replaces the old per-page manual schema builder calls.
@@ -40,6 +68,18 @@ export function buildPageSchemas(opts: {
   faqs?: { question: string; answer: string }[];
 }) {
   const schemas: object[] = [organizationSchema, websiteSchema];
+
+  if (opts.url === SITE_URL || opts.url.startsWith(`${SITE_URL}/docs`)) {
+    schemas.push(softwareApplicationSchema);
+  }
+
+  if (
+    opts.url.startsWith(`${SITE_URL}/docs/api`) ||
+    opts.url.startsWith(`${SITE_URL}/docs/mcp`) ||
+    opts.url.startsWith(`${SITE_URL}/docs/ai-agents`)
+  ) {
+    schemas.push(webApiSchema);
+  }
 
   // Article or WebPage
   if (opts.type === "article") {

--- a/apps/docs/src/pages/docs/[...slug].md.ts
+++ b/apps/docs/src/pages/docs/[...slug].md.ts
@@ -3,7 +3,7 @@ import { getCollection } from "astro:content";
 import type { CollectionEntry } from "astro:content";
 
 const toRouteSlug = (id: string) =>
-  id.replace(/^docs\//, "").replace(/\/index$/, "index");
+  id === "docs" ? "index" : id.replace(/^docs\//, "").replace(/\/index$/, "");
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const docs = await getCollection(

--- a/apps/docs/src/pages/docs/[...slug].md.ts
+++ b/apps/docs/src/pages/docs/[...slug].md.ts
@@ -1,0 +1,24 @@
+import type { APIRoute, GetStaticPaths } from "astro";
+import { getCollection } from "astro:content";
+import type { CollectionEntry } from "astro:content";
+
+const toRouteSlug = (id: string) =>
+  id.replace(/^docs\//, "").replace(/\/index$/, "index");
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const docs = await getCollection(
+    "docs",
+    (entry: CollectionEntry<"docs">) => !entry.data.draft
+  );
+  return docs.map((entry: CollectionEntry<"docs">) => ({
+    params: { slug: toRouteSlug(entry.id) },
+    props: { body: entry.body },
+  }));
+};
+
+export const GET: APIRoute<{ body: string }> = ({ props }) =>
+  new Response(props.body, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,5 +1,31 @@
 {
   "buildCommand": "bun run build",
+  "rewrites": [
+    {
+      "source": "/api",
+      "destination": "https://uncommon-ladybug-882.convex.site/v1"
+    },
+    {
+      "source": "/api/:path*",
+      "destination": "https://uncommon-ladybug-882.convex.site/:path*"
+    },
+    {
+      "source": "/mcp",
+      "destination": "https://uncommon-ladybug-882.convex.site/mcp"
+    },
+    {
+      "source": "/mcp/:path*",
+      "destination": "https://uncommon-ladybug-882.convex.site/mcp/:path*"
+    },
+    {
+      "source": "/.well-known/oauth-protected-resource",
+      "destination": "https://uncommon-ladybug-882.convex.site/.well-known/oauth-protected-resource"
+    },
+    {
+      "source": "/.well-known/oauth-protected-resource/mcp",
+      "destination": "https://uncommon-ladybug-882.convex.site/.well-known/oauth-protected-resource/mcp"
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teak/extension",
   "description": "Teak - Your Personal Knowledge Hub. Save, organize, and rediscover web content, text selections, and ideas effortlessly.",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "author": "Praveen Juge (hi@praveenjuge.com)",
   "homepage": "https://teakvault.com",
   "type": "module",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/mobile",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "main": "expo-router/entry",
   "scripts": {
     "build": "expo export --platform web --clear",

--- a/apps/raycast/README.md
+++ b/apps/raycast/README.md
@@ -35,4 +35,4 @@ Prefer an API key? Open the extension preferences and paste a key from Teak Sett
 - **Sign-in issues**: Use **Sign Out** from any command's action panel, then run a command again to re-authorize.
 - **Invalid key errors** (API key users): regenerate the key in Teak Settings > Manage API Keys, then update extension preferences.
 - **Rate limited errors**: wait briefly and retry.
-- **Network errors**: verify connectivity to `app.teakvault.com` and `api.teakvault.com`.
+- **Network errors**: verify connectivity to `app.teakvault.com` and `teakvault.com/api`.

--- a/apps/raycast/package.json
+++ b/apps/raycast/package.json
@@ -1,7 +1,7 @@
 {
   "name": "teak-raycast",
   "title": "Teak",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "private": true,
   "license": "MIT",
   "description": "Save ideas fast, search your Teak cards, and access favorites directly from Raycast.",

--- a/apps/raycast/src/lib/constants.ts
+++ b/apps/raycast/src/lib/constants.ts
@@ -45,7 +45,7 @@ const DEV_API_URL = `${resolveDevUrl(
   DEFAULT_TEAK_DEV_API_URL,
   "TEAK_DEV_API_URL",
 )}/v1`;
-const PROD_API_URL = "https://api.teakvault.com/v1";
+const PROD_API_URL = "https://teakvault.com/api/v1";
 
 const normalizeUrl = (url: string): string =>
   url.endsWith("/") ? url.slice(0, -1) : url;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/web",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/cli": {
       "name": "teak-cli",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "bin": {
         "teak": "./dist/index.js",
       },
@@ -30,7 +30,7 @@
     },
     "apps/desktop": {
       "name": "@teak/desktop",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.0",
         "@teak/convex": "workspace:*",
@@ -62,7 +62,7 @@
     },
     "apps/docs": {
       "name": "@teak/docs",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "dependencies": {
         "@astrojs/check": "^0.9.9",
         "@astrojs/sitemap": "^3.7.3",
@@ -73,6 +73,7 @@
         "@tailwindcss/vite": "^4.3.2",
         "@types/bun": "^1.3.14",
         "open-cli": "9.0.0",
+        "starlight-llms-txt": "0.11.0",
         "tailwindcss": "^4.3.2",
         "typescript": "^6.0.3",
         "vite": "^8.1.1",
@@ -80,7 +81,7 @@
     },
     "apps/extension": {
       "name": "@teak/extension",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "dependencies": {
         "@convex-dev/better-auth": "0.12.2",
         "@tailwindcss/vite": "^4.3.0",
@@ -103,7 +104,7 @@
     },
     "apps/mobile": {
       "name": "@teak/mobile",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "dependencies": {
         "@better-auth/expo": "1.6.11",
         "@convex-dev/better-auth": "0.12.2",
@@ -156,7 +157,7 @@
     },
     "apps/raycast": {
       "name": "teak-raycast",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "dependencies": {
         "@raycast/api": "^1.104.19",
         "@raycast/utils": "^2.2.7",
@@ -170,7 +171,7 @@
     },
     "apps/web": {
       "name": "@teak/web",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "dependencies": {
         "@convex-dev/better-auth": "^0.12.2",
         "@polar-sh/checkout": "^0.2.1",
@@ -207,7 +208,7 @@
     },
     "packages/convex": {
       "name": "@teak/convex",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "dependencies": {
         "@ai-sdk/groq": "^3.0.39",
         "@aws-sdk/client-s3": "3.1069.0",
@@ -246,7 +247,7 @@
     },
     "packages/ui": {
       "name": "@teak/ui",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -1695,6 +1696,8 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
+    "@types/braces": ["@types/braces@3.0.5", "", {}, "sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w=="],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
@@ -1742,6 +1745,8 @@
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/mdx": ["@types/mdx@2.0.13", "", {}, "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw=="],
+
+    "@types/micromatch": ["@types/micromatch@4.0.10", "", { "dependencies": { "@types/braces": "*" } }, "sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ=="],
 
     "@types/minimatch": ["@types/minimatch@3.0.5", "", {}, "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="],
 
@@ -2783,6 +2788,8 @@
 
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
+    "hast-util-to-mdast": ["hast-util-to-mdast@10.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-phrasing": "^3.0.0", "hast-util-to-html": "^9.0.0", "hast-util-to-text": "^4.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "mdast-util-to-string": "^4.0.0", "rehype-minify-whitespace": "^6.0.0", "trim-trailing-lines": "^2.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ=="],
+
     "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
 
     "hast-util-to-string": ["hast-util-to-string@3.0.1", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A=="],
@@ -3745,11 +3752,15 @@
 
     "rehype-format": ["rehype-format@5.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-format": "^1.0.0" } }, "sha512-zvmVru9uB0josBVpr946OR8ui7nJEdzZobwLOOqHb/OOD88W0Vk2SqLwoVOj0fM6IPCCO6TaV9CvQvJMWwukFQ=="],
 
+    "rehype-minify-whitespace": ["rehype-minify-whitespace@6.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-minify-whitespace": "^1.0.0" } }, "sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw=="],
+
     "rehype-parse": ["rehype-parse@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-from-html": "^2.0.0", "unified": "^11.0.0" } }, "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag=="],
 
     "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
 
     "rehype-recma": ["rehype-recma@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "hast-util-to-estree": "^3.0.0" } }, "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw=="],
+
+    "rehype-remark": ["rehype-remark@10.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "hast-util-to-mdast": "^10.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ=="],
 
     "rehype-stringify": ["rehype-stringify@10.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-html": "^9.0.0", "unified": "^11.0.0" } }, "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA=="],
 
@@ -3951,6 +3962,8 @@
 
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
 
+    "starlight-llms-txt": ["starlight-llms-txt@0.11.0", "", { "dependencies": { "@astrojs/mdx": "^7.0.0", "@types/hast": "^3.0.4", "@types/micromatch": "^4.0.10", "github-slugger": "^2.0.0", "hast-util-select": "^6.0.4", "micromatch": "^4.0.8", "rehype-parse": "^9.0.1", "rehype-remark": "^10.0.1", "remark-gfm": "^4.0.1", "remark-stringify": "^11.0.0", "unified": "^11.0.5", "unist-util-remove": "^4.0.0" }, "peerDependencies": { "@astrojs/starlight": ">=0.41.0", "astro": "^7.0.0" } }, "sha512-83TU5zPgJhL9fXIWAOWjQjyQ6EKocshEjJyA4zOJjOqu/oxQsrTpYGYxjHLyfZe4LRD52N9eCuykSkaIYwUyDw=="],
+
     "stat-mode": ["stat-mode@1.0.0", "", {}, "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
@@ -4097,6 +4110,8 @@
 
     "trim-repeated": ["trim-repeated@1.0.0", "", { "dependencies": { "escape-string-regexp": "^1.0.2" } }, "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg=="],
 
+    "trim-trailing-lines": ["trim-trailing-lines@2.1.0", "", {}, "sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg=="],
+
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
     "truncate-utf8-bytes": ["truncate-utf8-bytes@1.0.2", "", { "dependencies": { "utf8-byte-length": "^1.0.1" } }, "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ=="],
@@ -4174,6 +4189,8 @@
     "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
 
     "unist-util-position-from-estree": ["unist-util-position-from-estree@2.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ=="],
+
+    "unist-util-remove": ["unist-util-remove@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg=="],
 
     "unist-util-remove-position": ["unist-util-remove-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "private": true,
   "packageManager": "bun@1.3.5",
   "workspaces": [

--- a/packages/convex/__tests__/mcp.test.ts
+++ b/packages/convex/__tests__/mcp.test.ts
@@ -23,11 +23,29 @@ interface JsonRpcSuccess {
 const TEST_AUTHORIZATION = `Bearer teakapi_secret_live_a1b2c3d4_${"f".repeat(64)}`;
 
 const originalPublicApiUrl = process.env.PUBLIC_API_URL;
+const originalPublicMcpUrl = process.env.PUBLIC_MCP_URL;
 const originalAuthIssuerUrl = process.env.AUTH_ISSUER_URL;
 const originalSiteUrl = process.env.SITE_URL;
+const EXPECTED_TOOL_NAMES = [
+  "fetch",
+  "search",
+  "teak_v1_bulk_cards",
+  "teak_v1_create_card",
+  "teak_v1_create_upload",
+  "teak_v1_delete_card",
+  "teak_v1_get_card",
+  "teak_v1_get_card_changes",
+  "teak_v1_list_cards",
+  "teak_v1_list_favorite_cards",
+  "teak_v1_list_tags",
+  "teak_v1_search_cards",
+  "teak_v1_set_card_favorite",
+  "teak_v1_update_card",
+];
 
 afterEach(() => {
   process.env.PUBLIC_API_URL = originalPublicApiUrl;
+  process.env.PUBLIC_MCP_URL = originalPublicMcpUrl;
   process.env.AUTH_ISSUER_URL = originalAuthIssuerUrl;
   process.env.SITE_URL = originalSiteUrl;
 });
@@ -85,7 +103,7 @@ describe("Convex MCP endpoint", () => {
       error: "Missing or invalid Authorization header",
     });
     expect(response.headers.get("WWW-Authenticate")).toContain(
-      "/.well-known/oauth-protected-resource"
+      'resource_metadata="https://teakvault.com/.well-known/oauth-protected-resource/mcp"'
     );
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
   });
@@ -102,7 +120,7 @@ describe("Convex MCP endpoint", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
     expect(await response.json()).toEqual({
-      resource: "https://api.teakvault.com/mcp",
+      resource: "https://teakvault.com/mcp",
       authorization_servers: ["https://app.teakvault.com"],
       bearer_methods_supported: ["header"],
       scopes_supported: ["profile", "email", "offline_access"],
@@ -132,8 +150,39 @@ describe("Convex MCP endpoint", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({
-      resource: "https://api.teakvault.com/mcp",
+      resource: "https://teakvault.com/mcp",
     });
+  });
+
+  test("derives self-hosted MCP metadata from PUBLIC_API_URL", async () => {
+    process.env.PUBLIC_API_URL = "https://api.selfhost.example";
+    process.env.PUBLIC_MCP_URL = "";
+
+    const response = await handleOauthProtectedResourceV1Request(
+      new Request(
+        "https://api.selfhost.example/.well-known/oauth-protected-resource"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      resource: "https://api.selfhost.example/mcp",
+    });
+
+    const challenge = await handleMcpV1Request(
+      { runMutation: mock(), runQuery: mock() },
+      new Request("https://api.selfhost.example/mcp", {
+        method: "POST",
+        headers: {
+          Accept: "application/json, text/event-stream",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" }),
+      })
+    );
+    expect(challenge.headers.get("WWW-Authenticate")).toContain(
+      'resource_metadata="https://api.selfhost.example/.well-known/oauth-protected-resource/mcp"'
+    );
   });
 
   test("lets unauthenticated OPTIONS /mcp preflight through", async () => {
@@ -161,15 +210,10 @@ describe("Convex MCP endpoint", () => {
     );
   });
 
-  test("initializes and lists the six teak_v1 tools", async () => {
-    expect(TEAK_V1_TOOLS.map((tool) => tool.name).sort()).toEqual([
-      "teak_v1_create_card",
-      "teak_v1_delete_card",
-      "teak_v1_list_favorite_cards",
-      "teak_v1_search_cards",
-      "teak_v1_set_card_favorite",
-      "teak_v1_update_card",
-    ]);
+  test("initializes and lists the Teak and ChatGPT-compatible tools", async () => {
+    expect(TEAK_V1_TOOLS.map((tool) => tool.name).sort()).toEqual(
+      EXPECTED_TOOL_NAMES
+    );
 
     const runMutation = mock().mockResolvedValue({
       keyId: "key_1",
@@ -192,14 +236,7 @@ describe("Convex MCP endpoint", () => {
     );
     const payload = (await listResponse.json()) as JsonRpcSuccess;
     const names = (payload.result.tools ?? []).map((tool) => tool.name).sort();
-    expect(names).toEqual([
-      "teak_v1_create_card",
-      "teak_v1_delete_card",
-      "teak_v1_list_favorite_cards",
-      "teak_v1_search_cards",
-      "teak_v1_set_card_favorite",
-      "teak_v1_update_card",
-    ]);
+    expect(names).toEqual(EXPECTED_TOOL_NAMES);
   });
 
   test("caches successful MCP bearer validation briefly", async () => {
@@ -264,61 +301,101 @@ describe("Convex MCP endpoint", () => {
         return Promise.resolve(new Response(null, { status: 204 }));
       }
       return Promise.resolve(
-        new Response(JSON.stringify({ status: "created", cardId: "card_1" }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        })
+        new Response(
+          JSON.stringify({
+            id: "card_1",
+            appUrl: "https://app.teakvault.com/?card=card_1",
+            cardId: "card_1",
+            content: "Design note",
+            deletedIds: ["card_2"],
+            fileKey: "users/user_1/file/image.png",
+            items: [{ id: "card_1", metadataTitle: "Design note" }],
+            metadataTitle: "Design note",
+            pageInfo: { hasMore: false, nextCursor: null },
+            status: "created",
+            total: 1,
+            uploadUrl: "https://upload.example",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        )
       );
     }) as PublicApiToolExecutor;
-    for (const toolCall of [
-      {
-        id: 10,
-        name: "teak_v1_create_card",
-        arguments: { content: "https://example.com" },
-      },
-      {
-        id: 11,
-        name: "teak_v1_search_cards",
-        arguments: { q: "design", limit: 10 },
-      },
-      {
-        id: 12,
-        name: "teak_v1_delete_card",
-        arguments: { cardId: "card_1", confirm: true },
-      },
-    ] as const) {
+    const toolCalls = [
+      ["teak_v1_list_cards", { limit: 25, cursor: "cursor_1", tag: "design" }],
+      ["teak_v1_create_card", { content: "https://example.com" }],
+      ["teak_v1_search_cards", { q: "design", limit: 10 }],
+      ["teak_v1_delete_card", { cardId: "card_1", confirm: true }],
+      ["teak_v1_get_card", { cardId: "card_1" }],
+      ["teak_v1_list_tags", {}],
+      ["teak_v1_get_card_changes", { since: 1_710_000_000_000, limit: 10 }],
+      [
+        "teak_v1_bulk_cards",
+        { operation: "favorite", items: [{ cardId: "card_1", isFavorited: true }] },
+      ],
+      [
+        "teak_v1_create_upload",
+        { fileName: "image.png", mimeType: "image/png", fileSize: 123 },
+      ],
+      ["search", { query: "design" }],
+      ["fetch", { id: "card_1" }],
+    ] as const;
+    for (const [index, toolCall] of toolCalls.entries()) {
       const result = await callTeakV1Tool(
-        toolCall.name,
-        toolCall.arguments,
-        mcpRequest({ jsonrpc: "2.0", id: toolCall.id, method: "tools/call" }),
+        toolCall[0],
+        toolCall[1],
+        mcpRequest({ jsonrpc: "2.0", id: index + 9, method: "tools/call" }),
         executor
       );
       expect(result.isError).toBeUndefined();
     }
 
-    expect(captured).toEqual([
-      {
-        path: "/v1/cards",
-        method: "POST",
-        authorization: TEST_AUTHORIZATION,
-        body: { content: "https://example.com" },
-        query: undefined,
-      },
-      {
-        path: "/v1/cards/search",
-        method: "GET",
-        authorization: TEST_AUTHORIZATION,
-        body: undefined,
-        query: { q: "design", limit: 10 },
-      },
-      {
-        path: "/v1/cards/card_1",
-        method: "DELETE",
-        authorization: TEST_AUTHORIZATION,
-        body: undefined,
-        query: undefined,
-      },
+    expect(captured.map(({ method, path }) => `${method} ${path}`)).toEqual([
+      "GET /v1/cards",
+      "POST /v1/cards",
+      "GET /v1/cards/search",
+      "DELETE /v1/cards/card_1",
+      "GET /v1/cards/card_1",
+      "GET /v1/tags",
+      "GET /v1/cards/changes",
+      "POST /v1/cards/bulk",
+      "POST /v1/uploads",
+      "GET /v1/cards/search",
+      "GET /v1/cards/card_1",
     ]);
+    expect(captured.every((call) => call.authorization === TEST_AUTHORIZATION)).toBe(true);
+    expect(captured[0]?.query).toEqual({
+      cursor: "cursor_1",
+      tag: "design",
+      limit: 25,
+    });
+    expect(captured[1]?.body).toEqual({ content: "https://example.com" });
+    expect(captured[7]?.body).toEqual({
+      operation: "favorite",
+      items: [{ cardId: "card_1", isFavorited: true }],
+    });
+    expect(captured[8]?.body).toEqual({
+      fileName: "image.png",
+      mimeType: "image/png",
+      fileSize: 123,
+    });
+    expect(captured[9]?.query).toEqual({ q: "design", limit: 10 });
+  });
+
+  test("requires confirm=true for bulk delete tool", async () => {
+    const result = await callTeakV1Tool(
+      "teak_v1_bulk_cards",
+      { operation: "delete", items: [{ cardId: "card_1" }] },
+      mcpRequest({ jsonrpc: "2.0", id: 30, method: "tools/call" }),
+      mock(
+        async () => new Response(JSON.stringify({}), { status: 200 })
+      ) as PublicApiToolExecutor
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text.toLowerCase()).toContain("confirm");
   });
 
   test("requires confirm=true for delete tool", async () => {
@@ -332,7 +409,7 @@ describe("Convex MCP endpoint", () => {
     );
 
     expect(result.isError).toBe(true);
-    expect(result.content?.[0]?.text.toLowerCase()).toContain("confirm");
+    expect(result.content?.[0]?.text.toLowerCase()).toContain("expected true");
   });
 
   test("maps v1 errors to MCP isError payloads", async () => {

--- a/packages/convex/__tests__/publicApiGateway.test.ts
+++ b/packages/convex/__tests__/publicApiGateway.test.ts
@@ -45,7 +45,7 @@ describe("Convex public API metadata", () => {
     expect(payload.endpoints).toContain("POST /v1/cards");
     expect(payload.endpoints).toContain("POST /v1/uploads");
     expect(payload.mcp).toEqual({
-      endpoint: "https://api.teakvault.com/mcp",
+      endpoint: "https://teakvault.com/mcp",
       transport: "streamable-http",
       auth: "Authorization: Bearer <token> (OAuth access token or teakapi_ API key)",
     });
@@ -60,7 +60,7 @@ describe("Convex public API metadata", () => {
 
     expect(response.status).toBe(200);
     const payload = await response.json();
-    expect(payload.mcp.endpoint).toBe("https://api.teakvault.com/mcp");
+    expect(payload.mcp.endpoint).toBe("https://teakvault.com/mcp");
   });
 
   test("answers REST CORS preflight", async () => {
@@ -95,6 +95,7 @@ describe("Convex public API metadata", () => {
 
   test("uses the Convex dev site URL in the OpenAPI spec", () => {
     expect(openApiSpec.servers).toEqual([
+      { url: "https://teakvault.com/api" },
       { url: "https://api.teakvault.com" },
       { url: "https://reminiscent-kangaroo-59.convex.site" },
     ]);

--- a/packages/convex/client/sdk.ts
+++ b/packages/convex/client/sdk.ts
@@ -343,7 +343,7 @@ export const createTeakClient = (options: {
   userAgent?: string;
 }) => {
   const baseUrl = withoutTrailingSlashes(
-    options.baseUrl || "https://api.teakvault.com"
+    options.baseUrl || "https://teakvault.com/api"
   );
   const fetchImpl = options.fetch ?? fetch;
   const timeoutMs = options.timeoutMs ?? 10_000;

--- a/packages/convex/mcp/tools.ts
+++ b/packages/convex/mcp/tools.ts
@@ -37,6 +37,73 @@ const queryInputSchema = z.object({
 });
 
 const nonEmptyString = z.string().trim().min(1);
+const cardSortSchema = z.enum(["newest", "oldest"]);
+const cardTypeSchema = z.enum([
+  "text",
+  "link",
+  "image",
+  "video",
+  "audio",
+  "document",
+  "palette",
+  "quote",
+]);
+
+const listCardsInputSchema = z.object({
+  limit: z.number().int().positive().max(100).optional(),
+  cursor: nonEmptyString.optional(),
+  type: cardTypeSchema.optional(),
+  favorited: z.boolean().optional(),
+  tag: nonEmptyString.optional(),
+  sort: cardSortSchema.optional(),
+  createdAfter: z.number().optional(),
+  createdBefore: z.number().optional(),
+});
+
+const getCardChangesInputSchema = z.object({
+  since: z.number(),
+  cursor: nonEmptyString.optional(),
+  limit: z.number().int().positive().max(100).optional(),
+});
+
+const createUploadInputSchema = z.object({
+  fileName: nonEmptyString,
+  mimeType: nonEmptyString,
+  fileSize: z.number().positive(),
+});
+
+const bulkCardsInputSchema = z.object({
+  operation: z.enum(["create", "update", "favorite", "delete"]),
+  items: z.array(z.record(z.string(), z.unknown())).min(1).max(100),
+  confirm: z.literal(true).optional(),
+}).superRefine((value, ctx) => {
+  if (value.operation === "delete" && value.confirm !== true) {
+    ctx.addIssue({
+      code: "custom",
+      message: "confirm must be true for delete batches",
+      path: ["confirm"],
+    });
+  }
+});
+
+const chatgptSearchInputSchema = z.object({
+  query: nonEmptyString,
+});
+
+const chatgptFetchInputSchema = z.object({
+  id: nonEmptyString,
+});
+
+const createCardInputSchema = z.object({ content: nonEmptyString });
+const cardIdInputSchema = z.object({ cardId: nonEmptyString });
+const deleteCardInputSchema = z.object({
+  cardId: nonEmptyString,
+  confirm: z.literal(true),
+});
+const favoriteInputSchema = z.object({
+  cardId: nonEmptyString,
+  isFavorited: z.boolean(),
+});
 
 const updateCardInputSchema = z
   .object({
@@ -73,13 +140,111 @@ const inputSchema = (properties: JsonObject, required: string[] = []) => ({
   additionalProperties: false,
 });
 
+const queryParams = (
+  query: Record<string, QueryValue>
+): Record<string, QueryValue> =>
+  Object.fromEntries(
+    Object.entries(query).filter((entry): entry is [string, QueryValue] => {
+      const value = entry[1];
+      return value !== undefined;
+    })
+  );
+
 export const TEAK_V1_TOOLS = [
+  {
+    name: "teak_v1_list_cards",
+    description: "List cards with cursor pagination and optional filters.",
+    inputSchema: inputSchema({
+      limit: { type: "integer", minimum: 1, maximum: 100 },
+      cursor: { type: "string", minLength: 1 },
+      type: { enum: cardTypeSchema.options },
+      favorited: { type: "boolean" },
+      tag: { type: "string", minLength: 1 },
+      sort: { enum: cardSortSchema.options },
+      createdAfter: { type: "number" },
+      createdBefore: { type: "number" },
+    }),
+  },
+  {
+    name: "teak_v1_get_card",
+    description: "Get a card by ID.",
+    inputSchema: inputSchema(
+      { cardId: { type: "string", minLength: 1 } },
+      ["cardId"]
+    ),
+  },
   {
     name: "teak_v1_create_card",
     description: "Create a new card from text or a URL.",
     inputSchema: inputSchema(
       { content: { type: "string", minLength: 1 } },
       ["content"]
+    ),
+  },
+  {
+    name: "teak_v1_list_tags",
+    description: "List tags used by saved cards.",
+    inputSchema: inputSchema({}),
+  },
+  {
+    name: "teak_v1_get_card_changes",
+    description: "List card changes since a timestamp with cursor pagination.",
+    inputSchema: inputSchema(
+      {
+        since: { type: "number" },
+        cursor: { type: "string", minLength: 1 },
+        limit: { type: "integer", minimum: 1, maximum: 100 },
+      },
+      ["since"]
+    ),
+  },
+  {
+    name: "teak_v1_bulk_cards",
+    description:
+      "Run a bulk card operation for up to 100 items. Delete batches require confirm: true.",
+    inputSchema: inputSchema(
+      {
+        operation: { enum: ["create", "update", "favorite", "delete"] },
+        items: {
+          type: "array",
+          minItems: 1,
+          maxItems: 100,
+          items: { type: "object", additionalProperties: true },
+        },
+        confirm: { const: true },
+      },
+      ["operation", "items"]
+    ),
+  },
+  {
+    name: "teak_v1_create_upload",
+    description:
+      "Create a direct upload URL. PUT bytes to uploadUrl, then create a card with the returned fileKey.",
+    inputSchema: inputSchema(
+      {
+        fileName: { type: "string", minLength: 1 },
+        mimeType: { type: "string", minLength: 1 },
+        fileSize: { type: "number", minimum: 1 },
+      },
+      ["fileName", "mimeType", "fileSize"]
+    ),
+  },
+  {
+    name: "search",
+    description:
+      "Search Teak cards for ChatGPT connectors and Deep Research.",
+    inputSchema: inputSchema(
+      { query: { type: "string", minLength: 1 } },
+      ["query"]
+    ),
+  },
+  {
+    name: "fetch",
+    description:
+      "Fetch a Teak card by ID for ChatGPT connectors and Deep Research.",
+    inputSchema: inputSchema(
+      { id: { type: "string", minLength: 1 } },
+      ["id"]
     ),
   },
   {
@@ -201,6 +366,25 @@ const validationError = (message: string): McpToolResult =>
 const getAuthorizationHeader = (request: Request): string | null =>
   request.headers.get("authorization");
 
+const titleFromCard = (card: JsonObject): string => {
+  const metadataTitle =
+    typeof card.metadataTitle === "string" ? card.metadataTitle.trim() : "";
+  const content = typeof card.content === "string" ? card.content.trim() : "";
+  const url = typeof card.url === "string" ? card.url.trim() : "";
+  return metadataTitle || content || url || String(card.id ?? "Untitled card");
+};
+
+const textFromCard = (card: JsonObject): string =>
+  [
+    titleFromCard(card),
+    typeof card.content === "string" ? card.content : undefined,
+    typeof card.notes === "string" ? card.notes : undefined,
+    typeof card.aiSummary === "string" ? card.aiSummary : undefined,
+    typeof card.url === "string" ? card.url : undefined,
+  ]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .join("\n\n");
+
 type ToolHandler<TInput> = (
   input: TInput,
   request: Request
@@ -276,198 +460,182 @@ const executeToolOperation = async (
   };
 };
 
-const toolHandlers = (executor: PublicApiToolExecutor) => ({
-  teak_v1_create_card: instrumentToolHandler(
-    "teak_v1_create_card",
-    async (input: unknown, request) => {
-      const parsed = z.object({ content: nonEmptyString }).safeParse(input);
-      if (!parsed.success) {
-        return validationError(parsed.error.issues[0]?.message ?? "Invalid input");
-      }
+type ToolConfig = {
+  schema: z.ZodTypeAny;
+  operation: (input: any) => PublicApiToolOperation;
+  summary: (payload: JsonObject, input: any) => string;
+  transform?: (payload: JsonObject, input: any) => JsonObject;
+};
 
-      const result = await executeToolOperation(
-        {
-          method: "POST",
-          path: "/v1/cards",
-          body: {
-            content: parsed.data.content,
-          },
-        },
-        request,
-        executor
-      );
+const count = (payload: JsonObject, field = "items"): number =>
+  Array.isArray(payload[field]) ? payload[field].length : 0;
 
-      if (!result.ok) {
-        return result.result;
-      }
-
-      const status =
-        typeof result.payload.status === "string"
-          ? result.payload.status
-          : "created";
-      return successResult(result.payload, `Card ${status}`);
-    }
-  ),
-  teak_v1_search_cards: instrumentToolHandler(
-    "teak_v1_search_cards",
-    async (input: unknown, request) => {
-      const parsed = queryInputSchema.safeParse(input);
-      if (!parsed.success) {
-        return validationError(parsed.error.issues[0]?.message ?? "Invalid input");
-      }
-
-      const result = await executeToolOperation(
-        {
-          method: "GET",
-          path: "/v1/cards/search",
-          query: {
-            q: parsed.data.q,
-            limit: parsed.data.limit,
-          },
-        },
-        request,
-        executor
-      );
-
-      if (!result.ok) {
-        return result.result;
-      }
-
-      const total =
-        typeof result.payload.total === "number" ? result.payload.total : 0;
-      return successResult(result.payload, `Fetched ${total} cards`);
-    }
-  ),
-  teak_v1_list_favorite_cards: instrumentToolHandler(
-    "teak_v1_list_favorite_cards",
-    async (input: unknown, request) => {
-      const parsed = queryInputSchema.safeParse(input);
-      if (!parsed.success) {
-        return validationError(parsed.error.issues[0]?.message ?? "Invalid input");
-      }
-
-      const result = await executeToolOperation(
-        {
-          method: "GET",
-          path: "/v1/cards/favorites",
-          query: {
-            q: parsed.data.q,
-            limit: parsed.data.limit,
-          },
-        },
-        request,
-        executor
-      );
-
-      if (!result.ok) {
-        return result.result;
-      }
-
-      const total =
-        typeof result.payload.total === "number" ? result.payload.total : 0;
-      return successResult(result.payload, `Fetched ${total} favorite cards`);
-    }
-  ),
-  teak_v1_update_card: instrumentToolHandler(
-    "teak_v1_update_card",
-    async (input: unknown, request) => {
-      const parsed = updateCardInputSchema.safeParse(input);
-      if (!parsed.success) {
-        return validationError(parsed.error.issues[0]?.message ?? "Invalid input");
-      }
-
-      const result = await executeToolOperation(
-        {
-          method: "PATCH",
-          path: `/v1/cards/${encodeURIComponent(parsed.data.cardId)}`,
-          body: {
-            ...(parsed.data.content === undefined
-              ? {}
-              : { content: parsed.data.content }),
-            ...(parsed.data.url === undefined ? {} : { url: parsed.data.url }),
-            ...(parsed.data.notes === undefined
-              ? {}
-              : { notes: parsed.data.notes }),
-            ...(parsed.data.tags === undefined
-              ? {}
-              : { tags: parsed.data.tags }),
-          },
-        },
-        request,
-        executor
-      );
-
-      return result.ok
-        ? successResult(result.payload, "Card updated")
-        : result.result;
-    }
-  ),
-  teak_v1_set_card_favorite: instrumentToolHandler(
-    "teak_v1_set_card_favorite",
-    async (input: unknown, request) => {
-      const parsed = z
-        .object({ cardId: nonEmptyString, isFavorited: z.boolean() })
-        .safeParse(input);
-      if (!parsed.success) {
-        return validationError(parsed.error.issues[0]?.message ?? "Invalid input");
-      }
-
-      const result = await executeToolOperation(
-        {
-          method: "PATCH",
-          path: `/v1/cards/${encodeURIComponent(parsed.data.cardId)}/favorite`,
-          body: {
-            isFavorited: parsed.data.isFavorited,
-          },
-        },
-        request,
-        executor
-      );
-
-      if (!result.ok) {
-        return result.result;
-      }
-
-      const stateText = parsed.data.isFavorited ? "favorited" : "unfavorited";
-      return successResult(result.payload, `Card ${stateText}`);
-    }
-  ),
-  teak_v1_delete_card: instrumentToolHandler(
-    "teak_v1_delete_card",
-    async (input: unknown, request) => {
-      if (!(toObjectPayload(input).confirm === true)) {
-        return validationError("confirm must be true");
-      }
-
-      const parsed = z
-        .object({ cardId: nonEmptyString, confirm: z.literal(true) })
-        .safeParse(input);
-      if (!parsed.success) {
-        return validationError(parsed.error.issues[0]?.message ?? "Invalid input");
-      }
-
-      const result = await executeToolOperation(
-        {
-          method: "DELETE",
-          path: `/v1/cards/${encodeURIComponent(parsed.data.cardId)}`,
-        },
-        request,
-        executor
-      );
-
-      if (!result.ok) {
-        return result.result;
-      }
-
-      const payload = {
-        status: "deleted",
-        cardId: parsed.data.cardId,
-      };
-
-      return successResult(payload, `Deleted card ${parsed.data.cardId}`);
-    }
-  ),
+const cardPath = (id: string): string => `/v1/cards/${encodeURIComponent(id)}`;
+const queryTool = (path: string): ToolConfig => ({
+  schema: queryInputSchema,
+  operation: (input) => ({
+    method: "GET",
+    path,
+    query: queryParams({ q: input.q, limit: input.limit }),
+  }),
+  summary: (payload) => `Fetched ${Number(payload.total) || 0} cards`,
 });
+
+const toolConfigs: Record<string, ToolConfig> = {
+  teak_v1_list_cards: {
+    schema: listCardsInputSchema,
+    operation: (input) => ({
+      method: "GET",
+      path: "/v1/cards",
+      query: queryParams(input),
+    }),
+    summary: (payload) => `Fetched ${count(payload)} cards`,
+  },
+  teak_v1_get_card: {
+    schema: cardIdInputSchema,
+    operation: (input) => ({ method: "GET", path: cardPath(input.cardId) }),
+    summary: (_payload, input) => `Fetched card ${input.cardId}`,
+  },
+  teak_v1_create_card: {
+    schema: createCardInputSchema,
+    operation: (input) => ({
+      method: "POST",
+      path: "/v1/cards",
+      body: { content: input.content },
+    }),
+    summary: (payload) =>
+      `Card ${typeof payload.status === "string" ? payload.status : "created"}`,
+  },
+  teak_v1_search_cards: queryTool("/v1/cards/search"),
+  teak_v1_list_favorite_cards: {
+    ...queryTool("/v1/cards/favorites"),
+    summary: (payload) => `Fetched ${Number(payload.total) || 0} favorite cards`,
+  },
+  teak_v1_update_card: {
+    schema: updateCardInputSchema,
+    operation: ({ cardId, ...body }) => ({
+      method: "PATCH",
+      path: cardPath(cardId),
+      body: Object.fromEntries(
+        Object.entries(body).filter(([, value]) => value !== undefined)
+      ),
+    }),
+    summary: () => "Card updated",
+  },
+  teak_v1_set_card_favorite: {
+    schema: favoriteInputSchema,
+    operation: (input) => ({
+      method: "PATCH",
+      path: `${cardPath(input.cardId)}/favorite`,
+      body: { isFavorited: input.isFavorited },
+    }),
+    summary: (_payload, input) =>
+      `Card ${input.isFavorited ? "favorited" : "unfavorited"}`,
+  },
+  teak_v1_delete_card: {
+    schema: deleteCardInputSchema,
+    operation: (input) => ({ method: "DELETE", path: cardPath(input.cardId) }),
+    transform: (_payload, input) => ({
+      status: "deleted",
+      cardId: input.cardId,
+    }),
+    summary: (_payload, input) => `Deleted card ${input.cardId}`,
+  },
+  teak_v1_list_tags: {
+    schema: z.object({}),
+    operation: () => ({ method: "GET", path: "/v1/tags" }),
+    summary: (payload) => `Fetched ${count(payload)} tags`,
+  },
+  teak_v1_get_card_changes: {
+    schema: getCardChangesInputSchema,
+    operation: (input) => ({
+      method: "GET",
+      path: "/v1/cards/changes",
+      query: queryParams(input),
+    }),
+    summary: (payload) =>
+      `Fetched ${count(payload)} changed cards and ${count(payload, "deletedIds")} deleted IDs`,
+  },
+  teak_v1_bulk_cards: {
+    schema: bulkCardsInputSchema,
+    operation: (input) => ({
+      method: "POST",
+      path: "/v1/cards/bulk",
+      body: { operation: input.operation, items: input.items },
+    }),
+    summary: (_payload, input) => `Bulk ${input.operation} complete`,
+  },
+  teak_v1_create_upload: {
+    schema: createUploadInputSchema,
+    operation: (input) => ({ method: "POST", path: "/v1/uploads", body: input }),
+    summary: () =>
+      "Upload URL created. PUT bytes to uploadUrl, then create a card with fileKey.",
+  },
+  search: {
+    schema: chatgptSearchInputSchema,
+    operation: (input) => ({
+      method: "GET",
+      path: "/v1/cards/search",
+      query: { q: input.query, limit: 10 },
+    }),
+    transform: (payload) => ({
+      results: (Array.isArray(payload.items) ? payload.items : []).map(
+        (card: JsonObject) => ({
+          id: String(card.id ?? ""),
+          title: titleFromCard(card),
+          url:
+            typeof card.appUrl === "string"
+              ? card.appUrl
+              : "https://app.teakvault.com",
+        })
+      ),
+    }),
+    summary: (payload) => `Found ${count(payload, "results")} cards`,
+  },
+  fetch: {
+    schema: chatgptFetchInputSchema,
+    operation: (input) => ({ method: "GET", path: cardPath(input.id) }),
+    transform: (payload, input) => ({
+      id: String(payload.id ?? input.id),
+      title: titleFromCard(payload),
+      text: textFromCard(payload),
+      url:
+        typeof payload.appUrl === "string"
+          ? payload.appUrl
+          : "https://app.teakvault.com",
+      metadata: payload,
+    }),
+    summary: (payload) => `Fetched card ${payload.id}`,
+  },
+};
+
+const buildToolHandler = (
+  name: string,
+  executor: PublicApiToolExecutor
+) =>
+  instrumentToolHandler(name, async (input: unknown, request) => {
+    const config = toolConfigs[name];
+    const parsed = config.schema.safeParse(input);
+    if (!parsed.success) {
+      return validationError(parsed.error.issues[0]?.message ?? "Invalid input");
+    }
+    const result = await executeToolOperation(
+      config.operation(parsed.data),
+      request,
+      executor
+    );
+    if (!result.ok) return result.result;
+    const payload = config.transform?.(result.payload, parsed.data) ?? result.payload;
+    return successResult(payload, config.summary(payload, parsed.data));
+  });
+
+const toolHandlers = (executor: PublicApiToolExecutor) =>
+  Object.fromEntries(
+    Object.keys(toolConfigs).map((name) => [
+      name,
+      buildToolHandler(name, executor),
+    ])
+  ) as Record<string, ToolHandler<unknown>>;
 
 export const callTeakV1Tool = async (
   name: string,

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/convex",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "type": "module",
   "exports": {
     ".": "./index.ts",

--- a/packages/convex/publicApiHttp.ts
+++ b/packages/convex/publicApiHttp.ts
@@ -1702,7 +1702,7 @@ const toPublicApiRequest = (operation: PublicApiOperation): Request => {
   const normalizedPath = operation.path.startsWith("/")
     ? operation.path
     : `/${operation.path}`;
-  const url = new URL(normalizedPath, operation.origin ?? "https://api.teakvault.com");
+  const url = new URL(normalizedPath, operation.origin ?? "https://teakvault.com");
 
   for (const [key, value] of Object.entries(operation.query ?? {})) {
     if (value !== undefined) {

--- a/packages/convex/publicApiMeta.ts
+++ b/packages/convex/publicApiMeta.ts
@@ -36,7 +36,8 @@ export const PUBLIC_API_CORS_HEADERS: Record<string, string> = {
   "Access-Control-Max-Age": "86400",
 };
 
-const PROD_PUBLIC_API_URL = "https://api.teakvault.com";
+const PROD_PUBLIC_API_URL = "https://teakvault.com/api";
+const PROD_PUBLIC_MCP_URL = "https://teakvault.com/mcp";
 const PROD_AUTH_ISSUER_URL = "https://app.teakvault.com";
 const OAUTH_SCOPES_SUPPORTED = ["profile", "email", "offline_access"];
 
@@ -45,7 +46,7 @@ const normalizeBaseUrl = (raw: string): string => raw.replace(/\/+$/, "");
 const isLocalApiHost = (hostname: string): boolean =>
   isLocalDevelopmentHostname(hostname);
 
-const getPublicApiUrl = (requestUrl: string): string => {
+export const getPublicApiUrl = (requestUrl: string): string => {
   const fromEnv = process.env.PUBLIC_API_URL?.trim();
   if (fromEnv) {
     return normalizeBaseUrl(fromEnv);
@@ -59,7 +60,25 @@ const getPublicApiUrl = (requestUrl: string): string => {
 };
 
 export const getMcpEndpointFromRequestUrl = (requestUrl: string): string =>
-  `${getPublicApiUrl(requestUrl)}/mcp`;
+  getPublicMcpUrl(requestUrl);
+
+export const getPublicMcpUrl = (requestUrl: string): string => {
+  const fromEnv = process.env.PUBLIC_MCP_URL?.trim();
+  if (fromEnv) {
+    return normalizeBaseUrl(fromEnv);
+  }
+
+  const apiUrlFromEnv = process.env.PUBLIC_API_URL?.trim();
+  if (apiUrlFromEnv) {
+    return `${normalizeBaseUrl(apiUrlFromEnv)}/mcp`;
+  }
+
+  const { hostname, origin } = new URL(requestUrl);
+  const devApiOrigin = resolveTeakDevApiUrl(process.env);
+  return isLocalApiHost(hostname) || origin === devApiOrigin
+    ? `${origin}/mcp`
+    : PROD_PUBLIC_MCP_URL;
+};
 
 const getAuthIssuerUrl = (requestUrl: string): string => {
   const fromEnv =
@@ -74,11 +93,13 @@ const getAuthIssuerUrl = (requestUrl: string): string => {
     : PROD_AUTH_ISSUER_URL;
 };
 
-export const getProtectedResourceUrl = (requestUrl: string): string =>
-  `${getPublicApiUrl(requestUrl)}/.well-known/oauth-protected-resource`;
+export const getProtectedResourceUrl = (requestUrl: string): string => {
+  const mcpUrl = new URL(getPublicMcpUrl(requestUrl));
+  return `${mcpUrl.origin}/.well-known/oauth-protected-resource${mcpUrl.pathname}`;
+};
 
 export const buildProtectedResourceMetadata = (requestUrl: string) => ({
-  resource: `${getPublicApiUrl(requestUrl)}/mcp`,
+  resource: getPublicMcpUrl(requestUrl),
   authorization_servers: [getAuthIssuerUrl(requestUrl)],
   bearer_methods_supported: ["header"],
   scopes_supported: OAUTH_SCOPES_SUPPORTED,

--- a/packages/convex/publicApiOpenApi.ts
+++ b/packages/convex/publicApiOpenApi.ts
@@ -298,6 +298,7 @@ export const openApiSpec = {
     description: "Public API for creating, querying, and syncing Teak cards.",
   },
   servers: [
+    { url: "https://teakvault.com/api" },
     { url: "https://api.teakvault.com" },
     { url: resolveTeakDevApiUrl(process.env) },
   ],

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/ui",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "private": true,
   "exports": {
     "./logo": "./src/logo.tsx",

--- a/scripts/smoke-urls.sh
+++ b/scripts/smoke-urls.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+json_rpc='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"teak-smoke","version":"1.0.0"}}}'
+
+tmp_body="$(mktemp)"
+tmp_headers="$(mktemp)"
+trap 'rm -f "$tmp_body" "$tmp_headers"' EXIT
+
+check_status() {
+  local expected="$1"
+  local url="$2"
+  local status
+  status="$(curl -fsS -o "$tmp_body" -w '%{http_code}' "$url")"
+  if [[ "$status" != "$expected" ]]; then
+    echo "Expected $expected for $url, got $status" >&2
+    cat "$tmp_body" >&2
+    exit 1
+  fi
+}
+
+check_contains() {
+  local url="$1"
+  local expected="$2"
+  check_status 200 "$url"
+  if ! grep -q "$expected" "$tmp_body"; then
+    echo "Expected $url body to contain $expected" >&2
+    cat "$tmp_body" >&2
+    exit 1
+  fi
+}
+
+check_mcp_unauthorized() {
+  local url="$1"
+  local expected_metadata="$2"
+  local status
+  status="$(
+    curl -fsS -o "$tmp_body" -D "$tmp_headers" -w '%{http_code}' \
+      -X POST "$url" \
+      -H 'Accept: application/json, text/event-stream' \
+      -H 'Content-Type: application/json' \
+      -d "$json_rpc" || true
+  )"
+  if [[ "$status" != "401" ]]; then
+    echo "Expected 401 for $url, got $status" >&2
+    cat "$tmp_body" >&2
+    exit 1
+  fi
+  if ! grep -qi 'WWW-Authenticate:' "$tmp_headers"; then
+    echo "Missing WWW-Authenticate header for $url" >&2
+    cat "$tmp_headers" >&2
+    exit 1
+  fi
+  if ! grep -q "$expected_metadata" "$tmp_headers"; then
+    echo "WWW-Authenticate for $url did not reference $expected_metadata" >&2
+    cat "$tmp_headers" >&2
+    exit 1
+  fi
+}
+
+check_status 200 "https://teakvault.com/api/healthz"
+check_contains "https://teakvault.com/api" '"version":"v1"'
+check_contains "https://teakvault.com/api/v1" '"endpoint":"https://teakvault.com/mcp"'
+check_contains "https://teakvault.com/api/openapi.json" '"openapi":"3.1.0"'
+check_mcp_unauthorized \
+  "https://teakvault.com/mcp" \
+  "https://teakvault.com/.well-known/oauth-protected-resource/mcp"
+check_contains \
+  "https://teakvault.com/.well-known/oauth-protected-resource/mcp" \
+  '"resource":"https://teakvault.com/mcp"'
+check_status 200 "https://teakvault.com/llms.txt"
+check_contains "https://teakvault.com/.well-known/mcp.json" '"endpoint":"https://teakvault.com/mcp"'
+
+check_status 200 "https://api.teakvault.com/healthz"
+check_contains "https://api.teakvault.com/v1" '"endpoint":"https://teakvault.com/mcp"'
+check_contains "https://api.teakvault.com/openapi.json" '"openapi":"3.1.0"'
+check_mcp_unauthorized \
+  "https://api.teakvault.com/mcp" \
+  "https://teakvault.com/.well-known/oauth-protected-resource/mcp"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "com.teakvault/mcp",
+  "title": "Teak",
+  "description": "Remote MCP server for saving, searching, syncing, and managing Teak cards.",
+  "version": "1.0.54",
+  "websiteUrl": "https://teakvault.com",
+  "documentationUrl": "https://teakvault.com/docs/mcp",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://teakvault.com/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- move the canonical public API and MCP URLs to `https://teakvault.com/api` and `https://teakvault.com/mcp` while keeping legacy `https://api.teakvault.com` URLs working
- expand MCP coverage to the full v1 card/search/tag/upload/bulk surface plus ChatGPT-compatible `search` and `fetch` tools
- simplify API/MCP/AI-agent docs, add markdown/llms surfaces, MCP discovery metadata, registry metadata, and scheduled URL smoke coverage
- bump all package versions to `1.0.54` for the release workflows

## Local validation
- `bun test packages/convex/__tests__/mcp.test.ts packages/convex/__tests__/publicApiGateway.test.ts`
- `bun run test` in `packages/convex`
- `bun run typecheck` in `packages/convex`
- `bun run test && bun run typecheck` in `apps/cli`
- `bun run test && bun run typecheck` in `apps/raycast`
- `bun run build` in `apps/docs`
- `bun run typecheck` in `apps/docs`
- `git diff --check`
- `bun run pre-commit`
- validated `server.json` against the live MCP registry schema
- preview-smoked docs markdown, MCP discovery, llms.txt, JSON-LD, and page actions through `astro preview`

## Deployment notes
- Existing production URLs currently advertise the legacy MCP URL until this branch is deployed.
- After merge/deploy, run `bash scripts/smoke-urls.sh` to verify new apex URLs and legacy URL compatibility.
- The MCP registry currently documents `server.json` with schema `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`; publish remains manual via `mcp-publisher`.
