### PR TITLE
Harden production E2E sweep cleanup

### DIFF
--- a/packages/tests/src/helpers/mailpit.ts
+++ b/packages/tests/src/helpers/mailpit.ts
@@ -10,9 +10,22 @@ const api = (path: string) => `${env.mailpitUrl}/api/v1${path}`;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const mailpitFetch = async (path: string, init?: RequestInit) => {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      return await fetch(api(path), init);
+    } catch (error) {
+      lastError = error;
+      await sleep(attempt * 1000);
+    }
+  }
+  throw lastError;
+};
+
 export const assertMailpitReady = async () => {
   requireMailpit();
-  const response = await fetch(api("/messages?limit=1"));
+  const response = await mailpitFetch("/messages?limit=1");
   if (!response.ok) {
     throw new Error(`Mailpit not ready: ${response.status}`);
   }
@@ -21,7 +34,7 @@ export const assertMailpitReady = async () => {
 export const waitForEmail = async (to: string, subject: string) => {
   const deadline = Date.now() + 180_000;
   while (Date.now() < deadline) {
-    const response = await fetch(api("/messages?limit=50"));
+    const response = await mailpitFetch("/messages?limit=50");
     if (!response.ok) {
       throw new Error(`Mailpit search failed: ${response.status}`);
     }
@@ -32,7 +45,7 @@ export const waitForEmail = async (to: string, subject: string) => {
         message.To.some((recipient) => recipient.Address.toLowerCase() === to)
     );
     if (hit) {
-      const detail = await fetch(api(`/message/${hit.ID}`));
+      const detail = await mailpitFetch(`/message/${hit.ID}`);
       const body = (await detail.json()) as { HTML?: string; Text?: string };
       const link = (body.HTML || body.Text || "").match(
         /https?:\/\/[^"' <]+/
@@ -48,16 +61,31 @@ export const waitForEmail = async (to: string, subject: string) => {
 };
 
 export const deleteMessagesFor = async (email: string) => {
-  const response = await fetch(api("/messages?limit=100"));
+  try {
+    const response = await mailpitFetch("/messages?limit=100");
+    if (!response.ok) {
+      return;
+    }
+    const data = (await response.json()) as { messages?: MailpitMessage[] };
+    for (const message of data.messages ?? []) {
+      if (
+        message.To.some(
+          (recipient) => recipient.Address.toLowerCase() === email
+        )
+      ) {
+        await mailpitFetch(`/message/${message.ID}`, { method: "DELETE" });
+      }
+    }
+  } catch (error) {
+    console.warn(`Mailpit cleanup skipped for ${email}: ${error}`);
+  }
+};
+
+export const listMailpitMessages = async (limit = 200) => {
+  const response = await mailpitFetch(`/messages?limit=${limit}`);
   if (!response.ok) {
-    return;
+    throw new Error(`Mailpit sweep list failed: ${response.status}`);
   }
   const data = (await response.json()) as { messages?: MailpitMessage[] };
-  for (const message of data.messages ?? []) {
-    if (
-      message.To.some((recipient) => recipient.Address.toLowerCase() === email)
-    ) {
-      await fetch(api(`/message/${message.ID}`), { method: "DELETE" });
-    }
-  }
+  return data.messages ?? [];
 };

--- a/packages/tests/src/matrix/journey-lite.e2e.ts
+++ b/packages/tests/src/matrix/journey-lite.e2e.ts
@@ -11,10 +11,15 @@ test("signup, create, search, favorite, delete account", async ({ page }) => {
     await page.goto("/");
     await page.getByPlaceholder(/Write a note/i).fill(marker);
     await page.getByRole("button", { name: "Save", exact: true }).click();
-    await expect(page.getByRole("main").getByText(marker)).toBeVisible();
+    const savedCard = page
+      .getByRole("main")
+      .getByRole("paragraph")
+      .filter({ hasText: marker })
+      .first();
+    await expect(savedCard).toBeVisible();
     await page.getByPlaceholder("Search for anything...").fill(marker);
     await page.keyboard.press("Enter");
-    await expect(page.getByRole("main").getByText(marker)).toBeVisible();
+    await expect(savedCard).toBeVisible();
   } finally {
     await deleteAccountViaUi(page, account);
   }

--- a/packages/tests/src/scripts/sweep.ts
+++ b/packages/tests/src/scripts/sweep.ts
@@ -1,18 +1,10 @@
 import { chromium } from "@playwright/test";
-import { env } from "../helpers/env";
-import { deleteMessagesFor } from "../helpers/mailpit";
+import { deleteMessagesFor, listMailpitMessages } from "../helpers/mailpit";
 import { deleteAccountViaUi } from "../helpers/prod";
 
-const response = await fetch(`${env.mailpitUrl}/api/v1/messages?limit=200`);
-if (!response.ok) {
-  throw new Error(`Mailpit sweep failed: ${response.status}`);
-}
-const data = (await response.json()) as {
-  messages?: Array<{ To?: Array<{ Address: string }> }>;
-};
 const emails = [
   ...new Set(
-    (data.messages ?? [])
+    (await listMailpitMessages())
       .flatMap((message) => message.To ?? [])
       .map((to) => to.Address.toLowerCase())
       .filter((email) => email.startsWith("e2e-"))


### PR DESCRIPTION
## Summary
- make the matrix smoke assertion target the rendered card paragraph instead of ambiguous duplicate text
- retry Mailpit API calls and keep sweep message cleanup best-effort on transient network failures
- reuse the safe Mailpit listing helper in the sweep script

## Validation
- bun run --cwd packages/tests typecheck
- bun run --cwd packages/tests lint
- pre-commit affected checks for @teak/tests

## Follow-up to production run
Fixes the matrix strict locator failure and sweep Mailpit cleanup timeout from Production E2E run 28844967570.