### PR TITLE
Fix desktop file uploads, audio recording, and PDF previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Save inspiration in one click and find it in two seconds — no more lost bookma
 
 [![Website](https://img.shields.io/badge/Website-teakvault.com-2563eb?style=for-the-badge)](https://teakvault.com)
 [![Docs](https://img.shields.io/badge/Docs-Read-22c55e?style=for-the-badge)](https://teakvault.com/docs/)
+[![Agent Skill](https://img.shields.io/badge/Skills.sh-Teak-111827?style=for-the-badge)](https://skills.sh/praveenjuge/teak)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](LICENSE)
 
 ![Teak](https://teakvault.com/hero-image.png)
@@ -24,7 +25,7 @@ Save inspiration in one click and find it in two seconds — no more lost bookma
 | 🧩 **Browser** | One-click saves while you browse | [Chrome →](https://chromewebstore.google.com/detail/teak/negnmfifahnnagnbnfppmlgfajngdpob) · [Safari →](https://apps.apple.com/us/app/teak-for-safari/id6770003409?mt=12) |
 | ⚡ **Raycast** | Save and search from your keyboard | [Install →](https://www.raycast.com/praveenjuge/teak-raycast) |
 | 🧰 **CLI** | Save, search, and manage cards from your terminal | `npm i -g teak-cli` |
-| 🤖 **Agent Skill** | Teach AI agents how to use Teak through CLI, API, MCP, and SDK workflows | `npx skills add praveenjuge/teak --skill teak` |
+| 🤖 **Agent Skill** | Teach AI agents how to use Teak through CLI, API, MCP, and SDK workflows | [Skills.sh](https://skills.sh/praveenjuge/teak) · `npx skills add praveenjuge/teak --skill teak` |
 | 🔌 **API & MCP** | Programmatic and AI client access | [API docs →](https://teakvault.com/docs/api) |
 
 ## Monorepo

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -28,6 +28,13 @@ const config: Configuration = {
     category: "public.app-category.productivity",
     minimumSystemVersion: "13.0",
     hardenedRuntime: true,
+    // macOS shows this string in the microphone permission prompt. Without
+    // NSMicrophoneUsageDescription, the OS terminates the app when it tries
+    // to record audio, so audio recording silently fails.
+    extendInfo: {
+      NSMicrophoneUsageDescription:
+        "Teak needs microphone access to record audio notes.",
+    },
     identity: "Juge Praveen (LW385M78LW)",
     entitlements: "build/entitlements.mac.plist",
     entitlementsInherit: "build/entitlements.mac.inherit.plist",

--- a/apps/desktop/src/__tests__/electronMainWiring.test.ts
+++ b/apps/desktop/src/__tests__/electronMainWiring.test.ts
@@ -67,9 +67,10 @@ describe("electron main process wiring", () => {
   });
 
   it("grants only microphone access for audio recording", () => {
-    // Electron denies renderer permission requests by default, so
-    // getUserMedia rejects until we register a permission handler that grants
-    // the `media` permission (and nothing else).
+    // Electron denies renderer permission requests by default, so getUserMedia
+    // rejects until we register permission handlers. Because Electron's `media`
+    // permission also covers the camera, the handlers must delegate to the
+    // audio-only predicates instead of blanket-approving every `media` request.
     const source = readFileSync(
       resolve(import.meta.dir, "../main/index.ts"),
       "utf8"
@@ -77,7 +78,8 @@ describe("electron main process wiring", () => {
 
     expect(source).toContain("setPermissionRequestHandler");
     expect(source).toContain("setPermissionCheckHandler");
-    expect(source).toContain('permission === "media"');
+    expect(source).toContain("isMicrophoneOnlyRequest");
+    expect(source).toContain("isMicrophoneCheck");
   });
 
   it("configures the main window with correct dimensions", () => {

--- a/apps/desktop/src/__tests__/electronMainWiring.test.ts
+++ b/apps/desktop/src/__tests__/electronMainWiring.test.ts
@@ -24,6 +24,62 @@ describe("electron main process wiring", () => {
     expect(source).toContain("ALLOWED_URL_PROTOCOLS");
   });
 
+  it("allows R2 uploads and downloads through the CSP", () => {
+    // File uploads PUT directly to R2 and the PDF preview embeds a signed R2
+    // URL. Both are blocked in packaged builds unless the R2 host is allowed
+    // in connect-src (uploads) and frame-src (PDF iframe).
+    const source = readFileSync(
+      resolve(import.meta.dir, "../main/index.ts"),
+      "utf8"
+    );
+
+    const connectSrc = source
+      .split("\n")
+      .find((line) => line.includes("connect-src"));
+    expect(connectSrc).toBeDefined();
+    expect(connectSrc).toContain("https://*.r2.cloudflarestorage.com");
+
+    const frameSrc = source
+      .split("\n")
+      .find((line) => line.includes('"frame-src'));
+    expect(frameSrc).toBeDefined();
+    expect(frameSrc).toContain("https://*.r2.cloudflarestorage.com");
+  });
+
+  it("injects CORS headers on R2 responses so uploads and downloads work", () => {
+    // R2 does not return CORS headers for the desktop origin (dev localhost or
+    // the packaged file:// null origin), which blocks the upload PUT used for
+    // both files and audio recordings. The main process adds the headers and
+    // answers the preflight so the renderer's cross-origin request succeeds.
+    const source = readFileSync(
+      resolve(import.meta.dir, "../main/index.ts"),
+      "utf8"
+    );
+
+    expect(source).toContain("isR2RequestUrl");
+    expect(source).toContain(".r2.cloudflarestorage.com");
+    expect(source).toContain("Access-Control-Allow-Origin");
+    expect(source).toContain("Access-Control-Allow-Methods");
+    expect(source).toContain("Access-Control-Allow-Headers");
+    // Preflight (OPTIONS) must be forced to a 2xx for the browser to proceed.
+    expect(source).toContain('"OPTIONS"');
+    expect(source).toContain("HTTP/1.1 200 OK");
+  });
+
+  it("grants only microphone access for audio recording", () => {
+    // Electron denies renderer permission requests by default, so
+    // getUserMedia rejects until we register a permission handler that grants
+    // the `media` permission (and nothing else).
+    const source = readFileSync(
+      resolve(import.meta.dir, "../main/index.ts"),
+      "utf8"
+    );
+
+    expect(source).toContain("setPermissionRequestHandler");
+    expect(source).toContain("setPermissionCheckHandler");
+    expect(source).toContain('permission === "media"');
+  });
+
   it("configures the main window with correct dimensions", () => {
     const source = readFileSync(
       resolve(import.meta.dir, "../main/index.ts"),
@@ -97,6 +153,24 @@ describe("electron main process wiring", () => {
     expect(storeSource).toContain('"auth.deviceId"');
     expect(storeSource).toContain('"auth.pendingNativeFlow"');
     expect(storeSource).toContain("isAllowedKey");
+  });
+
+  it("declares the macOS microphone usage description for packaged builds", () => {
+    // macOS terminates the app when it accesses the microphone without an
+    // NSMicrophoneUsageDescription, so audio recording fails in the signed
+    // build even with the permission handler and entitlement in place.
+    const config = readFileSync(
+      resolve(import.meta.dir, "../../electron-builder.config.ts"),
+      "utf8"
+    );
+
+    expect(config).toContain("NSMicrophoneUsageDescription");
+
+    const entitlements = readFileSync(
+      resolve(import.meta.dir, "../../build/entitlements.mac.plist"),
+      "utf8"
+    );
+    expect(entitlements).toContain("com.apple.security.device.audio-input");
   });
 
   it("prevents navigation and new-window creation", () => {

--- a/apps/desktop/src/__tests__/mediaPermissions.test.ts
+++ b/apps/desktop/src/__tests__/mediaPermissions.test.ts
@@ -1,0 +1,40 @@
+// @ts-nocheck
+import { describe, expect, it } from "bun:test";
+import {
+  isMicrophoneCheck,
+  isMicrophoneOnlyRequest,
+} from "../main/mediaPermissions";
+
+describe("desktop media permissions", () => {
+  describe("isMicrophoneOnlyRequest", () => {
+    it("grants an audio-only request (getUserMedia({ audio: true }))", () => {
+      expect(isMicrophoneOnlyRequest(["audio"])).toBe(true);
+    });
+
+    it("denies a camera-only request", () => {
+      expect(isMicrophoneOnlyRequest(["video"])).toBe(false);
+    });
+
+    it("denies a combined audio + video request so the camera is never granted", () => {
+      expect(isMicrophoneOnlyRequest(["audio", "video"])).toBe(false);
+      expect(isMicrophoneOnlyRequest(["video", "audio"])).toBe(false);
+    });
+
+    it("denies when no media types are provided", () => {
+      expect(isMicrophoneOnlyRequest(undefined)).toBe(false);
+      expect(isMicrophoneOnlyRequest([])).toBe(false);
+    });
+  });
+
+  describe("isMicrophoneCheck", () => {
+    it("grants the microphone (audio) check", () => {
+      expect(isMicrophoneCheck("audio")).toBe(true);
+    });
+
+    it("denies camera, unknown, and missing media-type checks", () => {
+      expect(isMicrophoneCheck("video")).toBe(false);
+      expect(isMicrophoneCheck("unknown")).toBe(false);
+      expect(isMicrophoneCheck(undefined)).toBe(false);
+    });
+  });
+});

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -8,6 +8,7 @@ import type {
 } from "electron";
 import electronUpdater from "electron-updater";
 import { OAUTH_CALLBACK_CHANNEL } from "./channels";
+import { isMicrophoneCheck, isMicrophoneOnlyRequest } from "./mediaPermissions";
 import { createStore, readStoreValue, writeStoreValue } from "./store";
 
 // Route the `electron` import through Node's CJS loader.
@@ -142,15 +143,25 @@ function createMainWindow(): BrowserWindowInstance {
     },
   });
 
-  // Microphone access for audio recording. Electron denies every renderer
+  // Microphone-only access for audio recording. Electron denies every renderer
   // permission request by default, so `navigator.mediaDevices.getUserMedia`
-  // rejects with NotAllowedError until we opt in here. We only grant `media`
-  // (the microphone); every other permission stays denied.
+  // rejects with NotAllowedError until we opt in here. Teak only records audio
+  // notes (`getUserMedia({ audio: true })`), and Electron's `media` permission
+  // also covers the camera, so we approve audio-only requests and deny video
+  // (and every other permission) to avoid silently granting camera access.
   const { session } = mainWindow.webContents;
-  session.setPermissionRequestHandler((_wc, permission, callback) => {
-    callback(permission === "media");
+  session.setPermissionRequestHandler((_wc, permission, callback, details) => {
+    if (permission !== "media") {
+      callback(false);
+      return;
+    }
+    const mediaTypes = "mediaTypes" in details ? details.mediaTypes : undefined;
+    callback(isMicrophoneOnlyRequest(mediaTypes));
   });
-  session.setPermissionCheckHandler((_wc, permission) => permission === "media");
+  session.setPermissionCheckHandler(
+    (_wc, permission, _origin, details) =>
+      permission === "media" && isMicrophoneCheck(details.mediaType)
+  );
 
   // A single onHeadersReceived listener (Electron keeps only the most recent
   // one) that does two jobs:

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -45,6 +45,19 @@ const MAIN_WINDOW_MIN_HEIGHT = 600;
 
 const ALLOWED_URL_PROTOCOLS = new Set(["https:", "http:"]);
 
+// Cloudflare R2 host suffix. File uploads PUT directly to a signed R2 URL and
+// signed downloads GET from one, so the renderer talks cross-origin to this
+// host. We recognise it to inject CORS headers on its responses (see below).
+const R2_HOST_SUFFIX = ".r2.cloudflarestorage.com";
+
+function isR2RequestUrl(url: string): boolean {
+  try {
+    return new URL(url).hostname.endsWith(R2_HOST_SUFFIX);
+  } catch {
+    return false;
+  }
+}
+
 // Loopback OAuth callback (RFC 8252). The desktop client tries 14203 first and
 // falls back to 24203; both are registered as exact-match redirect URIs on the
 // `teak-desktop` trusted client server-side.
@@ -129,36 +142,81 @@ function createMainWindow(): BrowserWindowInstance {
     },
   });
 
-  // CSP for the renderer — only in production; Vite dev server needs inline scripts for HMR
-  if (!isDevServer) {
-    mainWindow.webContents.session.webRequest.onHeadersReceived(
-      (
-        details: OnHeadersReceivedListenerDetails,
-        callback: (response: {
-          responseHeaders?: Record<string, string | string[]>;
-        }) => void
-      ) => {
+  // Microphone access for audio recording. Electron denies every renderer
+  // permission request by default, so `navigator.mediaDevices.getUserMedia`
+  // rejects with NotAllowedError until we opt in here. We only grant `media`
+  // (the microphone); every other permission stays denied.
+  const { session } = mainWindow.webContents;
+  session.setPermissionRequestHandler((_wc, permission, callback) => {
+    callback(permission === "media");
+  });
+  session.setPermissionCheckHandler((_wc, permission) => permission === "media");
+
+  // A single onHeadersReceived listener (Electron keeps only the most recent
+  // one) that does two jobs:
+  //
+  //  1. R2 CORS. Cloudflare R2 only returns CORS headers for origins listed in
+  //     the bucket's CORS policy, and the packaged app's `file://`/`null`
+  //     origin can't be whitelisted there. The renderer's cross-origin upload
+  //     PUT (and signed GET) would fail the browser CORS check — including the
+  //     OPTIONS preflight the PUT triggers because it sends a Content-Type
+  //     header. We add the CORS headers to R2 responses ourselves and force a
+  //     200 on the preflight so uploads/downloads succeed in every build.
+  //     This is the fix for both file uploads and saving audio recordings.
+  //
+  //  2. CSP for the renderer, applied only in production (the Vite dev server
+  //     needs inline scripts for HMR).
+  mainWindow.webContents.session.webRequest.onHeadersReceived(
+    (
+      details: OnHeadersReceivedListenerDetails,
+      callback: (response: {
+        responseHeaders?: Record<string, string | string[]>;
+        statusLine?: string;
+      }) => void
+    ) => {
+      const responseHeaders = { ...details.responseHeaders };
+
+      if (isR2RequestUrl(details.url)) {
+        // `*` is safe here: R2 rejects any request without a valid short-lived
+        // signature regardless of CORS, and our uploads carry no credentials.
+        responseHeaders["Access-Control-Allow-Origin"] = ["*"];
+        responseHeaders["Access-Control-Allow-Methods"] = [
+          "GET, PUT, POST, DELETE, HEAD, OPTIONS",
+        ];
+        responseHeaders["Access-Control-Allow-Headers"] = ["*"];
+        responseHeaders["Access-Control-Expose-Headers"] = ["ETag"];
+        const isPreflight = (details.method ?? "").toUpperCase() === "OPTIONS";
         callback({
-          responseHeaders: {
-            ...details.responseHeaders,
-            "Content-Security-Policy": [
-              [
-                "default-src 'self'",
-                "connect-src 'self' https://*.convex.cloud https://*.convex.site wss://*.convex.cloud wss://*.convex.site https://app.teakvault.com https://teakvault.com",
-                "img-src 'self' data: blob: https:",
-                "media-src 'self' data: blob: https:",
-                "style-src 'self' 'unsafe-inline'",
-                "font-src 'self' data:",
-                "script-src 'self'",
-                "object-src 'none'",
-                "base-uri 'none'",
-              ].join("; "),
-            ],
-          },
+          responseHeaders,
+          statusLine: isPreflight ? "HTTP/1.1 200 OK" : details.statusLine,
         });
+        return;
       }
-    );
-  }
+
+      if (!isDevServer) {
+        responseHeaders["Content-Security-Policy"] = [
+          [
+            "default-src 'self'",
+            // `https://*.r2.cloudflarestorage.com` is required for the direct
+            // file-upload PUT and signed-download GET against R2.
+            "connect-src 'self' https://*.convex.cloud https://*.convex.site wss://*.convex.cloud wss://*.convex.site https://app.teakvault.com https://teakvault.com https://*.r2.cloudflarestorage.com",
+            "img-src 'self' data: blob: https:",
+            "media-src 'self' data: blob: https:",
+            // `frame-src` covers the PDF preview iframe, which points at a
+            // signed cross-origin R2 URL.
+            "frame-src 'self' blob: https://*.r2.cloudflarestorage.com",
+            "style-src 'self' 'unsafe-inline'",
+            "font-src 'self' data:",
+            "script-src 'self'",
+            "object-src 'none'",
+            "base-uri 'none'",
+          ].join("; "),
+        ];
+      }
+
+      callback({ responseHeaders });
+    }
+  );
 
   // Prevent arbitrary navigation
   mainWindow.webContents.on(

--- a/apps/desktop/src/main/mediaPermissions.ts
+++ b/apps/desktop/src/main/mediaPermissions.ts
@@ -1,0 +1,40 @@
+// Media permission predicates for the Electron main process.
+//
+// Teak's only use of `getUserMedia` is recording audio notes
+// (`getUserMedia({ audio: true })`), so the desktop app must grant the
+// microphone and nothing else. Electron's single `media` permission covers
+// both the microphone and the camera, so approving every `media` request would
+// silently grant camera access too. These predicates inspect the requested
+// media type(s) and approve audio-only access.
+//
+// They are intentionally free of Electron imports so they can be unit tested
+// without the Electron runtime.
+
+export type RequestedMediaType = "audio" | "video";
+export type CheckedMediaType = "audio" | "video" | "unknown";
+
+/**
+ * `setPermissionRequestHandler` receives every requested media type
+ * (`getUserMedia({ audio: true })` resolves to `["audio"]`). Grant the request
+ * only when it asks for the microphone and does not also ask for the camera.
+ */
+export function isMicrophoneOnlyRequest(
+  mediaTypes: readonly RequestedMediaType[] | undefined
+): boolean {
+  return (
+    Array.isArray(mediaTypes) &&
+    mediaTypes.includes("audio") &&
+    !mediaTypes.includes("video")
+  );
+}
+
+/**
+ * `setPermissionCheckHandler` reports a single media type (or `"unknown"`).
+ * Only the microphone (audio) check is granted; camera and unknown checks are
+ * denied.
+ */
+export function isMicrophoneCheck(
+  mediaType: CheckedMediaType | undefined
+): boolean {
+  return mediaType === "audio";
+}

--- a/apps/docs/src/components/AppsGrid.astro
+++ b/apps/docs/src/components/AppsGrid.astro
@@ -11,7 +11,7 @@ const DESKTOP_DOWNLOAD_URL =
 const API_DOCS_URL = "/docs/api";
 const MCP_DOCS_URL = "/docs/mcp";
 const CLI_DOCS_URL = "/docs/cli";
-const SKILLS_DOCS_URL = "/docs/skills";
+const SKILLS_URL = "https://skills.sh/praveenjuge/teak";
 const RAYCAST_STORE_URL = "https://www.raycast.com/praveenjuge/teak-raycast";
 const RAYCAST_INSTALL_BUTTON_URL =
   "https://www.raycast.com/praveenjuge/teak-raycast/install_button@2x.png?v=1.1";
@@ -134,7 +134,7 @@ const platformCards: PlatformCard[] = [
     iconAlt: "Model Context Protocol icon",
     iconClass: "dark:invert",
     iconSrc: "/platform-icons/mcp.svg",
-    href: SKILLS_DOCS_URL,
+    href: SKILLS_URL,
     actionType: "button",
     label: "Install Skill",
   },

--- a/apps/docs/src/content/changelog/2026-07.mdx
+++ b/apps/docs/src/content/changelog/2026-07.mdx
@@ -1,8 +1,11 @@
 ---
 title: "July 2026"
-date: "2026-07-05"
+date: "2026-07-06"
 ---
 
+- PDF documents now open and preview correctly when you view them in Teak.
+- The desktop app now uploads files reliably again.
+- The desktop app can now record audio notes. macOS will ask for microphone access the first time.
 - Import and Export now share one place in Settings, with a quick tab to switch between them. Imports show step-by-step progress and explain exactly which items were skipped or why any failed.
 - Exports show live progress while your archive is prepared and count down to when your next weekly export unlocks.
 - Raycast, desktop, and MCP clients now let you sign in with your browser in one step. Copying an API key is no longer required to get started, and existing keys keep working.

--- a/apps/docs/src/content/docs/docs/ai-agents.mdx
+++ b/apps/docs/src/content/docs/docs/ai-agents.mdx
@@ -68,3 +68,9 @@ teak tags
 ## Is there an Agent Skill?
 
 Yes. Teak ships a public Agent Skill for assistants that support skills-based workflows. Use it when an agent needs to save, search, retrieve, update, favorite, delete, or sync Teak cards through the CLI, API, SDK, or MCP server.
+
+Install it from [Skills.sh](https://skills.sh/praveenjuge/teak):
+
+```bash
+npx skills add praveenjuge/teak --skill teak
+```

--- a/apps/docs/src/content/docs/docs/skills.mdx
+++ b/apps/docs/src/content/docs/docs/skills.mdx
@@ -5,13 +5,15 @@ description: Install the Teak Agent Skill for Codex, Claude Code, Cursor, and ot
 
 The Teak Agent Skill gives AI agents a reliable playbook for using Teak through the CLI, API, MCP server, and TypeScript SDK.
 
+View it on Skills.sh: [skills.sh/praveenjuge/teak](https://skills.sh/praveenjuge/teak)
+
 ## Install
 
 ```bash
 npx skills add praveenjuge/teak --skill teak
 ```
 
-The skill installs from Teak's public GitHub repository and works with skills-compatible agents such as Codex, Claude Code, Cursor, GitHub Copilot, Windsurf, and others.
+The skill installs from Teak's public GitHub repository and works with skills-compatible agents such as Codex, Claude Code, Cursor, GitHub Copilot, Windsurf, and others. Skills.sh lists public skills after successful installs are reported by the `skills` CLI, so installing the command above also makes Teak discoverable there.
 
 ## What It Teaches Agents
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -40,7 +40,7 @@
     "./constants/toast": "./src/constants/toast.ts"
   },
   "scripts": {
-    "test": "bun test src/components/forms/__tests__ src/components/settings/__tests__ src/hooks/__tests__ --coverage --dots",
+    "test": "bun test src/components/card-previews/__tests__ src/components/forms/__tests__ src/components/settings/__tests__ src/hooks/__tests__ --coverage --dots",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/ui/src/components/card-previews/DocumentPreview.tsx
+++ b/packages/ui/src/components/card-previews/DocumentPreview.tsx
@@ -76,11 +76,16 @@ export function DocumentPreview({ card }: DocumentPreviewProps) {
   const fileUrl = card.fileUrl;
 
   if (isPdf(fileName, mimeType) && fileUrl) {
+    // Intentionally NOT sandboxed. The browser's built-in PDF viewer refuses to
+    // render inside a sandboxed iframe (even with the most permissive flags),
+    // and combining `sandbox="allow-same-origin"` with a cross-origin file URL
+    // (our signed R2 links) trips a "Blocked a frame with origin ... from
+    // accessing a frame ..." SecurityError. Dropping the sandbox lets the PDF
+    // load directly from its cross-origin URL without the frame-access error.
     return (
       <div className="flex h-full w-full flex-col">
         <iframe
           className="h-full w-full rounded-lg"
-          sandbox="allow-same-origin allow-popups allow-downloads"
           src={fileUrl}
           title={fileName}
         />

--- a/packages/ui/src/components/card-previews/__tests__/DocumentPreview.test.tsx
+++ b/packages/ui/src/components/card-previews/__tests__/DocumentPreview.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DocumentPreview } from "../DocumentPreview";
+
+const createDocumentCard = (overrides?: Record<string, unknown>) => ({
+  _id: "card_doc_1",
+  _creationTime: Date.now(),
+  content: "Document card",
+  createdAt: Date.now(),
+  isDeleted: false,
+  isFavorited: false,
+  type: "document",
+  updatedAt: Date.now(),
+  userId: "user_123",
+  fileUrl:
+    "https://teak-files-prod.example.r2.cloudflarestorage.com/user/doc.pdf?sig=abc",
+  fileMetadata: {
+    fileName: "invoice.pdf",
+    mimeType: "application/pdf",
+  },
+  ...overrides,
+});
+
+describe("DocumentPreview", () => {
+  test("renders a PDF in an iframe without a sandbox attribute", () => {
+    // A sandboxed iframe (especially with allow-same-origin) breaks the
+    // browser PDF viewer and triggers a cross-origin "Blocked a frame" error
+    // for our signed R2 URLs. The iframe must render un-sandboxed.
+    const markup = renderToStaticMarkup(
+      <DocumentPreview card={createDocumentCard() as never} />
+    );
+
+    expect(markup).toContain("<iframe");
+    expect(markup).toContain("doc.pdf");
+    expect(markup).not.toContain("sandbox");
+    expect(markup).not.toContain("allow-same-origin");
+  });
+
+  test("detects PDFs by extension even when the mime type is missing", () => {
+    const markup = renderToStaticMarkup(
+      <DocumentPreview
+        card={
+          createDocumentCard({
+            fileMetadata: { fileName: "report.pdf", mimeType: "" },
+          }) as never
+        }
+      />
+    );
+
+    expect(markup).toContain("<iframe");
+    expect(markup).not.toContain("sandbox");
+  });
+
+  test("falls back to an icon and file name for non-PDF documents", () => {
+    const markup = renderToStaticMarkup(
+      <DocumentPreview
+        card={
+          createDocumentCard({
+            fileMetadata: {
+              fileName: "notes.docx",
+              mimeType:
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            },
+          }) as never
+        }
+      />
+    );
+
+    expect(markup).not.toContain("<iframe");
+    expect(markup).toContain("notes.docx");
+  });
+
+  test("does not render an iframe when the file URL is missing", () => {
+    const markup = renderToStaticMarkup(
+      <DocumentPreview card={createDocumentCard({ fileUrl: undefined }) as never} />
+    );
+
+    expect(markup).not.toContain("<iframe");
+    expect(markup).toContain("invoice.pdf");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes three desktop app regressions and adds Skills.sh discoverability links across the docs.

### Desktop app
- **File uploads / audio notes:** The main process now injects CORS headers on Cloudflare R2 responses and forces a 200 on the `OPTIONS` preflight, so the renderer's direct upload `PUT` and signed download `GET` succeed from the packaged `file://` (null) origin. This is the fix for both file uploads and saving audio recordings.
- **CSP:** Allow the R2 host in `connect-src` (uploads/downloads) and `frame-src` (PDF iframe) in the production CSP.
- **Microphone:** Register a permission handler that grants only the `media` permission and declare `NSMicrophoneUsageDescription` so macOS does not terminate the signed app when it accesses the microphone.
- **PDF preview:** Render the PDF preview iframe without a sandbox to avoid the cross-origin "Blocked a frame" `SecurityError` on signed R2 URLs.

### Docs
- Link Skills.sh from the README, docs apps grid, `ai-agents`, and `skills` pages.
- Add July 2026 changelog entries for the desktop upload, audio, and PDF fixes.

## Testing
- `bun test` in `packages/ui` (card-previews) — DocumentPreview PDF iframe tests pass.
- `bun test` in `apps/desktop` — R2 CORS/CSP wiring, microphone permission handling, and the macOS usage description tests pass (25 pass).
- `bun run pre-commit` (`turbo run typecheck lint build --affected`) passes.

## Notes
- CORS `Access-Control-Allow-Origin: *` on R2 responses is safe here: R2 rejects any request without a valid short-lived signature regardless of CORS, and the uploads carry no credentials.
