### PR TITLE
Fix production E2E journey follow-ups

### DIFF
--- a/apps/web/src/app/HomePageClient.tsx
+++ b/apps/web/src/app/HomePageClient.tsx
@@ -8,7 +8,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 const settingsButton = (
   <Button asChild size="icon" variant="outline">
-    <Link href="/settings">
+    <Link aria-label="Settings" href="/settings">
       <Settings />
     </Link>
   </Button>

--- a/packages/tests/src/helpers/api.ts
+++ b/packages/tests/src/helpers/api.ts
@@ -49,7 +49,8 @@ export const loadOpenApi = async () => {
       if (!schema) {
         return;
       }
-      const ok = ajv.compile(schema)(payload);
+      const rootSchema = { ...schema, components: spec.components };
+      const ok = ajv.compile(rootSchema)(payload);
       if (!ok) {
         throw new Error(`OpenAPI mismatch ${method} ${path} ${status}`);
       }

--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -11,7 +11,7 @@ export const clientFor = (apiKey: string) =>
     userAgent: "teak-prod-e2e",
   });
 
-const appPath = (path: string) => new URL(path, env.appUrl).toString();
+export const appPath = (path: string) => new URL(path, env.appUrl).toString();
 
 const settingsRow = (page: Page, label: string) =>
   page

--- a/packages/tests/src/journey/02-web-journey.e2e.ts
+++ b/packages/tests/src/journey/02-web-journey.e2e.ts
@@ -17,7 +17,10 @@ test("web journey covers cards, search, settings, upload, and revoked key", asyn
     return dialog.dismiss();
   });
   await page.goto("/");
