### PR TITLE
Fix production E2E synthetic paste upload

### DIFF
--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -179,13 +179,14 @@ test("web product surfaces cover edit, deep links, rich cards, import/export, bu
       const file = new File([bytes], fileName, { type: "image/png" });
       const clipboardData = new DataTransfer();
       clipboardData.items.add(file);
-      document.dispatchEvent(
-        new ClipboardEvent("paste", {
-          bubbles: true,
-          cancelable: true,
-          clipboardData,
-        })
-      );
+      const event = new Event("paste", {
+        bubbles: true,
+        cancelable: true,
+      }) as ClipboardEvent;
+      Object.defineProperty(event, "clipboardData", {
+        value: clipboardData,
+      });
+      document.dispatchEvent(event);
     },
     { base64: png.toString("base64"), fileName: pastedFileName }
   );


### PR DESCRIPTION
## Summary
- Dispatch production paste-upload E2E events with an attached clipboardData property so Chromium delivers the synthetic file payload to the document paste handler.
- Keep the durable API-backed assertion from the previous PR unchanged.

## Validation
- bun run --cwd packages/tests typecheck
- bun run --cwd packages/tests lint
- Chromium sanity check: synthetic paste clipboardData delivered
