### PR TITLE
Fix production E2E API key selector

### DIFF
--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -13,6 +13,11 @@ export const clientFor = (apiKey: string) =>
 
 const appPath = (path: string) => new URL(path, env.appUrl).toString();
 
+const settingsRow = (page: Page, label: string) =>
+  page
+    .getByText(label, { exact: true })
+    .locator("xpath=ancestor::div[.//button][1]");
+
 export const signIn = async (
   page: Page,
   email: string,
@@ -46,7 +51,9 @@ export const signUp = async (page: Page, email = uniqueEmail()) => {
 export const generateApiKey = async (page: Page) => {
   await page.goto(appPath("/settings"));
   await page.getByText("API Keys").waitFor();
-  await page.getByRole("button", { name: "Manage" }).click();
+  await settingsRow(page, "API Keys")
+    .getByRole("button", { name: "Manage" })
+    .click();
   await expect(
     page.getByRole("dialog", { name: "Manage API Keys" })
   ).toBeVisible();
@@ -92,7 +99,9 @@ export const deleteAccountViaUi = async (page: Page, account: AccountState) => {
 export const revokeVisibleKey = async (page: Page, rawKey: string) => {
   const suffix = rawKey.slice(-4);
   await page.goto(appPath("/settings"));
-  await page.getByRole("button", { name: "Manage" }).click();
+  await settingsRow(page, "API Keys")
+    .getByRole("button", { name: "Manage" })
+    .click();
   const row = page.locator("div").filter({ hasText: suffix }).last();
   await row.getByRole("button", { name: "Revoke" }).click();
   await expect(row.getByText(/revoked/i)).toBeVisible();


### PR DESCRIPTION
## Summary
- scope the production E2E API-key Manage button to the API Keys settings row
- reuse the scoped selector for key generation and revocation

## Validation
- 
- Checked 29 files in 14ms. No fixes applied.
- first post-merge Production E2E dispatch passed gate/docs/sweep and exposed this journey selector ambiguity

## Follow-up
- after merge, rerun Production E2E from main with sweep enabled