-  await expect(page.getByText(/Let's add your first card/i)).toBeVisible();
+  await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
+  await expect(
+    page.getByText(/Welcome to Teak|Let's add your first card/i)
+  ).toBeVisible();
   await page
     .getByPlaceholder(/Write a note/i)
     .fill(`${marker} <script>alert("xss")</script>`);

--- a/packages/tests/src/journey/06-security.e2e.ts
+++ b/packages/tests/src/journey/06-security.e2e.ts
@@ -12,7 +12,8 @@ test("cross-tenant, revoked-key, hostile input, headers, and cookie security", a
   if (!state.primary?.apiKey) {
     throw new Error("Missing primary API key");
   }
-  const secondPage = await browser.newPage();
+  const secondContext = await browser.newContext();
+  const secondPage = await secondContext.newPage();
   const second = await createAccount(secondPage, "tenant-b");
   try {
     const targetCard = state.createdCardIds[0];
@@ -47,6 +48,6 @@ test("cross-tenant, revoked-key, hostile input, headers, and cookie security", a
     ).toBe(true);
   } finally {
     await deleteAccountViaUi(secondPage, second);
-    await secondPage.close();
+    await secondContext.close();
   }
 });

--- a/packages/tests/src/journey/07-account-flows.e2e.ts
+++ b/packages/tests/src/journey/07-account-flows.e2e.ts
@@ -1,47 +1,55 @@
 import { expect, test } from "@playwright/test";
 import { requirePassword } from "../helpers/env";
 import { waitForEmail } from "../helpers/mailpit";
-import { signIn } from "../helpers/prod";
+import { appPath, signIn } from "../helpers/prod";
 import { readState, updateState } from "../helpers/run-state";
 
-test("password reset and Polar checkout entry", async ({ page }) => {
+test("password reset and Polar checkout entry", async ({ browser }) => {
   const { primary } = readState();
   if (!primary?.email) {
     throw new Error("Missing primary account");
   }
   const nextPassword = `${requirePassword()}Reset1!`;
-  await page.goto("/forgot-password");
-  await page.getByLabel("Email").fill(primary.email);
-  await page.getByRole("button", { name: "Send reset link" }).click();
-  await expect(page.getByText(/Reset link sent/i)).toBeVisible();
-  await page.goto(await waitForEmail(primary.email, "Reset your Password"));
-  await page.locator("#password").fill(nextPassword);
-  await page.locator("#password_confirmation").fill(nextPassword);
-  await page.getByRole("button", { name: "Update password" }).click();
-  await expect(page.getByText("Your password has been updated")).toBeVisible();
-  updateState((state) => {
-    if (state.primary) {
-      state.primary.passwordReset = true;
-    }
-    for (const account of state.accounts) {
-      if (account.email === primary.email) {
-        account.passwordReset = true;
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  try {
+    await page.goto(appPath("/forgot-password"));
+    await page.getByLabel("Email").fill(primary.email);
+    await page.getByRole("button", { name: "Send reset link" }).click();
+    await expect(page.getByText(/Reset link sent/i)).toBeVisible();
+    await page.goto(await waitForEmail(primary.email, "Reset your Password"));
+    await page.locator("#password").fill(nextPassword);
+    await page.locator("#password_confirmation").fill(nextPassword);
+    await page.getByRole("button", { name: "Update password" }).click();
+    await expect(
+      page.getByText("Your password has been updated")
+    ).toBeVisible();
+    updateState((state) => {
+      if (state.primary) {
+        state.primary.passwordReset = true;
       }
-    }
-  });
-  await page.goto("/login");
-  await page.getByLabel("Email").fill(primary.email);
-  await page.getByLabel("Password").fill(requirePassword());
-  await page.getByRole("button", { name: /login|sign in/i }).click();
-  await expect(page.getByText(/invalid|incorrect/i)).toBeVisible();
-  await signIn(page, primary.email, nextPassword);
-  await page.goto("/settings");
-  await page.getByRole("button", { name: "Upgrade" }).click();
-  await expect(
-    page.getByRole("dialog", { name: "Upgrade to Pro" })
-  ).toBeVisible();
-  await page.getByRole("button", { name: "Continue" }).first().click();
-  await expect(
-    page.frameLocator('iframe[src*="polar.sh"]').locator("body")
-  ).toBeVisible();
+      for (const account of state.accounts) {
+        if (account.email === primary.email) {
+          account.passwordReset = true;
+        }
+      }
+    });
+    await page.goto(appPath("/login"));
+    await page.getByLabel("Email").fill(primary.email);
+    await page.getByLabel("Password").fill(requirePassword());
+    await page.getByRole("button", { name: /login|sign in/i }).click();
+    await expect(page.getByText(/invalid|incorrect/i)).toBeVisible();
+    await signIn(page, primary.email, nextPassword);
+    await page.goto(appPath("/settings"));
+    await page.getByRole("button", { name: "Upgrade" }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Upgrade to Pro" })
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Continue" }).first().click();
+    await expect(
+      page.frameLocator('iframe[src*="polar.sh"]').locator("body")
+    ).toBeVisible();
+  } finally {
+    await context.close();
+  }
 });

--- a/packages/ui/src/components/settings/ThemeToggle.tsx
+++ b/packages/ui/src/components/settings/ThemeToggle.tsx
@@ -26,8 +26,10 @@ export function ThemeToggle({ onThemeChange }: ThemeToggleProps) {
 
   return (
     <div className="flex items-center gap-px">
-      {THEME_OPTIONS.map(({ value, icon: Icon }) => (
+      {THEME_OPTIONS.map(({ label, value, icon: Icon }) => (
         <Button
+          aria-label={`Use ${label} theme`}
+          aria-pressed={mounted && theme === value}
           key={value}
           onClick={handleThemeChange(value)}
           size="sm"

--- a/packages/ui/src/constants/settings.ts
+++ b/packages/ui/src/constants/settings.ts
@@ -11,9 +11,9 @@ export const PRO_FEATURES = [
 ];
 
 export const THEME_OPTIONS = [
-  { value: "system", icon: Monitor },
-  { value: "light", icon: Sun },
-  { value: "dark", icon: Moon },
+  { value: "system", label: "system", icon: Monitor },
+  { value: "light", label: "light", icon: Sun },
+  { value: "dark", label: "dark", icon: Moon },
 ] as const;
 
 export type ThemeValue = (typeof THEME_OPTIONS)[number]["value"];


### PR DESCRIPTION
## Summary
- add accessible labels to web settings and theme icon controls
- make production E2E unauthenticated account flows use isolated browser contexts
- make the web journey assert the real production welcome state
- resolve OpenAPI response schema refs against the full spec during validation

## Validation
- 
- Checked 29 files in 22ms. No fixes applied.
- 
   • Packages in scope: @teak/convex, @teak/desktop, @teak/docs, @teak/extension, @teak/mobile, @teak/tests, @teak/ui, @teak/web, teak-cli, teak-raycast
   • Running typecheck in 10 packages
   • Remote caching disabled

@teak/ui:typecheck: cache hit, replaying logs 8e86f590620f3907
@teak/ui:typecheck: $ tsc --noEmit
teak-raycast:typecheck: cache hit, replaying logs 450fe4f535288629
teak-raycast:typecheck: $ tsc --noEmit
@teak/docs:typecheck: cache hit, replaying logs 3f31b003cd2b4d71
@teak/docs:typecheck: $ astro check
@teak/docs:typecheck: 18:34:06 [content] Syncing content
@teak/docs:typecheck: 18:34:06 [content] Synced content
@teak/docs:typecheck: 18:34:06 [types] Generated 303ms
@teak/docs:typecheck: 18:34:06 [check] Getting diagnostics for Astro files in /Users/praveenjuge/Projects/teak/apps/docs...
@teak/docs:typecheck: Result (25 files): 
@teak/docs:typecheck: - 0 errors
@teak/docs:typecheck: - 0 warnings
@teak/docs:typecheck: - 0 hints
@teak/docs:typecheck: 
@teak/convex:typecheck: cache hit, replaying logs e2f17a0a8e19612e
@teak/convex:typecheck: $ tsc --noEmit
@teak/extension:typecheck: cache hit, replaying logs b0db6d749b7448fc
@teak/extension:typecheck: $ tsc --noEmit
teak-cli:typecheck: cache hit, replaying logs f19c2cc17a3923cc
@teak/tests:typecheck: cache hit, replaying logs 56249ec798a5962d
teak-cli:typecheck: $ tsc --noEmit
@teak/tests:typecheck: $ tsc --noEmit
@teak/mobile:typecheck: cache hit, replaying logs 800297768f7bdaab
@teak/web:typecheck: cache hit, replaying logs ad97149d127b8a24
@teak/web:typecheck: $ tsc --noEmit
@teak/mobile:typecheck: $ tsc --noEmit
@teak/desktop:typecheck: cache hit, replaying logs 5190039ff332ea84
@teak/desktop:typecheck: $ tsc --noEmit && tsc --noEmit -p tsconfig.main.json && tsc --noEmit -p tsconfig.preload.json

 Tasks:    10 successful, 10 total
Cached:    10 cached, 10 total
  Time:    126ms >>> FULL TURBO
- 
   • Packages in scope: @teak/convex, @teak/desktop, @teak/docs, @teak/extension, @teak/mobile, @teak/tests, @teak/ui, @teak/web, teak-cli, teak-raycast
   • Running lint in 10 packages
   • Remote caching disabled

@teak/docs:lint: cache hit, replaying logs 5538b1b208b0b976
@teak/docs:lint: $ astro check && biome check astro.config.ts src/**/*.ts src/**/*.css *.json
@teak/docs:lint: 18:34:05 [content] Syncing content
@teak/docs:lint: 18:34:05 [content] Synced content
@teak/docs:lint: 18:34:05 [types] Generated 304ms
@teak/docs:lint: 18:34:05 [check] Getting diagnostics for Astro files in /Users/praveenjuge/Projects/teak/apps/docs...
@teak/docs:lint: Result (25 files): 
@teak/docs:lint: - 0 errors
@teak/docs:lint: - 0 warnings
@teak/docs:lint: - 0 hints
@teak/docs:lint: 
@teak/docs:lint: Checked 10 files in 16ms. No fixes applied.
teak-raycast:lint: cache hit, replaying logs 9e86664447e7741a
teak-raycast:lint: $ ray lint
teak-raycast:lint: [32mready[39m  - validate package.json file
teak-raycast:lint: [32mready[39m  - validate extension icons
teak-raycast:lint: [32mready[39m  - validate extension metadata
teak-raycast:lint: [32mready[39m  - run ESLint
teak-raycast:lint: [32mready[39m  - run Prettier 3.8.1
@teak/web:lint: cache hit, replaying logs ad4663ed6e3a20b2
@teak/web:lint: $ biome check .
@teak/web:lint: Checked 77 files in 104ms. No fixes applied.
@teak/tests:lint: cache hit, replaying logs 8cd36126257cc686
@teak/tests:lint: $ biome check .
@teak/tests:lint: Checked 29 files in 76ms. No fixes applied.
@teak/mobile:lint: cache hit, replaying logs 38f95b3deea216d8
@teak/mobile:lint: $ biome check .
@teak/mobile:lint: Checked 81 files in 267ms. No fixes applied.

 Tasks:    5 successful, 5 total
Cached:    5 cached, 5 total
  Time:    103ms >>> FULL TURBO
- latest Production E2E dispatch passed gate/docs/sweep and exposed these journey follow-ups

## Follow-up
- after merge, rerun Production E2E from main with sweep enabled