### PR TITLE
Fix production E2E signup toast assertion

### DIFF
--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -54,9 +54,23 @@ export const signUp = async (page: Page, email = uniqueEmail()) => {
   await page
     .getByRole("button", { name: /create an account|sign up/i })
     .click();
-  await expect(
-    page.getByText(`Verification email sent to ${email}`)
-  ).toBeVisible();
+  const verificationMessages = page.getByText(
+    `Verification email sent to ${email}`
+  );
+  await expect
+    .poll(
+      async () => {
+        const count = await verificationMessages.count();
+        for (let index = 0; index < count; index += 1) {
+          if (await verificationMessages.nth(index).isVisible()) {
+            return true;
+          }
+        }
+        return false;
+      },
+      { timeout: 15_000 }
+    )
+    .toBe(true);
   await page.goto(await waitForEmail(email, "Verify your email address"));
   await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
   return email;


### PR DESCRIPTION
## Summary
- make the shared production signup helper tolerate duplicate transient verification toasts
- fixes the extension confirmation failure from Production E2E run 28846617774

## Validation
- bun run --cwd packages/tests typecheck
- bun run --cwd packages/tests lint
- pre-commit affected checks for @teak/tests