### PR TITLE
Harden production E2E matrix timeout

### DIFF
--- a/.github/workflows/prod-e2e.yml
+++ b/.github/workflows/prod-e2e.yml
@@ -83,6 +83,14 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bunx playwright install --with-deps chromium firefox webkit
       - run: bun run --cwd packages/tests e2e:prod:matrix
+      - if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: prod-e2e-matrix-artifacts
+          path: |
+            packages/tests/playwright-report
+            packages/tests/test-results
+          retention-days: 7
       - if: always()
         run: bun run --cwd packages/tests teardown
 

--- a/packages/tests/src/matrix/journey-lite.e2e.ts
+++ b/packages/tests/src/matrix/journey-lite.e2e.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@playwright/test";
 import { createAccount, deleteAccountViaUi } from "../helpers/prod";
 
+test.setTimeout(180_000);
+const cleanupTimeoutMs = 120_000;
+
 test("signup, create, search, favorite, delete account", async ({ page }) => {
   const account = await createAccount(
     page,
@@ -21,6 +24,7 @@ test("signup, create, search, favorite, delete account", async ({ page }) => {
     await page.keyboard.press("Enter");
     await expect(savedCard).toBeVisible();
   } finally {
+    test.info().setTimeout(test.info().timeout + cleanupTimeoutMs);
     await deleteAccountViaUi(page, account);
   }
 });


### PR DESCRIPTION
## Summary
- give the production browser matrix journey enough time for account cleanup under production latency
- upload matrix Playwright artifacts on failure so screenshots/traces are retained

## Failure evidence
- second post-merge manual Production E2E run `28849477173` passed gate/docs/journey/extension/sweep, but matrix Chromium hit the global 120s timeout during account cleanup

## Validation
- `bun run --cwd packages/tests typecheck`
- `bun run --cwd packages/tests lint`
- pre-commit affected typecheck/lint passed