### PR TITLE
Fix prod CSP, recording, and E2E screenshots

### DIFF
--- a/.github/workflows/prod-e2e.yml
+++ b/.github/workflows/prod-e2e.yml
@@ -53,10 +53,10 @@ jobs:
       - run: bun run --cwd packages/tests e2e:prod:journey
       - if: always()
         run: bun run --cwd packages/tests teardown
-      - if: failure()
+      - if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: prod-e2e-journey-artifacts
+          name: prod-e2e-journey-results
           path: |
             packages/tests/playwright-report
             packages/tests/test-results
@@ -72,6 +72,14 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bunx playwright install --with-deps chromium
       - run: bun run --cwd packages/tests e2e:prod:docs
+      - if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: prod-e2e-docs-results
+          path: |
+            packages/tests/playwright-report
+            packages/tests/test-results
+          retention-days: 7
 
   matrix:
     needs: journey
@@ -83,16 +91,16 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bunx playwright install --with-deps chromium firefox webkit
       - run: bun run --cwd packages/tests e2e:prod:matrix
-      - if: failure()
+      - if: always()
+        run: bun run --cwd packages/tests teardown
+      - if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: prod-e2e-matrix-artifacts
+          name: prod-e2e-matrix-results
           path: |
             packages/tests/playwright-report
             packages/tests/test-results
           retention-days: 7
-      - if: always()
-        run: bun run --cwd packages/tests teardown
 
   extension:
     needs: journey
@@ -110,6 +118,14 @@ jobs:
       - run: bun run --cwd packages/tests e2e:prod:extension
       - if: always()
         run: bun run --cwd packages/tests teardown
+      - if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: prod-e2e-extension-results
+          path: |
+            packages/tests/playwright-report
+            packages/tests/test-results
+          retention-days: 7
 
   sweep:
     needs: [matrix, extension]

--- a/apps/docs/src/content/changelog/2026-07.mdx
+++ b/apps/docs/src/content/changelog/2026-07.mdx
@@ -4,6 +4,9 @@ date: "2026-07-06"
 ---
 
 - PDF documents now open and preview correctly when you view them in Teak.
+- Web audio recording now works reliably in Chrome. Dragging, dropping, or pasting files now reports upload progress accurately, and saved link icons load more consistently.
+- Settings and sign-in screens now show stable loading states instead of partial rows or empty cards.
+- Imports now keep progress visible after you reopen Settings, wrap long error reports inside the dialog, and stop cleanly when your card limit is reached.
 - The desktop app now uploads files reliably again.
 - The desktop app can now record audio notes. macOS will ask for microphone access the first time.
 - Import and Export now share one place in Settings, with a quick tab to switch between them. Imports show step-by-step progress and explain exactly which items were skipped or why any failed.

--- a/apps/web/src/__tests__/authRouteGuard.test.ts
+++ b/apps/web/src/__tests__/authRouteGuard.test.ts
@@ -23,5 +23,7 @@ describe("auth route session handling", () => {
     expect(source).toContain("authClient.useSession()");
     expect(source).toContain("if (session)");
     expect(source).toContain("getSafeNextPath");
+    expect(source).toContain("fallback?: ReactNode");
+    expect(source).toContain("return fallback");
   });
 });

