### PR TITLE
Fix production E2E deep link assertion

### DIFF
--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -67,7 +67,7 @@ test("web product surfaces cover edit, deep links, rich cards, import/export, bu
   );
   await page.keyboard.press("Escape");
   await expect(page.getByRole("dialog")).not.toBeVisible();
-  await page.goBack();
+  await page.goto(deepLink);
   await expect(page.getByRole("dialog")).toBeVisible();
   await page.keyboard.press("Escape");
   const searchResponse = await apiFetch(


### PR DESCRIPTION
## Summary
- Reopen the product-surface card modal via the captured deep-link URL instead of depending on browser history shape after closing the modal.

## Validation
- bun run --cwd packages/tests typecheck
- bun run --cwd packages/tests lint
- pre-commit affected typecheck/lint for @teak/tests

## Context
Manual Production E2E run 28855968579 proved cleanup and artifact upload still run on failure, but the new product-surface journey expected Back to reopen the modal after closing it. The app correctly preserves the deep link itself, so the test now asserts that durable URL directly.