### PR TITLE
[codex] add production e2e workflow

### DIFF
--- a/.github/workflows/prod-e2e.yml
+++ b/.github/workflows/prod-e2e.yml
@@ -34,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v3
+      - run: bun install --frozen-lockfile
       - run: bun run --cwd packages/tests preflight
       - run: curl -fsS "$PROD_APP_URL/login" >/dev/null
       - run: bash scripts/smoke-urls.sh

--- a/.github/workflows/prod-e2e.yml
+++ b/.github/workflows/prod-e2e.yml
@@ -1,0 +1,145 @@
+name: Production E2E
+
+on:
+  schedule:
+    - cron: "17 5 * * *"
+  workflow_dispatch:
+    inputs:
+      sweep:
+        description: Run orphan account sweep after tests
+        default: true
+        required: false
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: prod-e2e
+  cancel-in-progress: false
+
+env:
+  PROD_APP_URL: https://app.teakvault.com
+  PROD_SITE_URL: https://teakvault.com
+  PROD_API_URL: https://teakvault.com/api
+  PROD_MCP_URL: https://teakvault.com/mcp
+  PROD_E2E_PASSWORD: ${{ secrets.PROD_E2E_PASSWORD }}
+  MAILPIT_URL: ${{ secrets.MAILPIT_URL }}
+  E2E_EMAIL_DOMAIN: ${{ secrets.E2E_EMAIL_DOMAIN }}
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v3
+      - run: bun run --cwd packages/tests preflight
+      - run: curl -fsS "$PROD_APP_URL/login" >/dev/null
+      - run: bash scripts/smoke-urls.sh
+
+  journey:
+    needs: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v3
+      - run: bun install --frozen-lockfile
+      - run: bun run build:cli
+      - run: npm install --prefix "$RUNNER_TEMP/teak-npm" teak-cli@latest
+      - run: bunx playwright install --with-deps chromium
+      - run: bun run --cwd packages/tests e2e:prod:journey
+      - if: always()
+        run: bun run --cwd packages/tests teardown
+      - if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: prod-e2e-journey-artifacts
+          path: |
+            packages/tests/playwright-report
+            packages/tests/test-results
+          retention-days: 7
+
+  docs:
+    needs: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v3
+      - run: bun install --frozen-lockfile
+      - run: bunx playwright install --with-deps chromium
+      - run: bun run --cwd packages/tests e2e:prod:docs
+
+  matrix:
+    needs: journey
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v3
+      - run: bun install --frozen-lockfile
+      - run: bunx playwright install --with-deps chromium firefox webkit
+      - run: bun run --cwd packages/tests e2e:prod:matrix
+      - if: always()
+        run: bun run --cwd packages/tests teardown
+
+  extension:
+    needs: journey
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      VITE_PUBLIC_CONVEX_URL: ${{ vars.VITE_PUBLIC_CONVEX_URL }}
+      VITE_PUBLIC_CONVEX_SITE_URL: ${{ vars.VITE_PUBLIC_CONVEX_SITE_URL }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v3
+      - run: bun install --frozen-lockfile
+      - run: bun run --cwd apps/extension build
+      - run: bunx playwright install --with-deps chromium
+      - run: bun run --cwd packages/tests e2e:prod:extension
+      - if: always()
+        run: bun run --cwd packages/tests teardown
+
+  sweep:
+    needs: [matrix, extension]
+    if: always() && (github.event_name == 'schedule' || inputs.sweep)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v3
+      - run: bun install --frozen-lockfile
+      - run: bunx playwright install --with-deps chromium
+      - run: bun run --cwd packages/tests sweep
+
+  notify:
+    needs: [gate, journey, docs, matrix, extension, sweep]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const failed = Object.entries({
+              gate: '${{ needs.gate.result }}',
+              journey: '${{ needs.journey.result }}',
+              docs: '${{ needs.docs.result }}',
+              matrix: '${{ needs.matrix.result }}',
+              extension: '${{ needs.extension.result }}',
+              sweep: '${{ needs.sweep.result }}',
+            }).filter(([, result]) => !['success', 'skipped'].includes(result));
+            const { owner, repo } = context.repo;
+            const label = 'prod-e2e-failure';
+            try { await github.rest.issues.createLabel({ owner, repo, name: label, color: 'd73a4a' }); } catch {}
+            const issues = await github.rest.issues.listForRepo({ owner, repo, labels: label, state: 'open' });
+            if (failed.length) {
+              const body = `Production E2E failed: ${failed.map(([name, result]) => `${name}=${result}`).join(', ')}\n\n${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+              if (issues.data[0]) await github.rest.issues.createComment({ owner, repo, issue_number: issues.data[0].number, body });
+              else await github.rest.issues.create({ owner, repo, title: 'Production E2E failure', labels: [label], body });
+              core.setFailed(body);
+            } else if (issues.data[0]) {
+              await github.rest.issues.createComment({ owner, repo, issue_number: issues.data[0].number, body: `Production E2E recovered.\n\n${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}` });
+              await github.rest.issues.update({ owner, repo, issue_number: issues.data[0].number, state: 'closed' });
+            }

--- a/bun.lock
+++ b/bun.lock
@@ -245,6 +245,24 @@
         "typescript": "^6.0.3",
       },
     },
+    "packages/tests": {
+      "name": "@teak/tests",
+      "version": "1.0.55",
+      "dependencies": {
+        "@axe-core/playwright": "^4.12.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@teak/convex": "workspace:*",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
+        "node-html-parser": "^7.0.1",
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.61.0",
+        "@types/bun": "^1.3.14",
+        "tsx": "^4.21.0",
+        "typescript": "^6.0.3",
+      },
+    },
     "packages/ui": {
       "name": "@teak/ui",
       "version": "1.0.55",
@@ -445,6 +463,8 @@
     "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.30", "", { "dependencies": { "@smithy/types": "^4.14.3", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ=="],
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
+
+    "@axe-core/playwright": ["@axe-core/playwright@4.12.1", "", { "dependencies": { "axe-core": "~4.12.1" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -926,6 +946,8 @@
 
     "@gar/promisify": ["@gar/promisify@1.1.3", "", {}, "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -1045,6 +1067,8 @@
     "@malept/flatpak-bundler": ["@malept/flatpak-bundler@0.4.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.0", "lodash": "^4.17.15", "tmp-promise": "^3.0.2" } }, "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
 
@@ -1662,6 +1686,8 @@
 
     "@teak/mobile": ["@teak/mobile@workspace:apps/mobile"],
 
+    "@teak/tests": ["@teak/tests@workspace:packages/tests"],
+
     "@teak/ui": ["@teak/ui@workspace:packages/ui"],
 
     "@teak/web": ["@teak/web@workspace:apps/web"],
@@ -1916,7 +1942,7 @@
 
     "ai": ["ai@6.0.184", "", { "dependencies": { "@ai-sdk/gateway": "3.0.115", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@opentelemetry/api": "^1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-j//zHkKvj5ra27l8izHco8cj1g1Pr7vx1ZK+hrzrkHvndgIRmdfZKOb6+RAPpvbk42qGIsuYvlYbGlVAu3erNQ=="],
 
-    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
 
@@ -1996,6 +2022,8 @@
 
     "aws4": ["aws4@1.13.2", "", {}, "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="],
 
+    "axe-core": ["axe-core@4.12.1", "", {}, "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA=="],
+
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "b4a": ["b4a@1.8.1", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw=="],
@@ -2050,6 +2078,8 @@
 
     "bluebird": ["bluebird@3.7.2", "", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
 
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
@@ -2101,6 +2131,8 @@
     "cacheable-request": ["cacheable-request@7.0.4", "", { "dependencies": { "clone-response": "^1.0.2", "get-stream": "^5.1.0", "http-cache-semantics": "^4.0.0", "keyv": "^4.0.0", "lowercase-keys": "^2.0.0", "normalize-url": "^6.0.1", "responselike": "^2.0.0" } }, "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -2218,6 +2250,10 @@
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "convex": ["convex@1.39.1", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.18.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-W+gVXA7BpRF1xLlS1kGTtKVaqd5yonqbGESKiPtIUXjV744GdDz8IG7RVsSY5KzHbgxuJBHKaJYk+92OIHTskQ=="],
@@ -2228,9 +2264,13 @@
 
     "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
 
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
     "core-js-compat": ["core-js-compat@3.48.0", "", { "dependencies": { "browserslist": "^4.28.1" } }, "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q=="],
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "crc": ["crc@3.8.0", "", { "dependencies": { "buffer": "^5.1.0" } }, "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ=="],
 
@@ -2488,6 +2528,8 @@
 
     "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
 
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
     "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
 
     "execa": ["execa@1.0.0", "", { "dependencies": { "cross-spawn": "^6.0.0", "get-stream": "^4.0.0", "is-stream": "^1.1.0", "npm-run-path": "^2.0.0", "p-finally": "^1.0.0", "signal-exit": "^3.0.0", "strip-eof": "^1.0.0" } }, "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA=="],
@@ -2570,6 +2612,10 @@
 
     "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
 
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
     "expressive-code": ["expressive-code@0.44.0", "", { "dependencies": { "@expressive-code/core": "^0.44.0", "@expressive-code/plugin-frames": "^0.44.0", "@expressive-code/plugin-shiki": "^0.44.0", "@expressive-code/plugin-text-markers": "^0.44.0" } }, "sha512-JXVWVNCKlLuZLMQH8cOiDUSosT0Bb+elwE/dbAkpwFwDFmyFyWlECoWZIohh2FkIF1iI67TQJ+Ts9k7oNDh2qA=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
@@ -2644,7 +2690,7 @@
 
     "filter-obj": ["filter-obj@1.1.0", "", {}, "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="],
 
-    "finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -2674,9 +2720,11 @@
 
     "formdata-node": ["formdata-node@6.0.3", "", {}, "sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg=="],
 
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
     "forwarded-parse": ["forwarded-parse@2.1.2", "", {}, "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="],
 
-    "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
@@ -2800,6 +2848,8 @@
 
     "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
+    "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
+
     "hermes-compiler": ["hermes-compiler@250829098.0.10", "", {}, "sha512-TcRlZ0/TlyfJqquRFAWoyElVNnkdYRi/sEp4/Qy8/GYxjg8j2cS9D4MjuaQ+qimkmLN7AmO+44IznRf06mAr0w=="],
 
     "hermes-estree": ["hermes-estree@0.33.3", "", {}, "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg=="],
@@ -2842,7 +2892,7 @@
 
     "iconv-corefoundation": ["iconv-corefoundation@1.1.7", "", { "dependencies": { "cli-truncate": "^2.1.0", "node-addon-api": "^1.6.3" }, "os": "darwin" }, "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ=="],
 
-    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -2879,6 +2929,8 @@
     "invariant": ["invariant@2.2.4", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA=="],
 
     "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "iron-webcrypto": ["iron-webcrypto@1.2.1", "", {}, "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="],
 
@@ -2933,6 +2985,8 @@
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
     "is-primitive": ["is-primitive@3.0.1", "", {}, "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-reference": ["is-reference@1.2.1", "", { "dependencies": { "@types/estree": "*" } }, "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ=="],
 
@@ -3184,11 +3238,15 @@
 
     "mdn-data": ["mdn-data@2.0.14", "", {}, "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="],
 
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
     "mem": ["mem@4.3.0", "", { "dependencies": { "map-age-cleaner": "^0.1.1", "mimic-fn": "^2.0.0", "p-is-promise": "^2.0.0" } }, "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w=="],
 
     "memoize-one": ["memoize-one@5.2.1", "", {}, "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="],
 
     "meow": ["meow@14.1.0", "", {}, "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge-options": ["merge-options@3.0.4", "", { "dependencies": { "is-plain-obj": "^2.1.0" } }, "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ=="],
 
@@ -3300,9 +3358,9 @@
 
     "mime": ["mime@2.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="],
 
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
@@ -3392,6 +3450,8 @@
 
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
+    "node-html-parser": ["node-html-parser@7.1.0", "", { "dependencies": { "css-select": "^5.1.0", "he": "1.2.0" } }, "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ=="],
+
     "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
 
     "node-mock-http": ["node-mock-http@1.0.4", "", {}, "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ=="],
@@ -3421,6 +3481,8 @@
     "ob1": ["ob1@0.84.4", "", { "dependencies": { "flow-enums-runtime": "^0.0.6" } }, "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
@@ -3518,6 +3580,8 @@
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
     "path-type": ["path-type@2.0.0", "", { "dependencies": { "pify": "^2.0.0" } }, "sha512-dUnb5dXUf+kzhC/W/F4e5/SkluXIFf5VUHolW1Eg1irn1hGWjPGdsRcvYJ1nD6lhk8Ir7VM0bHJKsYTx8Jx9OQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
@@ -3547,6 +3611,8 @@
     "pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
@@ -3622,6 +3688,8 @@
 
     "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "publish-browser-extension": ["publish-browser-extension@4.0.5", "", { "dependencies": { "cac": "^6.7.14", "consola": "^3.4.2", "dotenv": "^17.2.4", "form-data-encoder": "^4.1.0", "formdata-node": "^6.0.3", "jsonwebtoken": "^9.0.3", "listr2": "^10.1.0", "ofetch": "^1.5.1", "zod": "3.25.76 || ^4.3.6" }, "bin": { "publish-extension": "bin/publish-extension.mjs" } }, "sha512-EePAn3VIHJS/jqCuvs1NgPgoecCT8+RsES76hbgYe2Ze1dyvB0tX60C1PCrV8Z8fv56mW3E59s9Gd/GwWiw7dw=="],
@@ -3635,6 +3703,8 @@
     "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
 
     "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
@@ -3653,6 +3723,8 @@
     "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
@@ -3830,6 +3902,8 @@
 
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
@@ -3870,7 +3944,7 @@
 
     "serialize-javascript": ["serialize-javascript@6.0.2", "", { "dependencies": { "randombytes": "^2.1.0" } }, "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g=="],
 
-    "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "server-only": ["server-only@0.0.1", "", {}, "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="],
 
@@ -3897,6 +3971,14 @@
     "shellwords": ["shellwords@0.1.1", "", {}, "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="],
 
     "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
@@ -4129,6 +4211,8 @@
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
 
@@ -4394,6 +4478,8 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@1natsu/wait-element/defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
@@ -4557,8 +4643,6 @@
     "@inquirer/expand/@inquirer/type": ["@inquirer/type@2.0.0", "", { "dependencies": { "mute-stream": "^1.0.0" } }, "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag=="],
 
     "@inquirer/external-editor/chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
-
-    "@inquirer/external-editor/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "@inquirer/input/@inquirer/type": ["@inquirer/type@2.0.0", "", { "dependencies": { "mute-stream": "^1.0.0" } }, "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag=="],
 
@@ -4760,6 +4844,8 @@
 
     "@react-native/dev-middleware/open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
 
+    "@react-native/dev-middleware/serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
+
     "@react-native/dev-middleware/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "@rollup/plugin-commonjs/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
@@ -4868,7 +4954,11 @@
 
     "@wxt-dev/storage/@wxt-dev/browser": ["@wxt-dev/browser@0.1.37", "", { "dependencies": { "@types/filesystem": "*", "@types/har-format": "*" } }, "sha512-I32XWCNRy2W6UgbaVXz8BHGBGtm8urGRRBrcNLagUBXTrBi7wCE6zWePUvvK+nUl7qUCZ7iQ1ufdP0c1DEWisw=="],
 
+    "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "aggregate-error/clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
+
+    "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
@@ -4877,6 +4967,8 @@
     "app-builder-lib/@electron/rebuild": ["@electron/rebuild@4.0.4", "", { "dependencies": { "@malept/cross-spawn-promise": "^2.0.0", "debug": "^4.1.1", "node-abi": "^4.2.0", "node-api-version": "^0.2.1", "node-gyp": "^12.2.0", "read-binary-file-arch": "^1.0.6" }, "bin": { "electron-rebuild": "lib/cli.js" } }, "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg=="],
 
     "app-builder-lib/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
+
+    "app-builder-lib/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "app-builder-lib/ci-info": ["ci-info@4.3.1", "", {}, "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA=="],
 
@@ -4899,6 +4991,8 @@
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "boxen/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -4942,6 +5036,8 @@
 
     "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
 
+    "compressible/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "compression/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "compression/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
@@ -4949,6 +5045,8 @@
     "compression/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "concat-stream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "conf/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "conf/env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
 
@@ -4961,6 +5059,8 @@
     "configstore/dot-prop": ["dot-prop@9.0.0", "", { "dependencies": { "type-fest": "^4.18.2" } }, "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ=="],
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "connect/finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
 
     "crc/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
@@ -5000,6 +5100,8 @@
 
     "electron-winstaller/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
+    "encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
     "eslint/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
     "eslint/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
@@ -5014,6 +5116,12 @@
 
     "expo-modules-autolinking/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
+    "express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "express/send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
     "external-editor/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "external-editor/tmp": ["tmp@0.0.33", "", { "dependencies": { "os-tmpdir": "~1.0.2" } }, "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw=="],
@@ -5026,14 +5134,6 @@
 
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
-    "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
-    "finalhandler/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
-
-    "finalhandler/on-finished": ["on-finished@2.3.0", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww=="],
-
-    "finalhandler/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
-
     "firefox-profile/fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
 
     "firefox-profile/ini": ["ini@4.1.3", "", {}, "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg=="],
@@ -5041,6 +5141,8 @@
     "firefox-profile/xml2js": ["xml2js@0.6.2", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "fs-minipass/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
@@ -5117,8 +5219,6 @@
     "metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
     "metro/hermes-parser": ["hermes-parser@0.35.0", "", { "dependencies": { "hermes-estree": "0.35.0" } }, "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA=="],
-
-    "metro/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "metro/serialize-error": ["serialize-error@2.1.0", "", {}, "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw=="],
 
@@ -5240,13 +5340,19 @@
 
     "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
+    "schema-utils/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
     "schema-utils/ajv-formats": ["ajv-formats@2.1.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA=="],
 
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "send/fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
     "send/mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
 
     "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
+
+    "serve-static/send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
     "simple-plist/bplist-parser": ["bplist-parser@0.3.1", "", { "dependencies": { "big-integer": "1.6.x" } }, "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA=="],
 
@@ -5302,6 +5408,8 @@
 
     "trim-repeated/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
     "unicode-trie/pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
 
     "unifont/css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
@@ -5338,6 +5446,8 @@
 
     "webpack/json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
+    "webpack/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "webpack/tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
     "webpack/watchpack": ["watchpack@2.5.1", "", { "dependencies": { "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.1.2" } }, "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg=="],
@@ -5357,6 +5467,8 @@
     "xcode/uuid": ["uuid@7.0.3", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="],
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "yaml-language-server/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "yaml-language-server/request-light": ["request-light@0.5.8", "", {}, "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="],
 
@@ -5696,6 +5808,8 @@
 
     "@vitejs/plugin-react/vite/rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
 
+    "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
     "app-builder-lib/@electron/rebuild/node-abi": ["node-abi@4.29.0", "", { "dependencies": { "semver": "^7.6.3" } }, "sha512-bGc7hHz6lrdpMqH3XqfiHc5PKzEhjgUj6OLpTXynkLi9JZKyMByI/tdpm4Liu6O2BjtE1lakBWXjOQS1EnSQLQ=="],
 
     "app-builder-lib/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
@@ -5749,6 +5863,12 @@
     "configstore/dot-prop/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "connect/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "connect/finalhandler/encodeurl": ["encodeurl@1.0.2", "", {}, "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="],
+
+    "connect/finalhandler/on-finished": ["on-finished@2.3.0", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww=="],
+
+    "connect/finalhandler/statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
 
     "css-select/domhandler/domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
@@ -5814,13 +5934,15 @@
 
     "execa/cross-spawn/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "which": "./bin/which" } }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
 
+    "express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "extract-zip/yauzl/buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
-    "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
-
     "firefox-profile/xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "fs-minipass/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
@@ -5861,8 +5983,6 @@
     "metro/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "metro/hermes-parser/hermes-estree": ["hermes-estree@0.35.0", "", {}, "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg=="],
-
-    "metro/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "minipass-collect/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
@@ -5937,6 +6057,8 @@
     "vite-node/vite/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "webpack/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
+
+    "webpack/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -6195,6 +6317,8 @@
     "electron-builder-squirrel-windows/app-builder-lib/@electron/universal/fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
 
     "electron-builder-squirrel-windows/app-builder-lib/@electron/universal/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "electron-builder-squirrel-windows/app-builder-lib/dmg-builder/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "electron-builder-squirrel-windows/app-builder-lib/resedit/pe-library": ["pe-library@0.4.1", "", {}, "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "pre-commit": "turbo run typecheck lint build --affected",
     "prepare": "simple-git-hooks || exit 0",
     "start": "turbo run start",
-    "test": "turbo run test",
+    "test": "turbo run test --filter=!@teak/tests",
     "typecheck": "turbo run typecheck",
     "check": "ultracite check",
     "fix": "ultracite fix",

--- a/packages/tests/.gitignore
+++ b/packages/tests/.gitignore
@@ -1,0 +1,4 @@
+.state/
+.turbo/
+playwright-report/
+test-results/

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -1,0 +1,34 @@
+# Teak Production E2E Tests
+
+This private workspace package tests the live Teak production surfaces: web signup and account deletion, REST API, CLI, MCP, docs, browser matrix coverage, accessibility, security headers, credential lifecycle, and the Chrome extension build.
+
+Run from the repo root:
+
+```bash
+bun install
+bun run --cwd packages/tests e2e:prod:docs
+bun run --cwd packages/tests e2e:prod:journey
+bun run --cwd packages/tests teardown
+```
+
+Required secret:
+
+- `PROD_E2E_PASSWORD`: strong password used only for throwaway `e2e-*` production accounts. The password is never written to `.state`.
+- `MAILPIT_URL`: private Mailpit HTTP origin used for verification and reset email polling.
+- `E2E_EMAIL_DOMAIN`: private MX-routed domain used for throwaway account inboxes.
+
+Useful variables:
+
+- `PROD_APP_URL` defaults to `https://app.teakvault.com`
+- `PROD_SITE_URL` defaults to `https://teakvault.com`
+- `PROD_API_URL` defaults to `https://teakvault.com/api`
+- `PROD_MCP_URL` defaults to `https://teakvault.com/mcp`
+
+Mailpit preflight:
+
+1. Expose host port 25 to Mailpit's internal SMTP port 1025 on `coolify.yogeshdesign.com`.
+2. Allow port 25 in the Hetzner firewall.
+3. Point MX for the private test email domain at the Mailpit host.
+4. Send a probe email from Resend to `probe@<E2E_EMAIL_DOMAIN>` and confirm it appears in the Mailpit UI/API.
+
+Mailpit is public and unauthenticated over HTTP. That is acceptable here because these are throwaway accounts, API keys are not uploaded as artifacts, and the test password is never emailed.

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "e2e:prod:journey": "playwright test --project=journey-setup --project=journey",
+    "e2e:prod:journey": "playwright test --project=journey-setup --project=journey --project=journey-delete --project=journey-post-delete",
     "e2e:prod:docs": "playwright test --project=docs",
     "e2e:prod:matrix": "playwright test --project=matrix-chromium --project=matrix-firefox --project=matrix-webkit",
     "e2e:prod:extension": "playwright test --project=extension",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@teak/tests",
+  "version": "1.0.55",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "e2e:prod:journey": "playwright test --project=journey-setup --project=journey",
+    "e2e:prod:docs": "playwright test --project=docs",
+    "e2e:prod:matrix": "playwright test --project=matrix-chromium --project=matrix-firefox --project=matrix-webkit",
+    "e2e:prod:extension": "playwright test --project=extension",
+    "preflight": "tsx src/scripts/preflight.ts",
+    "teardown": "tsx src/scripts/teardown.ts",
+    "sweep": "tsx src/scripts/sweep.ts",
+    "lint": "biome check .",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@axe-core/playwright": "^4.12.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@teak/convex": "workspace:*",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
+    "node-html-parser": "^7.0.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.61.0",
+    "@types/bun": "^1.3.14",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/tests/playwright.config.ts
+++ b/packages/tests/playwright.config.ts
@@ -1,0 +1,65 @@
+import { defineConfig, devices } from "@playwright/test";
+import { env } from "./src/helpers/env";
+
+const journey = "src/journey/**/*.e2e.ts";
+
+export default defineConfig({
+  testDir: "./src",
+  timeout: 120_000,
+  expect: { timeout: 15_000 },
+  reporter: process.env.CI
+    ? [["list"], ["html", { open: "never" }]]
+    : [["list"]],
+  use: {
+    baseURL: env.appUrl,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "journey-setup",
+      testMatch: "journey/01-signup.setup.ts",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "journey",
+      dependencies: ["journey-setup"],
+      testIgnore: "journey/01-signup.setup.ts",
+      testMatch: journey,
+      workers: 1,
+      use: { ...devices["Desktop Chrome"], storageState: ".state/user.json" },
+    },
+    {
+      name: "docs",
+      testMatch: "docs/**/*.e2e.ts",
+      retries: 1,
+      use: { ...devices["Desktop Chrome"], baseURL: env.siteUrl },
+    },
+    {
+      name: "matrix-chromium",
+      testMatch: "matrix/journey-lite.e2e.ts",
+      workers: 1,
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "matrix-firefox",
+      testMatch: "matrix/journey-lite.e2e.ts",
+      workers: 1,
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "matrix-webkit",
+      testMatch: "matrix/journey-lite.e2e.ts",
+      workers: 1,
+      use: { ...devices["Desktop Safari"] },
+    },
+    {
+      name: "extension",
+      testMatch: "extension/save-page.e2e.ts",
+      workers: 1,
+      use: { ...devices["Desktop Chrome"], channel: "chromium" },
+    },
+  ],
+  outputDir: "test-results",
+});

--- a/packages/tests/playwright.config.ts
+++ b/packages/tests/playwright.config.ts
@@ -2,6 +2,8 @@ import { defineConfig, devices } from "@playwright/test";
 import { env } from "./src/helpers/env";
 
 const journey = "src/journey/**/*.e2e.ts";
+const deleteAccount = "journey/99-delete-account.e2e.ts";
+const postDelete = "journey/100-post-delete.e2e.ts";
 
 export default defineConfig({
   testDir: "./src",
@@ -25,10 +27,24 @@ export default defineConfig({
     {
       name: "journey",
       dependencies: ["journey-setup"],
-      testIgnore: "journey/01-signup.setup.ts",
+      testIgnore: ["journey/01-signup.setup.ts", deleteAccount, postDelete],
       testMatch: journey,
       workers: 1,
       use: { ...devices["Desktop Chrome"], storageState: ".state/user.json" },
+    },
+    {
+      name: "journey-delete",
+      dependencies: ["journey"],
+      testMatch: deleteAccount,
+      workers: 1,
+      use: { ...devices["Desktop Chrome"], storageState: ".state/user.json" },
+    },
+    {
+      name: "journey-post-delete",
+      dependencies: ["journey-delete"],
+      testMatch: postDelete,
+      workers: 1,
+      use: { ...devices["Desktop Chrome"] },
     },
     {
       name: "docs",

--- a/packages/tests/src/docs/crawl.e2e.ts
+++ b/packages/tests/src/docs/crawl.e2e.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+import { parse } from "node-html-parser";
+import { env } from "../helpers/env";
+
+const urlsFromXml = (xml: string) =>
+  [...xml.matchAll(/<loc>(.*?)<\/loc>/g)].map((m) => m[1]);
+
+test("sitemap pages and internal links resolve", async () => {
+  const index = await fetch(`${env.siteUrl}/sitemap-index.xml`).then((r) =>
+    r.text()
+  );
+  const sitemaps = urlsFromXml(index);
+  const pages = (
+    await Promise.all(
+      sitemaps.map((url) =>
+        fetch(url)
+          .then((r) => r.text())
+          .then(urlsFromXml)
+      )
+    )
+  ).flat();
+  expect(pages.length).toBeGreaterThan(0);
+  for (const url of pages.slice(
+    0,
+    Number(process.env.PROD_E2E_DOCS_PAGE_LIMIT ?? 80)
+  )) {
+    const response = await fetch(url);
+    expect(response.status, url).toBeLessThan(400);
+    const html = await response.text();
+    expect(parse(html).querySelector("title")?.text.trim(), url).toBeTruthy();
+    for (const link of parse(html)
+      .querySelectorAll("a[href^='/']")
+      .slice(0, 20)) {
+      expect(
+        (await fetch(new URL(link.getAttribute("href")!, env.siteUrl))).status
+      ).toBeLessThan(400);
+    }
+  }
+});

--- a/packages/tests/src/docs/extra-prod-surfaces.e2e.ts
+++ b/packages/tests/src/docs/extra-prod-surfaces.e2e.ts
@@ -1,0 +1,182 @@
+import { expect, test } from "@playwright/test";
+import { env } from "../helpers/env";
+
+interface Probe {
+  body: RegExp;
+  kind: "html" | "json" | "text";
+  name: string;
+  nosniff?: boolean;
+  url: string;
+}
+
+const probes: Probe[] = [
+  { name: "site home", url: `${env.siteUrl}/`, kind: "html", body: /Teak/i },
+  {
+    name: "apps directory",
+    url: `${env.siteUrl}/apps`,
+    kind: "html",
+    body: /Teak/i,
+  },
+  {
+    name: "docs home",
+    url: `${env.siteUrl}/docs/`,
+    kind: "html",
+    body: /Docs|Teak/i,
+  },
+  {
+    name: "api docs",
+    url: `${env.siteUrl}/docs/api/`,
+    kind: "html",
+    body: /API/i,
+  },
+  {
+    name: "mcp docs",
+    url: `${env.siteUrl}/docs/mcp/`,
+    kind: "html",
+    body: /MCP/i,
+  },
+  {
+    name: "cli docs",
+    url: `${env.siteUrl}/docs/cli/`,
+    kind: "html",
+    body: /CLI|teak/i,
+  },
+  {
+    name: "raycast docs",
+    url: `${env.siteUrl}/docs/raycast/`,
+    kind: "html",
+    body: /Raycast/i,
+  },
+  {
+    name: "skills docs",
+    url: `${env.siteUrl}/docs/skills/`,
+    kind: "html",
+    body: /Skill|Teak/i,
+  },
+  {
+    name: "llms text",
+    url: `${env.siteUrl}/llms.txt`,
+    kind: "text",
+    body: /Teak/i,
+  },
+  {
+    name: "mcp well known",
+    url: `${env.siteUrl}/.well-known/mcp.json`,
+    kind: "json",
+    body: /endpoint/,
+  },
+  {
+    name: "apex api health",
+    url: `${env.siteUrl}/api/healthz`,
+    kind: "json",
+    body: /ok/,
+  },
+  {
+    name: "apex api root",
+    url: `${env.siteUrl}/api`,
+    kind: "json",
+    body: /v1/,
+  },
+  {
+    name: "apex api v1",
+    url: `${env.siteUrl}/api/v1`,
+    kind: "json",
+    body: /endpoint/,
+  },
+  {
+    name: "apex openapi",
+    url: `${env.siteUrl}/api/openapi.json`,
+    kind: "json",
+    body: /openapi/,
+  },
+  {
+    name: "apex mcp resource",
+    url: `${env.siteUrl}/.well-known/oauth-protected-resource/mcp`,
+    kind: "json",
+    body: /resource/,
+  },
+  {
+    name: "app login",
+    url: `${env.appUrl}/login`,
+    kind: "html",
+    body: /login|sign in/i,
+  },
+  {
+    name: "app register",
+    url: `${env.appUrl}/register`,
+    kind: "html",
+    body: /register|account/i,
+  },
+  {
+    name: "app forgot password",
+    url: `${env.appUrl}/forgot-password`,
+    kind: "html",
+    body: /Teak/i,
+  },
+  {
+    name: "api subdomain health",
+    url: "https://api.teakvault.com/healthz",
+    kind: "json",
+    body: /ok/,
+    nosniff: false,
+  },
+  {
+    name: "api subdomain v1",
+    url: "https://api.teakvault.com/v1",
+    kind: "json",
+    body: /endpoint/,
+    nosniff: false,
+  },
+  {
+    name: "api subdomain openapi",
+    url: "https://api.teakvault.com/openapi.json",
+    kind: "json",
+    body: /openapi/,
+    nosniff: false,
+  },
+];
+
+const contentType = {
+  html: /text\/html/,
+  json: /application\/json/,
+  text: /text\/plain/,
+} as const;
+
+for (const [index, probe] of probes.entries()) {
+  const prefix = `extra-${String(index + 1).padStart(3, "0")} ${probe.name}`;
+
+  test(`${prefix} status is successful`, async () => {
+    expect((await fetch(probe.url)).status).toBeLessThan(400);
+  });
+
+  test(`${prefix} content type is stable`, async () => {
+    const response = await fetch(probe.url);
+    expect(response.headers.get("content-type") ?? "").toMatch(
+      contentType[probe.kind]
+    );
+  });
+
+  test(`${prefix} security headers are present`, async () => {
+    const response = await fetch(probe.url);
+    expect(response.headers.get("strict-transport-security") ?? "").toContain(
+      "max-age"
+    );
+    if (probe.nosniff !== false) {
+      expect(response.headers.get("x-content-type-options") ?? "").toBe(
+        "nosniff"
+      );
+    }
+  });
+
+  test(`${prefix} body contains expected product marker`, async () => {
+    const body = await fetch(probe.url).then((response) => response.text());
+    expect(body).toMatch(probe.body);
+  });
+
+  test(`${prefix} body has no obvious server error leak`, async () => {
+    const body = await fetch(probe.url).then((response) => response.text());
+    expect(body).not.toMatch(
+      /Unhandled Runtime Error|Internal Server Error|stack trace/i
+    );
+  });
+}

--- a/packages/tests/src/docs/meta.e2e.ts
+++ b/packages/tests/src/docs/meta.e2e.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import { env } from "../helpers/env";
+
+test("llms, OpenAPI, and OAuth metadata are fresh", async () => {
+  expect(await fetch(`${env.siteUrl}/llms.txt`).then((r) => r.status)).toBe(
+    200
+  );
+  const spec = await fetch(`${env.apiUrl}/openapi.json`).then(
+    (r) => r.json() as any
+  );
+  for (const path of [
+    "/v1/cards",
+    "/v1/uploads",
+    "/v1/cards/bulk",
+    "/v1/cards/search",
+    "/v1/cards/favorites",
+    "/v1/tags",
+  ]) {
+    expect(spec.paths[path], path).toBeTruthy();
+  }
+  const protectedResource = await fetch(
+    `${env.siteUrl}/.well-known/oauth-protected-resource/mcp`
+  );
+  expect(protectedResource.status).toBe(200);
+  expect(await protectedResource.json()).toMatchObject({
+    resource: env.mcpUrl,
+  });
+});

--- a/packages/tests/src/docs/pages.e2e.ts
+++ b/packages/tests/src/docs/pages.e2e.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+
+for (const path of ["/docs/", "/docs/api/", "/docs/mcp/", "/docs/cli/"]) {
+  test(`docs key page ${path}`, async ({ page }) => {
+    await page.goto(path);
+    await expect(page.locator("h1")).toBeVisible();
+    await expect(page.locator("body")).toContainText(/Teak|API|MCP|CLI/);
+  });
+}
+
+test("docs Pagefind assets are published", async ({ page }) => {
+  for (const path of [
+    "/pagefind/pagefind.js",
+    "/pagefind/pagefind-ui.js",
+    "/pagefind/pagefind-ui.css",
+    "/pagefind/pagefind-entry.json",
+  ]) {
+    const response = await page.request.get(path);
+    expect(response.status(), path).toBe(200);
+  }
+});

--- a/packages/tests/src/extension/save-page.e2e.ts
+++ b/packages/tests/src/extension/save-page.e2e.ts
@@ -1,0 +1,40 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { chromium, expect, test } from "@playwright/test";
+import { clientFor, createAccount, deleteAccountViaUi } from "../helpers/prod";
+
+test("extension build loads and account can save the active page", async ({
+  browserName,
+}) => {
+  test.skip(browserName !== "chromium", "Chrome extensions require Chromium");
+  const extensionPath = resolve("../../apps/extension/.output/chrome-mv3");
+  expect(existsSync(extensionPath)).toBe(true);
+  const context = await chromium.launchPersistentContext("", {
+    headless: true,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+    ],
+  });
+  const page = await context.newPage();
+  const account = await createAccount(page, "extension");
+  try {
+    const serviceWorker =
+      context.serviceWorkers()[0] ??
+      (await context.waitForEvent("serviceworker"));
+    const extensionId = new URL(serviceWorker.url()).host;
+    const popup = await context.newPage();
+    await popup.goto(`chrome-extension://${extensionId}/popup.html`);
+    await expect(popup.locator("body")).toContainText(
+      /Teak|Sign in|Adding|Added/
+    );
+    const created = await clientFor(account.apiKey!).cards.create({
+      content: "https://example.com",
+      source: "prod-e2e-extension",
+    });
+    expect(created.cardId).toBeTruthy();
+  } finally {
+    await deleteAccountViaUi(page, account);
+    await context.close();
+  }
+});

--- a/packages/tests/src/helpers/api.ts
+++ b/packages/tests/src/helpers/api.ts
@@ -1,0 +1,81 @@
+import { appendFileSync } from "node:fs";
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+import { env } from "./env";
+
+interface Perf {
+  endpoint: string;
+  ms: number;
+  status: number;
+}
+const perf: Perf[] = [];
+
+export const apiFetch = async (
+  path: string,
+  apiKey: string,
+  init: RequestInit = {}
+) => {
+  const start = performance.now();
+  const response = await fetch(`${env.apiUrl}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+  perf.push({
+    endpoint: path,
+    ms: Math.round(performance.now() - start),
+    status: response.status,
+  });
+  return response;
+};
+
+export const loadOpenApi = async () => {
+  const response = await fetch(`${env.apiUrl}/openapi.json`);
+  if (!response.ok) {
+    throw new Error(`OpenAPI failed: ${response.status}`);
+  }
+  const spec = (await response.json()) as any;
+  const ajv = new Ajv({ strict: false });
+  addFormats(ajv as any);
+  return {
+    spec,
+    validate(path: string, method: string, status: number, payload: unknown) {
+      const schema =
+        spec.paths?.[path]?.[method.toLowerCase()]?.responses?.[status]
+          ?.content?.["application/json"]?.schema;
+      if (!schema) {
+        return;
+      }
+      const ok = ajv.compile(schema)(payload);
+      if (!ok) {
+        throw new Error(`OpenAPI mismatch ${method} ${path} ${status}`);
+      }
+    },
+  };
+};
+
+export const perfSummary = () => {
+  const rows = perf.map((p) => `| ${p.endpoint} | ${p.status} | ${p.ms}ms |`);
+  const table = [
+    "| Endpoint | Status | Latency |",
+    "| --- | ---: | ---: |",
+    ...rows,
+  ].join("\n");
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(
+      process.env.GITHUB_STEP_SUMMARY,
+      `\n### Production API latency\n\n${table}\n`
+    );
+  }
+  const slow = perf.filter(
+    (p) => p.ms > Number(process.env.PROD_E2E_API_BUDGET_MS ?? 5000)
+  );
+  if (slow.length) {
+    throw new Error(
+      `API latency budget exceeded: ${slow.map((p) => p.endpoint).join(", ")}`
+    );
+  }
+};

--- a/packages/tests/src/helpers/cli.ts
+++ b/packages/tests/src/helpers/cli.ts
@@ -1,0 +1,35 @@
+import { spawn } from "node:child_process";
+import { env } from "./env";
+
+export const runCli = async (
+  kind: "repo" | "npm",
+  args: string[],
+  apiKey: string
+) => {
+  const npmBin =
+    process.env.TEAK_NPM_BIN ||
+    `${process.env.RUNNER_TEMP}/teak-npm/node_modules/.bin/teak`;
+  const command =
+    kind === "repo"
+      ? ["bun", "apps/cli/src/index.ts", ...args]
+      : [npmBin, ...args];
+  const proc = spawn(command[0], command.slice(1), {
+    cwd: new URL("../../../../", import.meta.url).pathname,
+    env: { ...process.env, TEAK_API_KEY: apiKey, TEAK_API_URL: env.apiUrl },
+  });
+  let stdout = "";
+  let stderr = "";
+  proc.stdout.on("data", (chunk) => {
+    stdout += String(chunk);
+  });
+  proc.stderr.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
+  const code = await new Promise<number | null>((resolve) => {
+    proc.on("close", resolve);
+  });
+  if (code !== 0) {
+    throw new Error(`${kind} CLI failed: ${stderr || stdout}`);
+  }
+  return stdout.trim();
+};

--- a/packages/tests/src/helpers/env.ts
+++ b/packages/tests/src/helpers/env.ts
@@ -1,0 +1,28 @@
+const trim = (value: string | undefined, fallback: string) =>
+  (value?.trim() || fallback).replace(/\/+$/, "");
+
+export const env = {
+  appUrl: trim(process.env.PROD_APP_URL, "https://app.teakvault.com"),
+  siteUrl: trim(process.env.PROD_SITE_URL, "https://teakvault.com"),
+  apiUrl: trim(process.env.PROD_API_URL, "https://teakvault.com/api"),
+  mcpUrl: trim(process.env.PROD_MCP_URL, "https://teakvault.com/mcp"),
+  mailpitUrl: trim(process.env.MAILPIT_URL, ""),
+  emailDomain: process.env.E2E_EMAIL_DOMAIN?.trim() || "",
+  password: process.env.PROD_E2E_PASSWORD || "",
+};
+
+export const requirePassword = () => {
+  if (!env.password) {
+    throw new Error("PROD_E2E_PASSWORD is required");
+  }
+  return env.password;
+};
+
+export const requireMailpit = () => {
+  if (!(env.mailpitUrl && env.emailDomain)) {
+    throw new Error("MAILPIT_URL and E2E_EMAIL_DOMAIN secrets are required");
+  }
+};
+
+export const uniqueEmail = (label = "primary") =>
+  `e2e-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@${env.emailDomain}`;

--- a/packages/tests/src/helpers/mailpit.ts
+++ b/packages/tests/src/helpers/mailpit.ts
@@ -1,0 +1,63 @@
+import { env, requireMailpit } from "./env";
+
+interface MailpitMessage {
+  ID: string;
+  Subject: string;
+  To: Array<{ Address: string }>;
+}
+
+const api = (path: string) => `${env.mailpitUrl}/api/v1${path}`;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const assertMailpitReady = async () => {
+  requireMailpit();
+  const response = await fetch(api("/messages?limit=1"));
+  if (!response.ok) {
+    throw new Error(`Mailpit not ready: ${response.status}`);
+  }
+};
+
+export const waitForEmail = async (to: string, subject: string) => {
+  const deadline = Date.now() + 180_000;
+  while (Date.now() < deadline) {
+    const response = await fetch(api("/messages?limit=50"));
+    if (!response.ok) {
+      throw new Error(`Mailpit search failed: ${response.status}`);
+    }
+    const data = (await response.json()) as { messages?: MailpitMessage[] };
+    const hit = data.messages?.find(
+      (message) =>
+        message.Subject === subject &&
+        message.To.some((recipient) => recipient.Address.toLowerCase() === to)
+    );
+    if (hit) {
+      const detail = await fetch(api(`/message/${hit.ID}`));
+      const body = (await detail.json()) as { HTML?: string; Text?: string };
+      const link = (body.HTML || body.Text || "").match(
+        /https?:\/\/[^"' <]+/
+      )?.[0];
+      if (!link) {
+        throw new Error(`Email ${subject} for ${to} had no link`);
+      }
+      return link.replace(/&amp;/g, "&");
+    }
+    await sleep(5000);
+  }
+  throw new Error(`Timed out waiting for ${subject} email to ${to}`);
+};
+
+export const deleteMessagesFor = async (email: string) => {
+  const response = await fetch(api("/messages?limit=100"));
+  if (!response.ok) {
+    return;
+  }
+  const data = (await response.json()) as { messages?: MailpitMessage[] };
+  for (const message of data.messages ?? []) {
+    if (
+      message.To.some((recipient) => recipient.Address.toLowerCase() === email)
+    ) {
+      await fetch(api(`/message/${message.ID}`), { method: "DELETE" });
+    }
+  }
+};

--- a/packages/tests/src/helpers/mcp.ts
+++ b/packages/tests/src/helpers/mcp.ts
@@ -1,0 +1,12 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { env } from "./env";
+
+export const connectMcp = async (apiKey: string) => {
+  const client = new Client({ name: "teak-prod-e2e", version: "1.0.0" });
+  const transport = new StreamableHTTPClientTransport(new URL(env.mcpUrl), {
+    requestInit: { headers: { Authorization: `Bearer ${apiKey}` } },
+  });
+  await client.connect(transport);
+  return client;
+};

--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -11,12 +11,14 @@ export const clientFor = (apiKey: string) =>
     userAgent: "teak-prod-e2e",
   });
 
+const appPath = (path: string) => new URL(path, env.appUrl).toString();
+
 export const signIn = async (
   page: Page,
   email: string,
   password = requirePassword()
 ) => {
-  await page.goto("/login");
+  await page.goto(appPath("/login"));
   await page.getByLabel("Email").fill(email);
   await page.getByLabel("Password").fill(password);
   await page.getByRole("button", { name: /login|sign in/i }).click();
@@ -27,7 +29,7 @@ export const passwordFor = (account: AccountState) =>
   account.passwordReset ? `${requirePassword()}Reset1!` : requirePassword();
 
 export const signUp = async (page: Page, email = uniqueEmail()) => {
-  await page.goto("/register");
+  await page.goto(appPath("/register"));
   await page.getByLabel("Email").fill(email);
   await page.getByLabel("Password").fill(requirePassword());
   await page
@@ -42,7 +44,7 @@ export const signUp = async (page: Page, email = uniqueEmail()) => {
 };
 
 export const generateApiKey = async (page: Page) => {
-  await page.goto("/settings");
+  await page.goto(appPath("/settings"));
   await page.getByText("API Keys").waitFor();
   await page.getByRole("button", { name: "Manage" }).click();
   await expect(
@@ -67,7 +69,7 @@ export const deleteAccountViaUi = async (page: Page, account: AccountState) => {
     return;
   }
   await signIn(page, account.email, passwordFor(account));
-  await page.goto("/settings");
+  await page.goto(appPath("/settings"));
   await page.getByRole("button", { name: /delete your account/i }).click();
   await expect(
     page.getByRole("dialog", { name: "Delete Account" })
@@ -89,7 +91,7 @@ export const deleteAccountViaUi = async (page: Page, account: AccountState) => {
 
 export const revokeVisibleKey = async (page: Page, rawKey: string) => {
   const suffix = rawKey.slice(-4);
-  await page.goto("/settings");
+  await page.goto(appPath("/settings"));
   await page.getByRole("button", { name: "Manage" }).click();
   const row = page.locator("div").filter({ hasText: suffix }).last();
   await row.getByRole("button", { name: "Revoke" }).click();

--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -1,0 +1,97 @@
+import { expect, type Page } from "@playwright/test";
+import { createTeakClient } from "@teak/convex/sdk";
+import { env, requirePassword, uniqueEmail } from "./env";
+import { waitForEmail } from "./mailpit";
+import { type AccountState, rememberAccount, updateState } from "./run-state";
+
+export const clientFor = (apiKey: string) =>
+  createTeakClient({
+    baseUrl: env.apiUrl,
+    tokenProvider: { getAccessToken: async () => apiKey },
+    userAgent: "teak-prod-e2e",
+  });
+
+export const signIn = async (
+  page: Page,
+  email: string,
+  password = requirePassword()
+) => {
+  await page.goto("/login");
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(password);
+  await page.getByRole("button", { name: /login|sign in/i }).click();
+  await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
+};
+
+export const passwordFor = (account: AccountState) =>
+  account.passwordReset ? `${requirePassword()}Reset1!` : requirePassword();
+
+export const signUp = async (page: Page, email = uniqueEmail()) => {
+  await page.goto("/register");
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(requirePassword());
+  await page
+    .getByRole("button", { name: /create an account|sign up/i })
+    .click();
+  await expect(
+    page.getByText(`Verification email sent to ${email}`)
+  ).toBeVisible();
+  await page.goto(await waitForEmail(email, "Verify your email address"));
+  await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
+  return email;
+};
+
+export const generateApiKey = async (page: Page) => {
+  await page.goto("/settings");
+  await page.getByText("API Keys").waitFor();
+  await page.getByRole("button", { name: "Manage" }).click();
+  await expect(
+    page.getByRole("dialog", { name: "Manage API Keys" })
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Generate Key" }).click();
+  const input = page.locator('input[readonly][value^="teakapi_"]').first();
+  await expect(input).toHaveValue(/^teakapi_/);
+  return input.inputValue();
+};
+
+export const createAccount = async (page: Page, label = "acct") => {
+  const email = await signUp(page, uniqueEmail(label));
+  const apiKey = await generateApiKey(page);
+  const account = { email, apiKey };
+  rememberAccount(account);
+  return account;
+};
+
+export const deleteAccountViaUi = async (page: Page, account: AccountState) => {
+  if (account.deleted) {
+    return;
+  }
+  await signIn(page, account.email, passwordFor(account));
+  await page.goto("/settings");
+  await page.getByRole("button", { name: /delete your account/i }).click();
+  await expect(
+    page.getByRole("dialog", { name: "Delete Account" })
+  ).toBeVisible();
+  await page.locator("#deleteConfirm").fill("delete account");
+  await page.getByRole("button", { name: "Delete account" }).click();
+  await expect(page).toHaveURL(/\/login/);
+  updateState((state) => {
+    for (const saved of state.accounts) {
+      if (saved.email === account.email) {
+        saved.deleted = true;
+      }
+    }
+    if (state.primary?.email === account.email) {
+      state.primary.deleted = true;
+    }
+  });
+};
+
+export const revokeVisibleKey = async (page: Page, rawKey: string) => {
+  const suffix = rawKey.slice(-4);
+  await page.goto("/settings");
+  await page.getByRole("button", { name: "Manage" }).click();
+  const row = page.locator("div").filter({ hasText: suffix }).last();
+  await row.getByRole("button", { name: "Revoke" }).click();
+  await expect(row.getByText(/revoked/i)).toBeVisible();
+};

--- a/packages/tests/src/helpers/run-state.ts
+++ b/packages/tests/src/helpers/run-state.ts
@@ -1,0 +1,54 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export interface AccountState {
+  apiKey?: string;
+  deleted?: boolean;
+  email: string;
+  passwordReset?: boolean;
+}
+
+export interface RunState {
+  accounts: AccountState[];
+  createdCardIds: string[];
+  primary?: AccountState;
+  revokedKey?: string;
+}
+
+const file = new URL("../../.state/run-state.json", import.meta.url);
+export const storageStateFile = ".state/user.json";
+
+export const readState = (): RunState => {
+  try {
+    return JSON.parse(readFileSync(file, "utf8")) as RunState;
+  } catch {
+    return { accounts: [], createdCardIds: [] };
+  }
+};
+
+export const writeState = (next: RunState) => {
+  mkdirSync(dirname(file.pathname), { recursive: true });
+  writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`);
+};
+
+export const updateState = (fn: (state: RunState) => void) => {
+  const state = readState();
+  fn(state);
+  writeState(state);
+  return state;
+};
+
+export const rememberAccount = (account: AccountState, primary = false) =>
+  updateState((state) => {
+    const index = state.accounts.findIndex(
+      (item) => item.email === account.email
+    );
+    if (index >= 0) {
+      state.accounts[index] = { ...state.accounts[index], ...account };
+    } else {
+      state.accounts.push(account);
+    }
+    if (primary) {
+      state.primary = { ...(state.primary ?? account), ...account };
+    }
+  });

--- a/packages/tests/src/journey/01-signup.setup.ts
+++ b/packages/tests/src/journey/01-signup.setup.ts
@@ -1,0 +1,15 @@
+import { test } from "@playwright/test";
+import { assertMailpitReady } from "../helpers/mailpit";
+import { createAccount } from "../helpers/prod";
+import { storageStateFile, updateState } from "../helpers/run-state";
+
+test.setTimeout(240_000);
+
+test("create verified production account and API key", async ({ page }) => {
+  await assertMailpitReady();
+  const account = await createAccount(page, "primary");
+  updateState((state) => {
+    state.primary = account;
+  });
+  await page.context().storageState({ path: storageStateFile });
+});

--- a/packages/tests/src/journey/02-web-journey.e2e.ts
+++ b/packages/tests/src/journey/02-web-journey.e2e.ts
@@ -1,0 +1,64 @@
+import { Buffer } from "node:buffer";
+import { expect, test } from "@playwright/test";
+import { clientFor, generateApiKey, revokeVisibleKey } from "../helpers/prod";
+import { readState, updateState } from "../helpers/run-state";
+
+test("web journey covers cards, search, settings, upload, and revoked key", async ({
+  page,
+}) => {
+  const state = readState();
+  if (!state.primary?.apiKey) {
+    throw new Error("Missing primary API key");
+  }
+  const marker = `prod-e2e-${Date.now()}`;
+  const dialogTrap: string[] = [];
+  page.on("dialog", (dialog) => {
+    dialogTrap.push(dialog.message());
+    return dialog.dismiss();
+  });
+  await page.goto("/");
+  await expect(page.getByText(/Let's add your first card/i)).toBeVisible();
+  await page
+    .getByPlaceholder(/Write a note/i)
+    .fill(`${marker} <script>alert("xss")</script>`);
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(page.getByRole("main").getByText(marker)).toBeVisible();
+  await page.getByPlaceholder("Search for anything...").fill(marker);
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("main").getByText(marker)).toBeVisible();
+  await page.getByRole("button", { name: "Clear All" }).click();
+
+  const api = clientFor(state.primary.apiKey);
+  const png = Buffer.from(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+    "base64"
+  );
+  const upload = await api.uploads.create({
+    fileName: "pixel.png",
+    fileSize: png.byteLength,
+    mimeType: "image/png",
+  });
+  await api.uploads.putFile(upload.uploadUrl, png, "image/png");
+  const link = await api.cards.create({
+    content: "https://example.com",
+    tags: ["prod-e2e"],
+    source: "prod-e2e",
+  });
+  const text = await api.cards.create({
+    content: marker,
+    tags: ["prod-e2e"],
+    source: "prod-e2e",
+  });
+  await api.cards.setFavorite(text.cardId, true);
+  updateState((s) => s.createdCardIds.push(link.cardId, text.cardId));
+
+  await page.goto("/settings");
+  await expect(page.getByText(state.primary.email)).toBeVisible();
+  await expect(page.getByText("Free Plan")).toBeVisible();
+  const revokedKey = await generateApiKey(page);
+  await revokeVisibleKey(page, revokedKey);
+  updateState((s) => {
+    s.revokedKey = revokedKey;
+  });
+  expect(dialogTrap).toEqual([]);
+});

--- a/packages/tests/src/journey/03-api.e2e.ts
+++ b/packages/tests/src/journey/03-api.e2e.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test";
+import { apiFetch, loadOpenApi } from "../helpers/api";
+import { readState, updateState } from "../helpers/run-state";
+
+test("REST API happy paths and OpenAPI contracts", async () => {
+  const { primary } = readState();
+  if (!primary?.apiKey) {
+    throw new Error("Missing primary API key");
+  }
+  const openapi = await loadOpenApi();
+  for (const path of [
+    "/v1/cards",
+    "/v1/cards/search",
+    "/v1/cards/favorites",
+    "/v1/tags",
+  ]) {
+    const response = await apiFetch(path, primary.apiKey);
+    expect(response.ok).toBe(true);
+    openapi.validate(
+      path,
+      "GET",
+      response.status,
+      await response.clone().json()
+    );
+  }
+  const created = await apiFetch("/v1/cards", primary.apiKey, {
+    method: "POST",
+    body: JSON.stringify({
+      content: `api-prod-e2e-${Date.now()}`,
+      tags: ["prod-e2e"],
+      source: "prod-e2e",
+    }),
+  });
+  const payload = await created.json();
+  openapi.validate("/v1/cards", "POST", created.status, payload);
+  updateState((s) => s.createdCardIds.push(payload.cardId));
+  const cardPath = `/v1/cards/${payload.cardId}`;
+  expect((await apiFetch(cardPath, primary.apiKey)).status).toBe(200);
+  expect(
+    (
+      await apiFetch(`${cardPath}/favorite`, primary.apiKey, {
+        method: "PATCH",
+        body: JSON.stringify({ isFavorited: true }),
+      })
+    ).status
+  ).toBe(200);
+  expect(
+    (
+      await apiFetch(cardPath, primary.apiKey, {
+        method: "PATCH",
+        body: JSON.stringify({ notes: "updated by prod e2e" }),
+      })
+    ).status
+  ).toBe(200);
+  expect(
+    (
+      await apiFetch("/v1/cards/bulk", primary.apiKey, {
+        method: "POST",
+        body: JSON.stringify({
+          operation: "create",
+          items: [{ content: "bulk prod e2e" }],
+        }),
+      })
+    ).status
+  ).toBe(200);
+  expect((await apiFetch("/v1/cards/not-a-card", primary.apiKey)).status).toBe(
+    404
+  );
+});

--- a/packages/tests/src/journey/04-cli.e2e.ts
+++ b/packages/tests/src/journey/04-cli.e2e.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "@playwright/test";
+import { runCli } from "../helpers/cli";
+import { readState, updateState } from "../helpers/run-state";
+
+for (const kind of ["repo", "npm"] as const) {
+  test(`${kind} CLI covers auth, cards, tags, and aliases`, async () => {
+    const { primary } = readState();
+    if (!primary?.apiKey) {
+      throw new Error("Missing primary API key");
+    }
+    expect(
+      JSON.parse(
+        await runCli(kind, ["--json", "auth", "status"], primary.apiKey)
+      ).status
+    ).toBe("ok");
+    const created = JSON.parse(
+      await runCli(
+        kind,
+        ["--json", "cards", "create", `cli-${kind}-${Date.now()}`],
+        primary.apiKey
+      )
+    );
+    updateState((s) => s.createdCardIds.push(created.cardId));
+    for (const args of [
+      ["--json", "cards", "list", "--limit", "5"],
+      ["--json", "cards", "search", "cli"],
+      ["--json", "cards", "favorites"],
+      ["--json", "cards", "get", created.cardId],
+      ["--json", "tags"],
+      ["--json", "ls", "--limit", "1"],
+      ["--json", "search", "cli"],
+    ]) {
+      expect(await runCli(kind, args, primary.apiKey)).toBeTruthy();
+    }
+  });
+}

--- a/packages/tests/src/journey/05-mcp.e2e.ts
+++ b/packages/tests/src/journey/05-mcp.e2e.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "@playwright/test";
+import { env } from "../helpers/env";
+import { connectMcp } from "../helpers/mcp";
+import { readState, updateState } from "../helpers/run-state";
+
+test("MCP lists and calls every public tool", async () => {
+  const { primary, createdCardIds } = readState();
+  if (!primary?.apiKey) {
+    throw new Error("Missing primary API key");
+  }
+  const unauth = await fetch(env.mcpUrl);
+  expect(unauth.status).toBe(401);
+  expect(unauth.headers.get("www-authenticate")).toContain("resource_metadata");
+  const client = await connectMcp(primary.apiKey);
+  const tools = await client.listTools();
+  expect(tools.tools.map((tool) => tool.name).sort()).toEqual(
+    [
+      "fetch",
+      "search",
+      "teak_v1_bulk_cards",
+      "teak_v1_create_card",
+      "teak_v1_create_upload",
+      "teak_v1_delete_card",
+      "teak_v1_get_card",
+      "teak_v1_get_card_changes",
+      "teak_v1_list_cards",
+      "teak_v1_list_favorite_cards",
+      "teak_v1_list_tags",
+      "teak_v1_search_cards",
+      "teak_v1_set_card_favorite",
+      "teak_v1_update_card",
+    ].sort()
+  );
+  const created: any = await client.callTool({
+    name: "teak_v1_create_card",
+    arguments: { content: `mcp-${Date.now()}` },
+  });
+  const cardId = created.structuredContent.cardId;
+  updateState((s) => s.createdCardIds.push(cardId));
+  const calls = [
+    ["teak_v1_list_cards", { limit: 5 }],
+    ["teak_v1_get_card", { cardId }],
+    ["teak_v1_search_cards", { q: "mcp" }],
+    ["teak_v1_list_favorite_cards", {}],
+    ["teak_v1_update_card", { cardId, notes: "updated" }],
+    ["teak_v1_set_card_favorite", { cardId, isFavorited: true }],
+    ["teak_v1_list_tags", {}],
+    ["teak_v1_get_card_changes", { since: Date.now() - 86_400_000 }],
+    [
+      "teak_v1_bulk_cards",
+      { operation: "create", items: [{ content: "mcp bulk" }] },
+    ],
+    [
+      "teak_v1_create_upload",
+      { fileName: "mcp.txt", mimeType: "text/plain", fileSize: 1 },
+    ],
+    ["search", { query: "mcp" }],
+    ["fetch", { id: createdCardIds[0] || cardId }],
+  ] as const;
+  for (const [name, args] of calls) {
+    expect((await client.callTool({ name, arguments: args })).isError).not.toBe(
+      true
+    );
+  }
+});

--- a/packages/tests/src/journey/06-security.e2e.ts
+++ b/packages/tests/src/journey/06-security.e2e.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+import { apiFetch } from "../helpers/api";
+import { clientFor, createAccount, deleteAccountViaUi } from "../helpers/prod";
+import { readState } from "../helpers/run-state";
+
+test("cross-tenant, revoked-key, hostile input, headers, and cookie security", async ({
+  browser,
+  page,
+  context,
+}) => {
+  const state = readState();
+  if (!state.primary?.apiKey) {
+    throw new Error("Missing primary API key");
+  }
+  const secondPage = await browser.newPage();
+  const second = await createAccount(secondPage, "tenant-b");
+  try {
+    const targetCard = state.createdCardIds[0];
+    if (targetCard) {
+      expect(
+        (await apiFetch(`/v1/cards/${targetCard}`, second.apiKey!)).status
+      ).toBe(404);
+    }
+    if (state.revokedKey) {
+      expect((await apiFetch("/v1/tags", state.revokedKey)).status).toBe(401);
+    }
+    const hostile = `<img src=x onerror="window.__teakXss=1"> javascript:alert(1) שלום ${"x".repeat(100_000)}`;
+    await clientFor(state.primary.apiKey).cards.create({
+      content: hostile,
+      source: "prod-e2e",
+      tags: ["xss"],
+    });
+    await page.goto("/");
+    await expect
+      .poll(() => page.evaluate(() => (window as any).__teakXss))
+      .toBeUndefined();
+    for (const url of ["/login", "/settings"]) {
+      const response = await page.goto(url);
+      expect(response?.headers()["strict-transport-security"]).toBeTruthy();
+      expect(response?.headers()["content-security-policy"]).toBeTruthy();
+    }
+    const cookies = await context.cookies();
+    expect(
+      cookies.some(
+        (cookie) => cookie.secure && cookie.httpOnly && cookie.sameSite
+      )
+    ).toBe(true);
+  } finally {
+    await deleteAccountViaUi(secondPage, second);
+    await secondPage.close();
+  }
+});

--- a/packages/tests/src/journey/07-account-flows.e2e.ts
+++ b/packages/tests/src/journey/07-account-flows.e2e.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import { requirePassword } from "../helpers/env";
+import { waitForEmail } from "../helpers/mailpit";
+import { signIn } from "../helpers/prod";
+import { readState, updateState } from "../helpers/run-state";
+
+test("password reset and Polar checkout entry", async ({ page }) => {
+  const { primary } = readState();
+  if (!primary?.email) {
+    throw new Error("Missing primary account");
+  }
+  const nextPassword = `${requirePassword()}Reset1!`;
+  await page.goto("/forgot-password");
+  await page.getByLabel("Email").fill(primary.email);
+  await page.getByRole("button", { name: "Send reset link" }).click();
+  await expect(page.getByText(/Reset link sent/i)).toBeVisible();
+  await page.goto(await waitForEmail(primary.email, "Reset your Password"));
+  await page.locator("#password").fill(nextPassword);
+  await page.locator("#password_confirmation").fill(nextPassword);
+  await page.getByRole("button", { name: "Update password" }).click();
+  await expect(page.getByText("Your password has been updated")).toBeVisible();
+  updateState((state) => {
+    if (state.primary) {
+      state.primary.passwordReset = true;
+    }
+    for (const account of state.accounts) {
+      if (account.email === primary.email) {
+        account.passwordReset = true;
+      }
+    }
+  });
+  await page.goto("/login");
+  await page.getByLabel("Email").fill(primary.email);
+  await page.getByLabel("Password").fill(requirePassword());
+  await page.getByRole("button", { name: /login|sign in/i }).click();
+  await expect(page.getByText(/invalid|incorrect/i)).toBeVisible();
+  await signIn(page, primary.email, nextPassword);
+  await page.goto("/settings");
+  await page.getByRole("button", { name: "Upgrade" }).click();
+  await expect(
+    page.getByRole("dialog", { name: "Upgrade to Pro" })
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Continue" }).first().click();
+  await expect(
+    page.frameLocator('iframe[src*="polar.sh"]').locator("body")
+  ).toBeVisible();
+});

--- a/packages/tests/src/journey/08-a11y.e2e.ts
+++ b/packages/tests/src/journey/08-a11y.e2e.ts
@@ -1,0 +1,16 @@
+import { AxeBuilder } from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+for (const path of ["/login", "/register", "/", "/settings"]) {
+  test(`axe serious/critical scan ${path}`, async ({ page }) => {
+    await page.goto(path);
+    const results = await new AxeBuilder({ page })
+      .withTags(["wcag2a", "wcag2aa"])
+      .analyze();
+    expect(
+      results.violations.filter((item) =>
+        ["serious", "critical"].includes(item.impact ?? "")
+      )
+    ).toEqual([]);
+  });
+}

--- a/packages/tests/src/journey/100-post-delete.e2e.ts
+++ b/packages/tests/src/journey/100-post-delete.e2e.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+import { apiFetch, perfSummary } from "../helpers/api";
+import { env } from "../helpers/env";
+import { readState } from "../helpers/run-state";
+
+test("deleted account credentials are inert", async () => {
+  const { primary } = readState();
+  if (!primary?.apiKey) {
+    throw new Error("Missing primary API key");
+  }
+  expect((await apiFetch("/v1/tags", primary.apiKey)).status).toBe(401);
+  expect(
+    (
+      await fetch(env.mcpUrl, {
+        headers: { Authorization: `Bearer ${primary.apiKey}` },
+      })
+    ).status
+  ).toBe(401);
+  perfSummary();
+});

--- a/packages/tests/src/journey/99-delete-account.e2e.ts
+++ b/packages/tests/src/journey/99-delete-account.e2e.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/test";
+import { deleteAccountViaUi } from "../helpers/prod";
+import { readState } from "../helpers/run-state";
+
+test("delete primary account through the web UI", async ({ page }) => {
+  const { primary } = readState();
+  if (!primary) {
+    throw new Error("Missing primary account");
+  }
+  await deleteAccountViaUi(page, primary);
+  await page.goto("/login");
+  await page.getByLabel("Email").fill(primary.email);
+  await page.getByLabel("Password").fill(process.env.PROD_E2E_PASSWORD!);
+  await page.getByRole("button", { name: /login|sign in/i }).click();
+  await expect(page.getByText(/invalid|not found|unable/i)).toBeVisible();
+});

--- a/packages/tests/src/matrix/journey-lite.e2e.ts
+++ b/packages/tests/src/matrix/journey-lite.e2e.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@playwright/test";
+import { createAccount, deleteAccountViaUi } from "../helpers/prod";
+
+test("signup, create, search, favorite, delete account", async ({ page }) => {
+  const account = await createAccount(
+    page,
+    `matrix-${test.info().project.name}`
+  );
+  try {
+    const marker = `matrix-${Date.now()}`;
+    await page.goto("/");
+    await page.getByPlaceholder(/Write a note/i).fill(marker);
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(page.getByRole("main").getByText(marker)).toBeVisible();
+    await page.getByPlaceholder("Search for anything...").fill(marker);
+    await page.keyboard.press("Enter");
+    await expect(page.getByRole("main").getByText(marker)).toBeVisible();
+  } finally {
+    await deleteAccountViaUi(page, account);
+  }
+});

--- a/packages/tests/src/scripts/preflight.ts
+++ b/packages/tests/src/scripts/preflight.ts
@@ -1,0 +1,45 @@
+import { resolveMx } from "node:dns/promises";
+import { Socket } from "node:net";
+import { env, requireMailpit, requirePassword } from "../helpers/env";
+import { assertMailpitReady } from "../helpers/mailpit";
+
+const checkPort = (host: string, port: number) =>
+  new Promise<void>((resolve, reject) => {
+    const socket = new Socket();
+    socket.setTimeout(5000);
+    socket.once("connect", () => {
+      socket.destroy();
+      resolve();
+    });
+    socket.once("error", reject);
+    socket.once("timeout", () => {
+      socket.destroy();
+      reject(new Error(`${host}:${port} timed out`));
+    });
+    socket.connect(port, host);
+  });
+
+const main = async () => {
+  requirePassword();
+  requireMailpit();
+  await assertMailpitReady();
+
+  const mx = await resolveMx(env.emailDomain).catch(() => []);
+  if (!mx.length) {
+    throw new Error(`No MX records found for ${env.emailDomain}`);
+  }
+
+  mx.sort((a, b) => a.priority - b.priority);
+  await checkPort(mx[0].exchange, 25);
+
+  console.log(
+    `Mailpit preflight ok: ${env.emailDomain} -> ${mx[0].exchange}:25`
+  );
+};
+
+main().catch((error) => {
+  console.error(
+    `Mailpit preflight failed: ${error instanceof Error ? error.message : String(error)}`
+  );
+  process.exit(1);
+});

--- a/packages/tests/src/scripts/sweep.ts
+++ b/packages/tests/src/scripts/sweep.ts
@@ -1,0 +1,38 @@
+import { chromium } from "@playwright/test";
+import { env } from "../helpers/env";
+import { deleteMessagesFor } from "../helpers/mailpit";
+import { deleteAccountViaUi } from "../helpers/prod";
+
+const response = await fetch(`${env.mailpitUrl}/api/v1/messages?limit=200`);
+if (!response.ok) {
+  throw new Error(`Mailpit sweep failed: ${response.status}`);
+}
+const data = (await response.json()) as {
+  messages?: Array<{ To?: Array<{ Address: string }> }>;
+};
+const emails = [
+  ...new Set(
+    (data.messages ?? [])
+      .flatMap((message) => message.To ?? [])
+      .map((to) => to.Address.toLowerCase())
+      .filter((email) => email.startsWith("e2e-"))
+  ),
+].slice(0, 20);
+
+const browser = await chromium.launch();
+try {
+  for (const email of emails) {
+    const page = await browser.newPage();
+    try {
+      await deleteAccountViaUi(page, { email });
+    } catch (error) {
+      console.warn(`sweep skipped ${email}: ${error}`);
+    } finally {
+      await deleteMessagesFor(email);
+      await page.close();
+      await new Promise((resolve) => setTimeout(resolve, 15_000));
+    }
+  }
+} finally {
+  await browser.close();
+}

--- a/packages/tests/src/scripts/teardown.ts
+++ b/packages/tests/src/scripts/teardown.ts
@@ -1,0 +1,21 @@
+import { chromium } from "@playwright/test";
+import { deleteMessagesFor } from "../helpers/mailpit";
+import { deleteAccountViaUi } from "../helpers/prod";
+import { readState } from "../helpers/run-state";
+
+const browser = await chromium.launch();
+try {
+  for (const account of readState().accounts.filter((item) => !item.deleted)) {
+    const page = await browser.newPage();
+    try {
+      await deleteAccountViaUi(page, account);
+    } catch (error) {
+      console.warn(`teardown skipped ${account.email}: ${error}`);
+    } finally {
+      await deleteMessagesFor(account.email);
+      await page.close();
+    }
+  }
+} finally {
+  await browser.close();
+}

--- a/packages/tests/tsconfig.json
+++ b/packages/tests/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "lib": ["ES2024", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2024",
+    "types": ["bun-types", "node"]
+  },
+  "include": ["src/**/*.ts", "playwright.config.ts"]
+}


### PR DESCRIPTION
## Summary

Adds a private `@teak/tests` workspace package and a manual/daily production E2E workflow for Teak.

Coverage includes:
- production signup with Mailpit verification, API key creation, web card journey, uploads, search, favorites, hostile input, password reset, Polar checkout entry, account deletion, and post-delete credential checks
- REST API checks with deployed OpenAPI validation and latency summary output
- CLI coverage for both repo-built and npm-published `teak-cli`
- MCP auth challenge, tool listing, and tool-call coverage across all 14 tools
- docs sitemap crawl, key docs pages, Pagefind assets, llms/OpenAPI/well-known metadata
- browser matrix lifecycle checks and Chrome extension build smoke
- 105 additional deterministic public production probes across app, docs/site, API, MCP metadata, and API subdomain surfaces
- always-run teardown and daily orphan sweep scripts

## Workflow

Adds `.github/workflows/prod-e2e.yml` with `workflow_dispatch` and daily schedule only. It stores Mailpit details in GitHub Actions secrets, not committed defaults.

Required secrets are already set with `gh`:
- `PROD_E2E_PASSWORD`
- `MAILPIT_URL`
- `E2E_EMAIL_DOMAIN`

## Mailpit infrastructure status

Mailpit delivery is now configured for production E2E use. The service was restarted in Coolify with SMTP ingress enabled, the E2E email-domain secret now points at an MX-capable Mailpit host, and external SMTP port 25 connectivity has been verified.

The preflight still fails fast before account creation if any of the Mailpit API, MX, or SMTP checks regress.

## Validation

- `bun install`
- `bun run --cwd packages/tests typecheck`
- `bun run --cwd packages/tests lint`
- `bun run typecheck`
- `bun run lint`
- `bun run build:cli`
- `bun run --cwd apps/extension build`
- `bun run --cwd packages/tests e2e:prod:docs` -> 112 passed
- `bunx turbo run test --filter=!@teak/tests --dry=json` -> no `@teak/tests#test` task
- `bunx playwright test --config packages/tests/playwright.config.ts --project=journey --project=journey-delete --project=journey-post-delete --list` -> delete runs before post-delete
- external SMTP port 25 check for the configured Mailpit host -> reachable
- `bun run pre-commit`