--- a/apps/web/src/__tests__/securityHeaders.test.ts
+++ b/apps/web/src/__tests__/securityHeaders.test.ts
@@ -29,10 +29,16 @@ describe("web security headers", () => {
     expect(contentSecurityPolicy).toContain("media-src 'self' blob: data:");
     expect(directiveTokens("img-src")).toContain(teakR2StorageOrigin);
     expect(directiveTokens("img-src")).toContain("https://www.google.com");
+    expect(directiveTokens("img-src")).toContain("https://*.gstatic.com");
     expect(directiveTokens("img-src")).not.toContain("https:");
     expect(directiveTokens("script-src")).toContain("'nonce-test-nonce'");
     expect(directiveTokens("connect-src")).toContain(teakR2StorageOrigin);
     expect(directiveTokens("media-src")).toContain(teakR2StorageOrigin);
+    expect(directiveTokens("frame-src")).toContain(teakR2StorageOrigin);
+    expect(directiveTokens("frame-src")).toContain(
+      "https://*.r2.cloudflarestorage.com"
+    );
+    expect(directiveTokens("frame-src")).toContain("https://*.r2.dev");
     expect(directiveTokens("img-src")).not.toContain(
       "https://*.r2.cloudflarestorage.com"
     );
@@ -52,6 +58,35 @@ describe("web security headers", () => {
     expect(directiveTokens("connect-src")).not.toContain("wss:");
   });
 
+  test("allows configured custom R2 origins only for document frames", () => {
+    const previous = process.env.NEXT_PUBLIC_R2_PUBLIC_ORIGIN;
+    process.env.NEXT_PUBLIC_R2_PUBLIC_ORIGIN =
+      "https://files.teakvault.com/path, http://unsafe.example, not-a-url";
+    try {
+      const policy = buildContentSecurityPolicy(nonce);
+      const tokens = (name: string) =>
+        policy
+          .split("; ")
+          .find((directive) => directive.startsWith(`${name} `))
+          ?.split(" ")
+          .slice(1) ?? [];
+
+      expect(tokens("frame-src")).toContain("https://files.teakvault.com");
+      expect(tokens("frame-src")).not.toContain("http://unsafe.example");
+      expect(tokens("img-src")).not.toContain("https://files.teakvault.com");
+      expect(tokens("connect-src")).not.toContain(
+        "https://files.teakvault.com"
+      );
+      expect(tokens("media-src")).not.toContain("https://files.teakvault.com");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.NEXT_PUBLIC_R2_PUBLIC_ORIGIN;
+      } else {
+        process.env.NEXT_PUBLIC_R2_PUBLIC_ORIGIN = previous;
+      }
+    }
+  });
+
   test("keeps baseline browser security headers enabled", () => {
     expect(
       staticSecurityHeaders.some(({ key }) => key === "Content-Security-Policy")
@@ -60,6 +95,7 @@ describe("web security headers", () => {
       "includeSubDomains"
     );
     expect(headers.get("Permissions-Policy")).toContain("camera=()");
+    expect(headers.get("Permissions-Policy")).toContain("microphone=(self)");
     expect(headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(headers.get("X-Frame-Options")).toBe("DENY");
   });

--- a/apps/web/src/app/(auth)/AuthCardLoading.tsx
+++ b/apps/web/src/app/(auth)/AuthCardLoading.tsx
@@ -1,0 +1,14 @@
+import { CardContent } from "@teak/ui/components/ui/card";
+import { Spinner } from "@teak/ui/components/ui/spinner";
+
+export function AuthCardLoading() {
+  return (
+    <CardContent
+      aria-label="Loading authentication"
+      className="flex min-h-16 items-center justify-center py-8"
+      role="status"
+    >
+      <Spinner className="size-5" />
+    </CardContent>
+  );
+}

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -3,6 +3,7 @@ import { AuthScreenShell } from "@teak/ui/screens";
 import Link from "next/link";
 import { Suspense } from "react";
 import { AuthRouteGuard } from "@/components/AuthRouteGuard";
+import { AuthCardLoading } from "./AuthCardLoading";
 
 export default function RootLayout({
   children,
@@ -17,8 +18,10 @@ export default function RootLayout({
         </Link>
       }
     >
-      <Suspense>
-        <AuthRouteGuard>{children}</AuthRouteGuard>
+      <Suspense fallback={<AuthCardLoading />}>
+        <AuthRouteGuard fallback={<AuthCardLoading />}>
+          {children}
+        </AuthRouteGuard>
       </Suspense>
     </AuthScreenShell>
   );

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -18,6 +18,7 @@ import { Suspense, useState } from "react";
 import { toast } from "sonner";
 import { authClient } from "@/lib/auth-client";
 import { resolveAuthRedirect } from "@/lib/auth-redirect";
+import { AuthCardLoading } from "../AuthCardLoading";
 
 type PendingProvider = "email" | "google" | "apple" | null;
 
@@ -41,7 +42,7 @@ function showSignInError(message: string) {
 
 export default function SignIn() {
   return (
-    <Suspense>
+    <Suspense fallback={<AuthCardLoading />}>
       <SignInForm />
     </Suspense>
   );

--- a/apps/web/src/app/(auth)/register/page.tsx
+++ b/apps/web/src/app/(auth)/register/page.tsx
@@ -21,13 +21,14 @@ import { Suspense, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { authClient } from "@/lib/auth-client";
 import { resolveAuthRedirect } from "@/lib/auth-redirect";
+import { AuthCardLoading } from "../AuthCardLoading";
 
 const MIN_PASSWORD_LENGTH = 8;
 type PendingProvider = "email" | "google" | "apple" | null;
 
 export default function SignUp() {
   return (
-    <Suspense>
+    <Suspense fallback={<AuthCardLoading />}>
       <SignUpForm />
     </Suspense>
   );

--- a/apps/web/src/app/(auth)/reset-password/page.tsx
+++ b/apps/web/src/app/(auth)/reset-password/page.tsx
@@ -21,6 +21,7 @@ import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { authClient } from "@/lib/auth-client";
+import { AuthCardLoading } from "../AuthCardLoading";
 
 const MIN_PASSWORD_LENGTH = 8;
 
@@ -32,7 +33,7 @@ const errorMessages: Record<string, string> = {
 
 export default function ResetPassword() {
   return (
-    <Suspense>
+    <Suspense fallback={<AuthCardLoading />}>
       <ResetPasswordForm />
     </Suspense>
   );

--- a/apps/web/src/components/AuthRouteGuard.tsx
+++ b/apps/web/src/components/AuthRouteGuard.tsx
@@ -6,7 +6,13 @@ import { useEffect } from "react";
 import { authClient } from "@/lib/auth-client";
 import { getSafeNextPath } from "@/lib/safe-next-path";
 
-export function AuthRouteGuard({ children }: { children: ReactNode }) {
+export function AuthRouteGuard({
+  children,
+  fallback = null,
+}: {
+  children: ReactNode;
+  fallback?: ReactNode;
+}) {
   const searchParams = useSearchParams();
   const { data: session, isPending } = authClient.useSession();
   const nextPath = getSafeNextPath(searchParams.get("next")) ?? "/";
@@ -20,7 +26,7 @@ export function AuthRouteGuard({ children }: { children: ReactNode }) {
   }, [nextPath, session]);
 
   if (isPending || session) {
-    return null;
+    return fallback;
   }
 
   return <>{children}</>;

--- a/apps/web/src/lib/security-headers.ts
+++ b/apps/web/src/lib/security-headers.ts
@@ -2,6 +2,42 @@ export const CSP_NONCE_HEADER = "x-nonce";
 
 const TEAK_R2_STORAGE_ORIGIN =
   "https://teak-files-prod.dd19e45b8f2f3cc0393cc2deb51fa27d.r2.cloudflarestorage.com";
+const R2_FRAME_SOURCES = [
+  "https://*.r2.cloudflarestorage.com",
+  "https://*.r2.dev",
+] as const;
+
+const normalizeHttpsOrigin = (value: string): string | null => {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:") {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+};
+
+const configuredR2FrameSources = () => {
+  const values = [
+    process.env.NEXT_PUBLIC_R2_PUBLIC_ORIGIN,
+    process.env.NEXT_PUBLIC_R2_PUBLIC_URL,
+    process.env.R2_PUBLIC_ORIGIN,
+    process.env.R2_PUBLIC_URL,
+  ];
+  return Array.from(
+    new Set(
+      values.flatMap(
+        (value) =>
+          value
+            ?.split(",")
+            .map((item) => normalizeHttpsOrigin(item.trim()))
+            .filter((item): item is string => Boolean(item)) ?? []
+      )
+    )
+  );
+};
 
 export const buildContentSecurityPolicy = (nonce: string) =>
   [
@@ -14,6 +50,7 @@ export const buildContentSecurityPolicy = (nonce: string) =>
       "img-src 'self' blob: data:",
       TEAK_R2_STORAGE_ORIGIN,
       "https://www.google.com",
+      "https://*.gstatic.com",
       "https://*.teakvault.com",
     ].join(" "),
     "font-src 'self' data:",
@@ -31,7 +68,12 @@ export const buildContentSecurityPolicy = (nonce: string) =>
       TEAK_R2_STORAGE_ORIGIN,
     ].join(" "),
     ["media-src 'self' blob: data:", TEAK_R2_STORAGE_ORIGIN].join(" "),
-    "frame-src https://*.polar.sh https://polar.sh",
+    [
+      "frame-src https://*.polar.sh https://polar.sh",
+      TEAK_R2_STORAGE_ORIGIN,
+      ...R2_FRAME_SOURCES,
+      ...configuredR2FrameSources(),
+    ].join(" "),
     "worker-src 'self' blob:",
     "upgrade-insecure-requests",
   ].join("; ");
@@ -39,7 +81,7 @@ export const buildContentSecurityPolicy = (nonce: string) =>
 export const staticSecurityHeaders: { key: string; value: string }[] = [
   {
     key: "Permissions-Policy",
-    value: "camera=(), geolocation=(), microphone=()",
+    value: "camera=(), geolocation=(), microphone=(self)",
   },
   {
     key: "X-DNS-Prefetch-Control",

--- a/packages/convex/__tests__/importWorkflow.test.ts
+++ b/packages/convex/__tests__/importWorkflow.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+describe("import workflow", () => {
+  test("stops the job on card limit instead of failing every remaining item", () => {
+    const source = readFileSync(
+      fileURLToPath(new URL("../workflows/import.ts", import.meta.url)),
+      "utf8"
+    );
+    const limitBranch = source.match(
+      /if \(result\.limitReached\) \{[\s\S]*?\n      \}/
+    )?.[0];
+
+    expect(source).toContain("result.limitReached");
+    expect(limitBranch).toContain("CARD_ERROR_MESSAGES.CARD_LIMIT_REACHED");
+    expect(limitBranch).toContain('"failed"');
+    expect(limitBranch).not.toContain("failRemaining");
+    expect(limitBranch).not.toContain('"completed"');
+  });
+});

--- a/packages/convex/workflows/import.ts
+++ b/packages/convex/workflows/import.ts
@@ -2,26 +2,10 @@ import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { internalMutation } from "../_generated/server";
 import { IMPORT_CARD_BATCH } from "../import/constants";
+import { CARD_ERROR_MESSAGES } from "../shared/constants";
 import { workflow } from "./manager";
 
 const internalAny = internal as Record<string, any>;
-
-async function failRemaining(
-  step: any,
-  jobId: string,
-  code: string,
-  reason: string
-) {
-  for (;;) {
-    const result = await step.runMutation(
-      internalAny.dataImport.failPendingPage,
-      { jobId, code, reason, limit: 100 }
-    );
-    if (!result.count) {
-      return;
-    }
-  }
-}
 
 async function finalize(
   step: any,
@@ -120,13 +104,12 @@ export const importWorkflow = workflow.define({
         { jobId, itemIds: items.map((item: any) => item._id) }
       );
       if (result.limitReached) {
-        await failRemaining(
+        return finalize(
           step,
           jobId,
-          "CARD_LIMIT_REACHED",
-          "Your card limit was reached"
+          "failed",
+          CARD_ERROR_MESSAGES.CARD_LIMIT_REACHED
         );
-        return finalize(step, jobId, "completed");
       }
       if (result.retryAt) {
         await step.sleep(Math.max(1000, result.retryAt - Date.now()), {

--- a/packages/tests/playwright.config.ts
+++ b/packages/tests/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   use: {
     baseURL: env.appUrl,
     trace: "retain-on-failure",
-    screenshot: "only-on-failure",
+    screenshot: "on",
     video: "retain-on-failure",
   },
   projects: [
@@ -30,7 +30,16 @@ export default defineConfig({
       testIgnore: ["journey/01-signup.setup.ts", deleteAccount, postDelete],
       testMatch: journey,
       workers: 1,
-      use: { ...devices["Desktop Chrome"], storageState: ".state/user.json" },
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: ".state/user.json",
+        launchOptions: {
+          args: [
+            "--use-fake-device-for-media-stream",
+            "--use-fake-ui-for-media-stream",
+          ],
+        },
+      },
     },
     {
       name: "journey-delete",

--- a/packages/tests/src/journey/02-web-journey.e2e.ts
+++ b/packages/tests/src/journey/02-web-journey.e2e.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer";
 import { expect, test } from "@playwright/test";
+import { env } from "../helpers/env";
 import { clientFor, generateApiKey, revokeVisibleKey } from "../helpers/prod";
 import { readState, updateState } from "../helpers/run-state";
 
@@ -31,6 +32,18 @@ test("web journey covers cards, search, settings, upload, and revoked key", asyn
   await page.keyboard.press("Enter");
   await expect(savedCard).toBeVisible();
   await page.getByRole("button", { name: "Clear All" }).click();
+
+  await page.context().grantPermissions(["microphone"], { origin: env.appUrl });
+  await page.getByRole("button", { name: "Record audio" }).click();
+  await expect(
+    page.getByRole("dialog", { name: "Recording audio" })
+  ).toBeVisible();
+  await expect(page.getByText(/Speak naturally/i)).toBeVisible();
+  await expect(page.getByText("0:01")).toBeVisible({ timeout: 5000 });
+  await page.getByRole("button", { name: "Stop and Save" }).click();
+  await expect(page.getByText("Audio recording saved")).toBeVisible({
+    timeout: 45_000,
+  });
 
   const api = clientFor(state.primary.apiKey);
   const png = Buffer.from(

--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -1,0 +1,233 @@
+import { Buffer } from "node:buffer";
+import { expect, type Page, test } from "@playwright/test";
+import { MAX_FILE_SIZE } from "@teak/convex/shared";
+import { apiFetch } from "../helpers/api";
+import { clientFor } from "../helpers/prod";
+import { readState, updateState } from "../helpers/run-state";
+
+const png = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "base64"
+);
+
+interface FilePayload {
+  buffer: Buffer;
+  mimeType: string;
+  name: string;
+}
+const pdf = Buffer.from(
+  "%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Count 0>>endobj\ntrailer<</Root 1 0 R>>\n%%EOF\n"
+);
+
+const saveTextCard = async (page: Page, content: string) => {
+  await page.goto("/");
+  await page.getByPlaceholder(/Write a note/i).fill(content);
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(page.getByRole("main").getByText(content).first()).toBeVisible();
+};
+
+const searchFor = async (page: Page, query: string) => {
+  await page.goto("/");
+  const search = page.getByPlaceholder("Search for anything...");
+  await search.fill(query);
+  await search.press("Enter");
+};
+
+const uploadFiles = async (page: Page, files: FilePayload | FilePayload[]) => {
+  const [chooser] = await Promise.all([
+    page.waitForEvent("filechooser"),
+    page.getByRole("button", { name: "Upload files" }).click(),
+  ]);
+  await chooser.setFiles(files);
+};
+
+test("web product surfaces cover edit, deep links, rich cards, import/export, bulk, and empty states", async ({
+  page,
+}) => {
+  const state = readState();
+  if (!state.primary?.apiKey) {
+    throw new Error("Missing primary API key");
+  }
+  const api = clientFor(state.primary.apiKey);
+  const marker = `prod-surface-${Date.now()}`;
+
+  await saveTextCard(page, `${marker} original`);
+  await page.getByRole("main").getByText(`${marker} original`).click();
+  const editor = page.getByPlaceholder("Enter your text...");
+  await editor.fill(`# ${marker} updated\n\n- **bold** item\n- \`code\``);
+  await page.getByRole("button", { name: "Save changes" }).click();
+  await expect(editor).toHaveValue(/updated/);
+  const deepLink = page.url();
+  const cardId = new URL(deepLink).searchParams.get("card");
+  expect(cardId).toBeTruthy();
+  await page.reload();
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await expect(page.getByPlaceholder("Enter your text...")).toHaveValue(
+    /updated/
+  );
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("dialog")).not.toBeVisible();
+  await page.goBack();
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await page.keyboard.press("Escape");
+  const searchResponse = await apiFetch(
+    `/v1/cards/search?q=${encodeURIComponent(marker)}`,
+    state.primary.apiKey
+  );
+  const searchPayload = (await searchResponse.json()) as {
+    items?: Array<{ content?: string }>;
+  };
+  expect(
+    searchPayload.items?.filter((card) => card.content?.includes(marker))
+  ).toHaveLength(1);
+
+  await saveTextCard(page, "https://example.com/");
+  await expect
+    .poll(
+      async () =>
+        (
+          (await (
+            await apiFetch(
+              "/v1/cards/search?q=example.com",
+              state.primary!.apiKey!
+            )
+          ).json()) as { items?: Array<{ metadataTitle?: string }> }
+        ).items?.some((card) =>
+          /Example Domain/i.test(card.metadataTitle ?? "")
+        ),
+      { timeout: 90_000 }
+    )
+    .toBe(true);
+  await searchFor(page, "example.com");
+  await expect(page.getByRole("main").getByText(/Example Domain/i)).toBeVisible(
+    { timeout: 30_000 }
+  );
+
+  await page.goto("/");
+  await uploadFiles(page, [
+    { buffer: pdf, mimeType: "application/pdf", name: `${marker}.pdf` },
+    {
+      buffer: Buffer.from("teak audio"),
+      mimeType: "audio/webm",
+      name: `${marker}.webm`,
+    },
+    {
+      buffer: Buffer.from("teak video"),
+      mimeType: "video/mp4",
+      name: `${marker}.mp4`,
+    },
+  ]);
+  await expect(page.getByText(/Uploaded 3 files|File uploaded/)).toBeVisible({
+    timeout: 90_000,
+  });
+
+  await uploadFiles(page, {
+    buffer: Buffer.alloc(MAX_FILE_SIZE + 1),
+    mimeType: "application/octet-stream",
+    name: `${marker}-too-large.bin`,
+  });
+  await expect(page.getByText(/Maximum file size is 20MB/i)).toBeVisible();
+
+  await page.goto("/");
+  await page.evaluate((base64) => {
+    const bytes = Uint8Array.from(atob(base64), (char) => char.charCodeAt(0));
+    const file = new File([bytes], "pasted-prod-e2e.png", {
+      type: "image/png",
+    });
+    const clipboardData = new DataTransfer();
+    clipboardData.items.add(file);
+    document.dispatchEvent(
+      new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData,
+      })
+    );
+  }, png.toString("base64"));
+  await expect(page.getByText("File uploaded")).toBeVisible({
+    timeout: 90_000,
+  });
+
+  const bulkA = await api.cards.create({
+    content: `${marker} bulk-a`,
+    source: "prod-e2e",
+  });
+  const bulkB = await api.cards.create({
+    content: `${marker} bulk-b`,
+    source: "prod-e2e",
+  });
+  updateState((s) => s.createdCardIds.push(bulkA.cardId, bulkB.cardId));
+  await searchFor(page, `${marker} bulk`);
+  await page.getByText(`${marker} bulk-a`).click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Select" }).click();
+  await page.getByText(`${marker} bulk-b`).click();
+  await expect(page.getByText("2 cards selected")).toBeVisible();
+  await page.getByRole("button", { name: "Delete" }).click();
+  await expect(page.getByText("Deleted 2 cards")).toBeVisible({
+    timeout: 30_000,
+  });
+
+  const restoreCard = await api.cards.create({
+    content: `${marker} restore-me`,
+    source: "prod-e2e",
+  });
+  updateState((s) => s.createdCardIds.push(restoreCard.cardId));
+  await searchFor(page, `${marker} restore-me`);
+  await page.getByText(`${marker} restore-me`).click();
+  await page.getByRole("button", { name: "Favorite" }).click();
+  await page.getByRole("button", { name: "Manage Tags" }).click();
+  await page.locator("#new-tag").fill(`${marker}-tag`);
+  await page.getByRole("button", { name: "Add" }).click();
+  await expect(page.getByText(`${marker}-tag`)).toBeVisible();
+  await page.keyboard.press("Escape");
+  await page.getByRole("button", { name: "Delete" }).click();
+  await expect(page.getByRole("dialog")).not.toBeVisible();
+  await searchFor(page, "trash");
+  await page.getByText(`${marker} restore-me`).click();
+  await page.getByRole("button", { name: "Restore" }).click();
+  await expect(page.getByRole("dialog")).not.toBeVisible();
+  await searchFor(page, `${marker} restore-me`);
+  await expect(page.getByText(`${marker} restore-me`)).toBeVisible();
+
+  await page.goto("/settings");
+  await page.getByText("Import/Export Data").waitFor();
+  await page
+    .getByText("Import/Export Data")
+    .locator("xpath=ancestor::div[.//button][1]")
+    .getByRole("button", { name: "Manage" })
+    .click();
+  await expect(page.getByRole("dialog")).toContainText("Import or export");
+  await page.getByRole("tab", { name: "Export" }).click();
+  await expect(
+    page.getByText(/Export your data|Your export is ready/)
+  ).toBeVisible();
+  await page.getByRole("tab", { name: "Import" }).click();
+  await expect(
+    page.getByRole("button", { name: "Import Bookmarks" })
+  ).toBeVisible();
+  const [bookmarkChooser] = await Promise.all([
+    page.waitForEvent("filechooser"),
+    page.getByRole("button", { name: "Import Bookmarks" }).click(),
+  ]);
+  await bookmarkChooser.setFiles({
+    buffer: Buffer.from(
+      '<!doctype NETSCAPE-Bookmark-file-1><TITLE>Bookmarks</TITLE><H1>Bookmarks</H1><DL><DT><A HREF="https://example.com/">Example import</A></DT></DL>'
+    ),
+    mimeType: "text/html",
+    name: `${marker}-bookmarks.html`,
+  });
+  await expect(page.getByText(`${marker}-bookmarks.html`)).toBeVisible();
+  await page.getByRole("button", { name: "Start import" }).click();
+  await expect(page.getByText(/created|skipped|Import/i)).toBeVisible({
+    timeout: 120_000,
+  });
+  await page.keyboard.press("Escape");
+
+  await searchFor(page, `${marker}-no-results`);
+  await expect(page.getByText(/nothing found/i)).toBeVisible();
+  await page.getByRole("button", { name: "Clear All" }).click();
+  await searchFor(page, `${marker}-tag`);
+  await expect(page.getByText(/nothing found/i)).toBeVisible();
+  await searchFor(page, "trash");
+  await expect(page.getByText(/nothing found|restore-me/i)).toBeVisible();
+});

--- a/packages/tests/src/matrix/journey-lite.e2e.ts
+++ b/packages/tests/src/matrix/journey-lite.e2e.ts
@@ -1,30 +1,21 @@
 import { expect, test } from "@playwright/test";
-import { createAccount, deleteAccountViaUi } from "../helpers/prod";
+import { createAccount } from "../helpers/prod";
 
 test.setTimeout(180_000);
-const cleanupTimeoutMs = 120_000;
 
-test("signup, create, search, favorite, delete account", async ({ page }) => {
-  const account = await createAccount(
-    page,
-    `matrix-${test.info().project.name}`
-  );
-  try {
-    const marker = `matrix-${Date.now()}`;
-    await page.goto("/");
-    await page.getByPlaceholder(/Write a note/i).fill(marker);
-    await page.getByRole("button", { name: "Save", exact: true }).click();
-    const savedCard = page
-      .getByRole("main")
-      .getByRole("paragraph")
-      .filter({ hasText: marker })
-      .first();
-    await expect(savedCard).toBeVisible();
-    await page.getByPlaceholder("Search for anything...").fill(marker);
-    await page.keyboard.press("Enter");
-    await expect(savedCard).toBeVisible();
-  } finally {
-    test.info().setTimeout(test.info().timeout + cleanupTimeoutMs);
-    await deleteAccountViaUi(page, account);
-  }
+test("signup, create, and search", async ({ page }) => {
+  await createAccount(page, `matrix-${test.info().project.name}`);
+  const marker = `matrix-${Date.now()}`;
+  await page.goto("/");
+  await page.getByPlaceholder(/Write a note/i).fill(marker);
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  const savedCard = page
+    .getByRole("main")
+    .getByRole("paragraph")
+    .filter({ hasText: marker })
+    .first();
+  await expect(savedCard).toBeVisible();
+  await page.getByPlaceholder("Search for anything...").fill(marker);
+  await page.keyboard.press("Enter");
+  await expect(savedCard).toBeVisible();
 });

--- a/packages/ui/src/components/settings/ImportExportDialog.tsx
+++ b/packages/ui/src/components/settings/ImportExportDialog.tsx
@@ -34,7 +34,7 @@ export function ImportExportDialog({
 }: ImportExportDialogProps) {
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="max-h-[85vh] gap-4 overflow-y-auto p-4 sm:max-w-lg">
+      <DialogContent className="max-h-[85vh] min-w-0 gap-4 overflow-x-hidden overflow-y-auto p-4 sm:max-w-lg">
         <DialogHeader className="gap-1">
           <DialogTitle>Manage Data</DialogTitle>
           <DialogDescription>
@@ -42,16 +42,16 @@ export function ImportExportDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <Tabs defaultValue="import">
+        <Tabs className="min-w-0" defaultValue="import">
           <TabsList className="w-full">
             <TabsTrigger value="import">Import</TabsTrigger>
             <TabsTrigger value="export">Export</TabsTrigger>
           </TabsList>
 
-          <TabsContent className="pt-4" value="import">
+          <TabsContent className="min-w-0 pt-4" value="import">
             <ImportPanel onActiveChange={onImportActiveChange} />
           </TabsContent>
-          <TabsContent className="pt-4" value="export">
+          <TabsContent className="min-w-0 pt-4" value="export">
             <ExportPanel
               exportState={exportState}
               isLoading={exportLoading}

--- a/packages/ui/src/components/settings/ImportPanel.tsx
+++ b/packages/ui/src/components/settings/ImportPanel.tsx
@@ -30,6 +30,7 @@ interface ImportJob {
   completedAt?: number;
   createdCount: number;
   failedCount: number;
+  failureClass?: string;
   id: string;
   mode: ImportMode;
   parsedCount: number;
@@ -120,6 +121,13 @@ function describeImport(job: ImportJob): string {
   return `Last import: ${parts.join(", ")} — ${when}`;
 }
 
+function describeFailure(job: ImportJob): string | null {
+  if (job.status !== "failed") {
+    return null;
+  }
+  return job.failureClass ?? "Import failed. Please try again.";
+}
+
 // Overall progress as one monotonic fraction: upload fills the first stretch,
 // then parsing/importing carry it to the end (importing uses the real
 // processed/parsed ratio when available).
@@ -161,7 +169,7 @@ export function ImportProgressSummary({
   ].filter((count) => count.value > 0);
 
   return (
-    <div aria-live="polite" className="space-y-2.5 border-t pt-3">
+    <div aria-live="polite" className="min-w-0 space-y-2.5 border-t pt-3">
       <div className="flex items-center gap-2">
         {active ? <Spinner className="size-4" /> : null}
         <span className="font-medium">{job.phase}</span>
@@ -190,6 +198,12 @@ export function ImportProgressSummary({
             </span>
           ))}
         </div>
+      ) : null}
+      {active && job.status !== "uploading" ? (
+        <p className="text-muted-foreground">
+          You can close this and come back later. Importing continues in the
+          background.
+        </p>
       ) : null}
     </div>
   );
@@ -244,6 +258,7 @@ export function ImportPanel({ onActiveChange }: ImportPanelProps) {
     job?.status === "importing";
   const active = transporting || serverProcessing;
   const isResuming = job?.status === "uploading" && !transporting;
+  const terminalFailure = job ? describeFailure(job) : null;
 
   const failureSamples = useQuery(
     api.dataImport.getImportFailureSamples,
@@ -401,10 +416,10 @@ export function ImportPanel({ onActiveChange }: ImportPanelProps) {
       };
 
   return (
-    <div className="space-y-4 text-sm">
+    <div className="min-w-0 space-y-4 text-sm">
       {pending ? (
         <div className="space-y-3">
-          <div className="flex items-center gap-3">
+          <div className="flex min-w-0 items-center gap-3">
             <FileText className="size-5 shrink-0 text-muted-foreground" />
             <div className="min-w-0">
               <div className="truncate font-medium">{pending.file.name}</div>
@@ -507,25 +522,34 @@ export function ImportPanel({ onActiveChange }: ImportPanelProps) {
       ) : null}
 
       {showIdle ? (
-        <div className="flex items-center gap-2 border-t pt-3 text-muted-foreground">
+        <div className="flex min-w-0 items-center gap-2 border-t pt-3 text-muted-foreground">
           {lastLoading ? <Spinner className="size-4" /> : null}
-          {lastLoading ? "Loading last import details…" : lastText}
+          <span className="min-w-0 break-words">
+            {lastLoading ? "Loading last import details…" : lastText}
+          </span>
+        </div>
+      ) : null}
+
+      {terminalFailure ? (
+        <div className="min-w-0 rounded-md border border-destructive/35 bg-destructive/10 p-3 text-destructive">
+          <div className="font-medium">Import stopped</div>
+          <p className="mt-1 break-words">{terminalFailure}</p>
         </div>
       ) : null}
 
       {terminal && failureSamples && failureSamples.length > 0 ? (
-        <div className="space-y-1.5">
+        <div className="min-w-0 space-y-1.5">
           <div className="font-medium">Items that couldn't be imported</div>
           <ul className="max-h-40 space-y-1.5 overflow-y-auto pr-1">
             {failureSamples.map((sample) => (
               <li
-                className="flex items-start gap-2"
+                className="flex min-w-0 items-start gap-2"
                 key={`${sample.sourceIndex}-${sample.item}`}
               >
                 <X className="mt-0.5 size-3.5 shrink-0 text-destructive" />
                 <span className="min-w-0">
-                  <span className="block truncate">{sample.item}</span>
-                  <span className="block text-muted-foreground">
+                  <span className="block break-words">{sample.item}</span>
+                  <span className="block break-words text-muted-foreground">
                     {sample.reason}
                   </span>
                 </span>
@@ -536,12 +560,18 @@ export function ImportPanel({ onActiveChange }: ImportPanelProps) {
       ) : null}
 
       {!active && job?.reportAvailable ? (
-        <div className="flex flex-wrap gap-2">
-          <Button onClick={() => void copyReport()} size="sm" variant="outline">
+        <div className="flex min-w-0 flex-wrap gap-2">
+          <Button
+            className="min-w-0"
+            onClick={() => void copyReport()}
+            size="sm"
+            variant="outline"
+          >
             <Copy />
             Copy error report
           </Button>
           <Button
+            className="min-w-0"
             onClick={() => void downloadReport()}
             size="sm"
             variant="outline"

--- a/packages/ui/src/components/settings/SettingsContent.tsx
+++ b/packages/ui/src/components/settings/SettingsContent.tsx
@@ -89,30 +89,39 @@ export function SettingsContent({
     </>
   );
 
+  if (isLoading) {
+    return (
+      <>
+        <h1 className="font-semibold text-xl tracking-tight">Settings</h1>
+        <div
+          aria-label="Loading settings"
+          className="flex min-h-64 items-center justify-center"
+          role="status"
+        >
+          <Spinner className="size-5" />
+        </div>
+      </>
+    );
+  }
+
   return (
     <>
       <h1 className="font-semibold text-xl tracking-tight">Settings</h1>
 
       <SettingRow title="Email">
         <Button disabled size="sm" variant="ghost">
-          {isLoading ? <Spinner /> : (email ?? "Not available")}
+          {email ?? "Not available"}
         </Button>
       </SettingRow>
 
       <SettingRow title="Usage">
         <Button disabled size="sm" variant="ghost">
-          {isLoading ? <Spinner /> : `${cardCount} Cards`}
+          {`${cardCount} Cards`}
         </Button>
       </SettingRow>
 
       <SettingRow title="Plan">
-        {isLoading ? (
-          <Button disabled size="sm" variant="ghost">
-            <Spinner />
-          </Button>
-        ) : (
-          planRowContent
-        )}
+        {planRowContent}
       </SettingRow>
 
       {/* Show the API Keys section once keys have loaded, even for keyless

--- a/packages/ui/src/components/settings/__tests__/ImportPanel.contract.test.tsx
+++ b/packages/ui/src/components/settings/__tests__/ImportPanel.contract.test.tsx
@@ -85,6 +85,7 @@ describe("ImportPanel", () => {
     expect(markup).toContain("2 created");
     expect(markup).toContain("1 skipped");
     expect(markup).toContain("1 failed");
+    expect(markup).toContain("Importing continues in the background");
   });
 
   test("renders a concise completion summary", () => {
@@ -109,6 +110,33 @@ describe("ImportPanel", () => {
     expect(markup).toContain("5 created");
     expect(markup).toContain("3 skipped");
     expect(markup).toContain("2 failed");
+  });
+
+  test("renders job-level failures without requiring report rows", () => {
+    importQueryResult = {
+      id: "job",
+      mode: "bookmarks",
+      status: "failed",
+      createdCount: 105,
+      failedCount: 1,
+      failureClass:
+        "Card limit reached. Please upgrade to Pro for unlimited cards.",
+      reportAvailable: false,
+      parsedCount: 200,
+      phase: "Import failed",
+      processedCount: 106,
+      skippedCount: 0,
+      updatedAt: 0,
+    };
+    try {
+      const markup = renderToStaticMarkup(<ImportPanel />);
+      expect(markup).toContain("Import stopped");
+      expect(markup).toContain(
+        "Card limit reached. Please upgrade to Pro for unlimited cards."
+      );
+    } finally {
+      importQueryResult = null;
+    }
   });
 
   test("shows multipart upload progress and hides counts", () => {

--- a/packages/ui/src/components/settings/__tests__/SettingsContent.contract.test.tsx
+++ b/packages/ui/src/components/settings/__tests__/SettingsContent.contract.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, mock, test } from "bun:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+mock.module("../ApiKeysSection", () => ({
+  ApiKeysSection: () => React.createElement("section", null, "API keys"),
+}));
+mock.module("../DeleteAccountDialog", () => ({
+  DeleteAccountDialog: () => null,
+}));
+mock.module("../ImportExportDialog", () => ({
+  ImportExportDialog: () => null,
+}));
+mock.module("../SettingsFooter", () => ({
+  SettingsFooter: () => React.createElement("footer", null, "Footer"),
+}));
+mock.module("../ThemeToggle", () => ({
+  ThemeToggle: () => React.createElement("div", null, "Theme toggle"),
+}));
+
+const { SettingsContent } = await import("../SettingsContent");
+
+const baseProps = {
+  cardCount: 3,
+  deleteDialogError: null,
+  deleteDialogOpen: false,
+  deleteLoading: false,
+  email: "hello@example.com",
+  exportState: { job: null, canStartNew: true, quotaResetMs: 0 },
+  hasPremium: false,
+  keys: [],
+  onCancelExport: mock(() => Promise.resolve()),
+  onCreateApiKey: mock(() => Promise.resolve({ key: "teak_test" })),
+  onCreateCustomerPortal: mock(() => Promise.resolve()),
+  onDeleteAccount: mock(() => Promise.resolve()),
+  onDeleteDialogOpenChange: mock(() => undefined),
+  onDownloadExport: mock(() => Promise.resolve()),
+  onRevokeApiKey: mock(() => Promise.resolve()),
+  onRotateApiKey: mock(() => Promise.resolve({ key: "teak_rotated" })),
+  onSignOut: mock(() => undefined),
+  onStartExport: mock(() => Promise.resolve()),
+  onUpgrade: mock(() => undefined),
+  signOutLoading: false,
+};
+
+describe("SettingsContent", () => {
+  test("uses one settings-level loading state before data is ready", () => {
+    const markup = renderToStaticMarkup(
+      <SettingsContent {...baseProps} isLoading={true} />
+    );
+
+    expect(markup).toContain("Settings");
+    expect(markup).toContain("Loading settings");
+    expect(markup).not.toContain("Email");
+    expect(markup).not.toContain("Usage");
+    expect(markup).not.toContain("Plan");
+  });
+
+  test("shows all settings rows together after data is ready", () => {
+    const markup = renderToStaticMarkup(
+      <SettingsContent {...baseProps} isLoading={false} />
+    );
+
+    expect(markup).toContain("hello@example.com");
+    expect(markup).toContain("3 Cards");
+    expect(markup).toContain("Free Plan");
+    expect(markup).toContain("Import/Export Data");
+  });
+});

--- a/packages/ui/src/hooks/GlobalFileDropProvider.tsx
+++ b/packages/ui/src/hooks/GlobalFileDropProvider.tsx
@@ -222,7 +222,9 @@ export function GlobalFileDropProvider({
         queueRef.current = queueRef.current.slice(snapshot.length);
       }
 
-      resolveResultToast(batchAggregateRef.current);
+      if (batchAggregateRef.current.length > 0) {
+        resolveResultToast(batchAggregateRef.current);
+      }
     } finally {
       batchAggregateRef.current = [];
       uploadingRef.current = false;
@@ -261,11 +263,9 @@ export function GlobalFileDropProvider({
         id: createQueueItemId(),
         file,
       }));
-      setQueue((previous) => {
-        const next = previous.concat(newItems);
-        queueRef.current = next;
-        return next;
-      });
+      const nextQueue = queueRef.current.concat(newItems);
+      queueRef.current = nextQueue;
+      setQueue(nextQueue);
 
       void drainQueue();
     },
@@ -364,6 +364,31 @@ export function GlobalFileDropProvider({
       enqueueValidatedFiles(files);
     };
 
+    const handlePaste = (event: ClipboardEvent) => {
+      if (!dataTransferHasFiles(event.clipboardData)) {
+        return;
+      }
+      if (isBlockedDropTarget(event.target)) {
+        return;
+      }
+
+      const { files } = extractFilesFromDataTransfer(event.clipboardData);
+      if (files.length === 0) {
+        return;
+      }
+
+      event.preventDefault();
+      if (!isOnline) {
+        toast.error("You're offline. Reconnect and try again.", {
+          ...UPLOAD_QUEUE_CRITICAL_TOAST_OPTIONS,
+          id: "upload-queue-offline",
+        });
+        return;
+      }
+
+      enqueueValidatedFiles(files);
+    };
+
     const handleDragEnd = () => {
       resetDragState();
     };
@@ -372,6 +397,7 @@ export function GlobalFileDropProvider({
     document.addEventListener("dragover", handleDragOver);
     document.addEventListener("dragleave", handleDragLeave);
     document.addEventListener("drop", handleDrop);
+    document.addEventListener("paste", handlePaste);
     document.addEventListener("dragend", handleDragEnd);
 
     return () => {
@@ -379,6 +405,7 @@ export function GlobalFileDropProvider({
       document.removeEventListener("dragover", handleDragOver);
       document.removeEventListener("dragleave", handleDragLeave);
       document.removeEventListener("drop", handleDrop);
+      document.removeEventListener("paste", handlePaste);
       document.removeEventListener("dragend", handleDragEnd);
     };
   }, [enqueueValidatedFiles, isOnline]);

--- a/packages/ui/src/hooks/useSettingsController.ts
+++ b/packages/ui/src/hooks/useSettingsController.ts
@@ -194,7 +194,8 @@ export function useSettingsController({
     handleSignOut,
     handleStartExport,
     hasPremium: user?.hasPremium,
-    isLoading: user === undefined,
+    isLoading:
+      user === undefined || keys === undefined || exportState === undefined,
     keys,
     setDeleteDialogOpen,
     setDeleteError,


### PR DESCRIPTION
## Summary
- Fix production web CSP/Permissions-Policy regressions seen in Chrome: R2 previews are allowed in frames, Google favicon redirect hosts are allowed for images, and microphone recording is allowed for the app origin.
- Add real Chrome production E2E coverage for audio recording with fake media devices, plus paste-to-create image uploads through the existing upload queue.
- Expand authenticated production E2E coverage for edit persistence, card deep links, link previews/favicons, PDF/video/audio uploads, large-file rejection, bulk delete, restore, tags/favorites, import/export controls, bookmark import, and empty states.
- Preserve Playwright screenshots/results on successful prod E2E runs for journey, docs, matrix, and extension jobs.
- Keep the browser matrix focused on compatibility by removing full UI account deletion from the per-browser matrix test; teardown/sweep remain the cleanup safety net.

## Validation
- `bun test apps/web/src/__tests__/securityHeaders.test.ts`
- `bun run --cwd packages/tests typecheck`
- `bun run --cwd packages/tests lint`
- `TURBO_CONCURRENCY=1 bun run pre-commit`

## Notes
- Teak currently has bulk delete and per-card restore/tag/favorite UI. Bulk tag, bulk favorite, select-all, and bulk restore are not existing controls in the product yet, so this PR covers the canonical current UI and leaves those as follow-up product work.
