### PR TITLE
fix remaining production e2e journey flakes

### DIFF
--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -27,7 +27,18 @@ export const signIn = async (
   password = requirePassword()
 ) => {
   await page.goto(appPath("/login"));
-  await page.getByLabel("Email").fill(email);
+  const emailInput = page.getByLabel("Email");
+  const canSignIn = await emailInput
+    .waitFor({ state: "visible", timeout: 5000 })
+    .then(
+      () => true,
+      () => false
+    );
+  if (!canSignIn) {
+    await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
+    return;
+  }
+  await emailInput.fill(email);
   await page.getByLabel("Password").fill(password);
   await page.getByRole("button", { name: /login|sign in/i }).click();
   await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
@@ -99,13 +110,20 @@ export const deleteAccountViaUi = async (page: Page, account: AccountState) => {
   });
 };
 
-export const revokeVisibleKey = async (page: Page, rawKey: string) => {
-  const suffix = rawKey.slice(-4);
+export const revokeVisibleKey = async (page: Page, _rawKey: string) => {
   await page.goto(appPath("/settings"));
   await settingsRow(page, "API Keys")
     .getByRole("button", { name: "Manage" })
     .click();
-  const row = page.locator("div").filter({ hasText: suffix }).last();
+  const dialog = page.getByRole("dialog", { name: "Manage API Keys" });
+  const row = dialog
+    .locator("div")
+    .filter({
+      has: page.getByRole("button", { name: "Revoke" }),
+      hasText: "Last used: Never",
+    })
+    .last();
+  await expect(row).toBeVisible();
   await row.getByRole("button", { name: "Revoke" }).click();
   await expect(row.getByText(/revoked/i)).toBeVisible();
 };

--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -110,7 +110,8 @@ export const deleteAccountViaUi = async (page: Page, account: AccountState) => {
   });
 };
 
-export const revokeVisibleKey = async (page: Page, _rawKey: string) => {
+export const revokeVisibleKey = async (page: Page, rawKey: string) => {
+  const visiblePrefix = rawKey.split("_").slice(0, 4).join("_");
   await page.goto(appPath("/settings"));
   await settingsRow(page, "API Keys")
     .getByRole("button", { name: "Manage" })
@@ -120,7 +121,7 @@ export const revokeVisibleKey = async (page: Page, _rawKey: string) => {
     .locator("div")
     .filter({
       has: page.getByRole("button", { name: "Revoke" }),
-      hasText: "Last used: Never",
+      hasText: visiblePrefix,
     })
     .last();
   await expect(row).toBeVisible();

--- a/packages/tests/src/journey/08-a11y.e2e.ts
+++ b/packages/tests/src/journey/08-a11y.e2e.ts
@@ -1,16 +1,28 @@
 import { AxeBuilder } from "@axe-core/playwright";
 import { expect, test } from "@playwright/test";
+import { appPath, newAnonymousContext } from "../helpers/prod";
+
+const authPaths = new Set(["/login", "/register"]);
 
 for (const path of ["/login", "/register", "/", "/settings"]) {
-  test(`axe serious/critical scan ${path}`, async ({ page }) => {
-    await page.goto(path);
-    const results = await new AxeBuilder({ page })
-      .withTags(["wcag2a", "wcag2aa"])
-      .analyze();
-    expect(
-      results.violations.filter((item) =>
-        ["serious", "critical"].includes(item.impact ?? "")
-      )
-    ).toEqual([]);
+  test(`axe serious/critical scan ${path}`, async ({ browser, page }) => {
+    const context = authPaths.has(path)
+      ? await newAnonymousContext(browser)
+      : null;
+    const scanPage = context ? await context.newPage() : page;
+    try {
+      await scanPage.goto(appPath(path));
+      await scanPage.waitForLoadState("domcontentloaded");
+      const results = await new AxeBuilder({ page: scanPage })
+        .withTags(["wcag2a", "wcag2aa"])
+        .analyze();
+      expect(
+        results.violations.filter((item) =>
+          ["serious", "critical"].includes(item.impact ?? "")
+        )
+      ).toEqual([]);
+    } finally {
+      await context?.close();
+    }
   });
 }


### PR DESCRIPTION
## Summary
- make sign-in helper tolerate already-authenticated cleanup pages
- revoke the newly generated unused API key using visible dialog state instead of hidden raw-key suffixes
- run public auth-page axe scans in anonymous browser contexts

## Validation
- bun run --cwd packages/tests typecheck
- bun run --cwd packages/tests lint
- pre-commit hook: turbo run typecheck lint build --affected