### PR TITLE
fix production e2e clean auth contexts

### DIFF
--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from "@playwright/test";
+import { type Browser, expect, type Page } from "@playwright/test";
 import { createTeakClient } from "@teak/convex/sdk";
 import { env, requirePassword, uniqueEmail } from "./env";
 import { waitForEmail } from "./mailpit";
@@ -12,6 +12,9 @@ export const clientFor = (apiKey: string) =>
   });
 
 export const appPath = (path: string) => new URL(path, env.appUrl).toString();
+
+export const newAnonymousContext = (browser: Browser) =>
+  browser.newContext({ storageState: { cookies: [], origins: [] } });
 
 const settingsRow = (page: Page, label: string) =>
   page

--- a/packages/tests/src/journey/02-web-journey.e2e.ts
+++ b/packages/tests/src/journey/02-web-journey.e2e.ts
@@ -25,10 +25,11 @@ test("web journey covers cards, search, settings, upload, and revoked key", asyn
     .getByPlaceholder(/Write a note/i)
     .fill(`${marker} <script>alert("xss")</script>`);
   await page.getByRole("button", { name: "Save", exact: true }).click();
-  await expect(page.getByRole("main").getByText(marker)).toBeVisible();
+  const savedCard = page.locator("main p").filter({ hasText: marker }).first();
+  await expect(savedCard).toBeVisible();
   await page.getByPlaceholder("Search for anything...").fill(marker);
   await page.keyboard.press("Enter");
-  await expect(page.getByRole("main").getByText(marker)).toBeVisible();
+  await expect(savedCard).toBeVisible();
   await page.getByRole("button", { name: "Clear All" }).click();
 
   const api = clientFor(state.primary.apiKey);

--- a/packages/tests/src/journey/06-security.e2e.ts
+++ b/packages/tests/src/journey/06-security.e2e.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "@playwright/test";
 import { apiFetch } from "../helpers/api";
-import { clientFor, createAccount, deleteAccountViaUi } from "../helpers/prod";
+import {
+  clientFor,
+  createAccount,
+  deleteAccountViaUi,
+  newAnonymousContext,
+} from "../helpers/prod";
 import { readState } from "../helpers/run-state";
 
 test("cross-tenant, revoked-key, hostile input, headers, and cookie security", async ({
@@ -12,7 +17,7 @@ test("cross-tenant, revoked-key, hostile input, headers, and cookie security", a
   if (!state.primary?.apiKey) {
     throw new Error("Missing primary API key");
   }
-  const secondContext = await browser.newContext();
+  const secondContext = await newAnonymousContext(browser);
   const secondPage = await secondContext.newPage();
   const second = await createAccount(secondPage, "tenant-b");
   try {

--- a/packages/tests/src/journey/07-account-flows.e2e.ts
+++ b/packages/tests/src/journey/07-account-flows.e2e.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { requirePassword } from "../helpers/env";
 import { waitForEmail } from "../helpers/mailpit";
-import { appPath, signIn } from "../helpers/prod";
+import { appPath, newAnonymousContext, signIn } from "../helpers/prod";
 import { readState, updateState } from "../helpers/run-state";
 
 test("password reset and Polar checkout entry", async ({ browser }) => {
@@ -10,7 +10,7 @@ test("password reset and Polar checkout entry", async ({ browser }) => {
     throw new Error("Missing primary account");
   }
   const nextPassword = `${requirePassword()}Reset1!`;
-  const context = await browser.newContext();
+  const context = await newAnonymousContext(browser);
   const page = await context.newPage();
   try {
     await page.goto(appPath("/forgot-password"));


### PR DESCRIPTION
## Summary
- force unauthenticated Playwright contexts for registration and password reset checks even when the journey project has an authenticated storage state
- make the web journey search assertion target rendered card content instead of the matching filter chip

## Validation
- bun run --cwd packages/tests typecheck
- bun run --cwd packages/tests lint
- pre-commit hook: turbo run typecheck lint build --affected