### PR TITLE
Fix production E2E workflow dispatch

### DIFF
--- a/.github/workflows/prod-e2e.yml
+++ b/.github/workflows/prod-e2e.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v3
+      - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - run: bun run --cwd packages/tests preflight
       - run: curl -fsS "$PROD_APP_URL/login" >/dev/null
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v3
+      - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - run: bun run build:cli
       - run: npm install --prefix "$RUNNER_TEMP/teak-npm" teak-cli@latest
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v3
+      - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - run: bunx playwright install --with-deps chromium
       - run: bun run --cwd packages/tests e2e:prod:docs
@@ -79,7 +79,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v3
+      - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - run: bunx playwright install --with-deps chromium firefox webkit
       - run: bun run --cwd packages/tests e2e:prod:matrix
@@ -95,7 +95,7 @@ jobs:
       VITE_PUBLIC_CONVEX_SITE_URL: ${{ vars.VITE_PUBLIC_CONVEX_SITE_URL }}
     steps:
       - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v3
+      - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - run: bun run --cwd apps/extension build
       - run: bunx playwright install --with-deps chromium
@@ -110,7 +110,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-      - uses: oven-sh/setup-bun@v3
+      - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - run: bunx playwright install --with-deps chromium
       - run: bun run --cwd packages/tests sweep


### PR DESCRIPTION
## Summary
- pin Production E2E workflow jobs to the repo-supported Bun setup action version
- refresh the repository production E2E password secret after the first dispatch showed an empty env value

## Validation
- first manual Production E2E dispatch reached GitHub and failed at setup because oven-sh/setup-bun@v3 does not exist
- existing release workflows use oven-sh/setup-bun@v2
- pre-commit hook ran on commit; no affected package tasks for the YAML-only change

## Follow-up
- after merge, manually dispatch Production E2E again with sweep enabled and watch it to completion