### PR TITLE
Fix import upload CSP and polish settings keys

### DIFF
--- a/apps/docs/src/content/changelog/2026-07.mdx
+++ b/apps/docs/src/content/changelog/2026-07.mdx
@@ -7,6 +7,7 @@ date: "2026-07-06"
 - Web audio recording now works reliably in Chrome. Dragging, dropping, or pasting files now reports upload progress accurately, and saved link icons load more consistently.
 - Settings and sign-in screens now show stable loading states instead of partial rows or empty cards.
 - Imports now keep progress visible after you reopen Settings, wrap long error reports inside the dialog, and stop cleanly when your card limit is reached.
+- Import uploads now connect reliably to storage, and API key management in Settings uses a cleaner table layout.
 - The desktop app now uploads files reliably again.
 - The desktop app can now record audio notes. macOS will ask for microphone access the first time.
 - Import and Export now share one place in Settings, with a quick tab to switch between them. Imports show step-by-step progress and explain exactly which items were skipped or why any failed.

--- a/apps/web/src/__tests__/securityHeaders.test.ts
+++ b/apps/web/src/__tests__/securityHeaders.test.ts
@@ -13,6 +13,8 @@ const headers = new Map(
 );
 const teakR2StorageOrigin =
   "https://teak-files-prod.dd19e45b8f2f3cc0393cc2deb51fa27d.r2.cloudflarestorage.com";
+const teakR2UploadOrigin =
+  "https://dd19e45b8f2f3cc0393cc2deb51fa27d.r2.cloudflarestorage.com";
 const directiveTokens = (name: string) =>
   contentSecurityPolicy
     .split("; ")
@@ -33,9 +35,7 @@ describe("web security headers", () => {
     expect(directiveTokens("img-src")).not.toContain("https:");
     expect(directiveTokens("script-src")).toContain("'nonce-test-nonce'");
     expect(directiveTokens("connect-src")).toContain(teakR2StorageOrigin);
-    expect(directiveTokens("connect-src")).toContain(
-      "https://*.r2.cloudflarestorage.com"
-    );
+    expect(directiveTokens("connect-src")).toContain(teakR2UploadOrigin);
     expect(directiveTokens("media-src")).toContain(teakR2StorageOrigin);
     expect(directiveTokens("frame-src")).toContain(teakR2StorageOrigin);
     expect(directiveTokens("frame-src")).toContain(
@@ -46,6 +46,9 @@ describe("web security headers", () => {
       "https://*.r2.cloudflarestorage.com"
     );
     expect(directiveTokens("img-src")).not.toContain("https://*.r2.dev");
+    expect(directiveTokens("connect-src")).not.toContain(
+      "https://*.r2.cloudflarestorage.com"
+    );
     expect(directiveTokens("connect-src")).not.toContain("https://*.r2.dev");
     expect(directiveTokens("media-src")).not.toContain(
       "https://*.r2.cloudflarestorage.com"
@@ -83,6 +86,38 @@ describe("web security headers", () => {
         delete process.env.NEXT_PUBLIC_R2_PUBLIC_ORIGIN;
       } else {
         process.env.NEXT_PUBLIC_R2_PUBLIC_ORIGIN = previous;
+      }
+    }
+  });
+
+  test("allows configured R2 upload origins only for browser uploads", () => {
+    const previous = process.env.R2_ENDPOINT;
+    process.env.R2_ENDPOINT =
+      "https://uploads.teakvault.example/path, http://unsafe.example, not-a-url";
+    try {
+      const policy = buildContentSecurityPolicy(nonce);
+      const tokens = (name: string) =>
+        policy
+          .split("; ")
+          .find((directive) => directive.startsWith(`${name} `))
+          ?.split(" ")
+          .slice(1) ?? [];
+
+      expect(tokens("connect-src")).toContain(
+        "https://uploads.teakvault.example"
+      );
+      expect(tokens("connect-src")).not.toContain("http://unsafe.example");
+      expect(tokens("img-src")).not.toContain(
+        "https://uploads.teakvault.example"
+      );
+      expect(tokens("frame-src")).not.toContain(
+        "https://uploads.teakvault.example"
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.R2_ENDPOINT;
+      } else {
+        process.env.R2_ENDPOINT = previous;
       }
     }
   });

--- a/apps/web/src/__tests__/securityHeaders.test.ts
+++ b/apps/web/src/__tests__/securityHeaders.test.ts
@@ -33,6 +33,9 @@ describe("web security headers", () => {
     expect(directiveTokens("img-src")).not.toContain("https:");
     expect(directiveTokens("script-src")).toContain("'nonce-test-nonce'");
     expect(directiveTokens("connect-src")).toContain(teakR2StorageOrigin);
+    expect(directiveTokens("connect-src")).toContain(
+      "https://*.r2.cloudflarestorage.com"
+    );
     expect(directiveTokens("media-src")).toContain(teakR2StorageOrigin);
     expect(directiveTokens("frame-src")).toContain(teakR2StorageOrigin);
     expect(directiveTokens("frame-src")).toContain(
@@ -43,9 +46,6 @@ describe("web security headers", () => {
       "https://*.r2.cloudflarestorage.com"
     );
     expect(directiveTokens("img-src")).not.toContain("https://*.r2.dev");
-    expect(directiveTokens("connect-src")).not.toContain(
-      "https://*.r2.cloudflarestorage.com"
-    );
     expect(directiveTokens("connect-src")).not.toContain("https://*.r2.dev");
     expect(directiveTokens("media-src")).not.toContain(
       "https://*.r2.cloudflarestorage.com"

--- a/apps/web/src/lib/security-headers.ts
+++ b/apps/web/src/lib/security-headers.ts
@@ -6,6 +6,7 @@ const R2_FRAME_SOURCES = [
   "https://*.r2.cloudflarestorage.com",
   "https://*.r2.dev",
 ] as const;
+const R2_UPLOAD_SOURCES = ["https://*.r2.cloudflarestorage.com"] as const;
 
 const normalizeHttpsOrigin = (value: string): string | null => {
   try {
@@ -66,6 +67,7 @@ export const buildContentSecurityPolicy = (nonce: string) =>
       "https://polar.sh",
       "https://*.polar.sh",
       TEAK_R2_STORAGE_ORIGIN,
+      ...R2_UPLOAD_SOURCES,
     ].join(" "),
     ["media-src 'self' blob: data:", TEAK_R2_STORAGE_ORIGIN].join(" "),
     [

--- a/apps/web/src/lib/security-headers.ts
+++ b/apps/web/src/lib/security-headers.ts
@@ -2,11 +2,12 @@ export const CSP_NONCE_HEADER = "x-nonce";
 
 const TEAK_R2_STORAGE_ORIGIN =
   "https://teak-files-prod.dd19e45b8f2f3cc0393cc2deb51fa27d.r2.cloudflarestorage.com";
+const TEAK_R2_UPLOAD_ORIGIN =
+  "https://dd19e45b8f2f3cc0393cc2deb51fa27d.r2.cloudflarestorage.com";
 const R2_FRAME_SOURCES = [
   "https://*.r2.cloudflarestorage.com",
   "https://*.r2.dev",
 ] as const;
-const R2_UPLOAD_SOURCES = ["https://*.r2.cloudflarestorage.com"] as const;
 
 const normalizeHttpsOrigin = (value: string): string | null => {
   try {
@@ -26,6 +27,28 @@ const configuredR2FrameSources = () => {
     process.env.NEXT_PUBLIC_R2_PUBLIC_URL,
     process.env.R2_PUBLIC_ORIGIN,
     process.env.R2_PUBLIC_URL,
+  ];
+  return Array.from(
+    new Set(
+      values.flatMap(
+        (value) =>
+          value
+            ?.split(",")
+            .map((item) => normalizeHttpsOrigin(item.trim()))
+            .filter((item): item is string => Boolean(item)) ?? []
+      )
+    )
+  );
+};
+
+const configuredR2UploadSources = () => {
+  const values = [
+    TEAK_R2_UPLOAD_ORIGIN,
+    process.env.NEXT_PUBLIC_R2_UPLOAD_ORIGIN,
+    process.env.NEXT_PUBLIC_R2_UPLOAD_URL,
+    process.env.R2_UPLOAD_ORIGIN,
+    process.env.R2_UPLOAD_URL,
+    process.env.R2_ENDPOINT,
   ];
   return Array.from(
     new Set(
@@ -67,7 +90,7 @@ export const buildContentSecurityPolicy = (nonce: string) =>
       "https://polar.sh",
       "https://*.polar.sh",
       TEAK_R2_STORAGE_ORIGIN,
-      ...R2_UPLOAD_SOURCES,
+      ...configuredR2UploadSources(),
     ].join(" "),
     ["media-src 'self' blob: data:", TEAK_R2_STORAGE_ORIGIN].join(" "),
     [

--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -103,9 +103,21 @@ export const deleteAccountViaUi = async (page: Page, account: AccountState) => {
   if (account.deleted) {
     return;
   }
-  await signIn(page, account.email, passwordFor(account));
   await page.goto(appPath("/settings"));
-  await page.getByRole("button", { name: /delete your account/i }).click();
+  const deleteAccountButton = page.getByRole("button", {
+    name: /delete your account/i,
+  });
+  const canDelete = await deleteAccountButton
+    .waitFor({ state: "visible", timeout: 5000 })
+    .then(
+      () => true,
+      () => false
+    );
+  if (!canDelete) {
+    await signIn(page, account.email, passwordFor(account));
+  }
+  await page.goto(appPath("/settings"));
+  await deleteAccountButton.click();
   await expect(
     page.getByRole("dialog", { name: "Delete Account" })
   ).toBeVisible();
@@ -152,20 +164,22 @@ export const revokeVisibleKey = async (page: Page, rawKey: string) => {
     .getByRole("button", { name: "Manage" })
     .click();
   const dialog = page.getByRole("dialog", { name: "Manage API Keys" });
-  const row = dialog
-    .locator("div")
-    .filter({
-      has: page.getByRole("button", { name: "Revoke" }),
-      hasText: visiblePrefix,
-    })
-    .last();
+  const row = dialog.getByRole("row").filter({ hasText: visiblePrefix });
   await expect(row).toBeVisible();
   await row.getByRole("button", { name: "Revoke" }).click();
   await expect(
-    dialog
-      .locator("div")
-      .filter({ hasText: visiblePrefix })
-      .filter({ hasText: /revoked/i })
-      .last()
-  ).toBeVisible();
+    row,
+    "revoked API keys should disappear from the settings table"
+  ).toHaveCount(0);
+  await expect
+    .poll(
+      async () =>
+        (
+          await fetch(`${env.apiUrl}/v1/tags`, {
+            headers: { Authorization: `Bearer ${rawKey}` },
+          })
+        ).status,
+      { timeout: 30_000 }
+    )
+    .toBe(401);
 };

--- a/packages/ui/src/components/settings/ApiKeysDialog.tsx
+++ b/packages/ui/src/components/settings/ApiKeysDialog.tsx
@@ -1,17 +1,18 @@
-import { Copy, KeyRound, RotateCw, Trash2 } from "lucide-react";
+import { Copy, RotateCw, Trash2 } from "lucide-react";
 import { useRef, useState } from "react";
 import { toast } from "sonner";
-import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "../ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
 import { Input } from "../ui/input";
 import { Spinner } from "../ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../ui/table";
 
 export interface ApiKeyListItem {
   createdAt: number;
@@ -50,23 +51,11 @@ const formatDate = (value?: number) => {
   return apiKeyDateFormatter.format(new Date(value));
 };
 
-const getStatusVariant = (
-  status: ApiKeyListItem["status"]
-): "default" | "outline" | "secondary" | "destructive" =>
-  status === "active"
-    ? "outline"
-    : status === "disabled"
-      ? "secondary"
-      : "destructive";
-
 const formatStatus = (status: ApiKeyListItem["status"]) =>
   status
     .split("_")
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
-
-const formatKeyName = (name: string) =>
-  name === "API Keys" ? "Default API key" : name;
 
 export function ApiKeysDialog({
   isLoading,
@@ -120,7 +109,7 @@ export function ApiKeysDialog({
 
   const runKeyAction = async (
     keyId: string,
-    action: () => Promise<void | CreatedApiKey | null>,
+    action: () => Promise<CreatedApiKey | null | undefined>,
     successMessage: string
   ) => {
     setActionKey(keyId);
@@ -142,12 +131,8 @@ export function ApiKeysDialog({
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="max-h-[82vh] gap-3 overflow-y-auto p-4 sm:max-w-xl">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <DialogHeader className="gap-1">
+          <DialogHeader>
             <DialogTitle>Manage API Keys</DialogTitle>
-            <DialogDescription>
-              {keys?.length ? `${keys.length} keys` : "No keys yet"} for API,
-              MCP, and Raycast access.
-            </DialogDescription>
           </DialogHeader>
 
           <Button
@@ -156,7 +141,7 @@ export function ApiKeysDialog({
             onClick={handleCreate}
             size="sm"
           >
-            {isCreating ? <Spinner /> : <KeyRound />}
+            {isCreating ? <Spinner /> : null}
             Generate Key
           </Button>
         </div>
@@ -182,7 +167,7 @@ export function ApiKeysDialog({
             </div>
           )}
 
-          <div className="divide-y rounded-md border">
+          <div className="rounded-md border">
             {isLoading && (
               <div className="flex items-center justify-center p-6">
                 <Spinner />
@@ -195,73 +180,79 @@ export function ApiKeysDialog({
               </div>
             )}
 
-            {keys?.map((key) => {
-              const isBusy = actionKey === key.id;
-              const canRotate =
-                key.status === "active" || key.status === "disabled";
+            {keys && keys.length > 0 ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Key</TableHead>
+                    <TableHead>Last used</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {keys.map((key) => {
+                    const isBusy = actionKey === key.id;
+                    const canRotate =
+                      key.status === "active" || key.status === "disabled";
 
-              return (
-                <div
-                  className="flex flex-col gap-2 p-2.5 sm:flex-row sm:items-center sm:justify-between"
-                  key={key.id}
-                >
-                  <div className="min-w-0 space-y-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="font-medium text-sm">
-                        {formatKeyName(key.name)}
-                      </span>
-                      {key.status !== "active" && (
-                        <Badge variant={getStatusVariant(key.status)}>
+                    return (
+                      <TableRow key={key.id}>
+                        <TableCell className="break-all font-mono text-muted-foreground text-xs">
+                          {key.maskedKey}
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap text-muted-foreground">
+                          {formatDate(key.lastUsedAt)}
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap text-muted-foreground">
                           {formatStatus(key.status)}
-                        </Badge>
-                      )}
-                    </div>
-                    <div className="break-all font-mono text-muted-foreground text-xs">
-                      {key.maskedKey}
-                    </div>
-                    <div className="text-muted-foreground text-xs">
-                      Last used: {formatDate(key.lastUsedAt)}
-                    </div>
-                  </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex justify-end gap-1.5">
+                            {canRotate && (
+                              <Button
+                                disabled={isBusy}
+                                onClick={() =>
+                                  runKeyAction(
+                                    key.id,
+                                    () => onRotateKey(key.id),
+                                    "API key regenerated. Copy the new key now."
+                                  )
+                                }
+                                size="sm"
+                                variant="outline"
+                              >
+                                {isBusy ? <Spinner /> : <RotateCw />}
+                                Regenerate
+                              </Button>
+                            )}
 
-                  <div className="flex shrink-0 flex-wrap gap-1.5 sm:justify-end">
-                    {canRotate && (
-                      <Button
-                        disabled={isBusy}
-                        onClick={() =>
-                          runKeyAction(
-                            key.id,
-                            () => onRotateKey(key.id),
-                            "API key regenerated. Copy the new key now."
-                          )
-                        }
-                        size="sm"
-                        variant="outline"
-                      >
-                        {isBusy ? <Spinner /> : <RotateCw />}
-                        Regenerate
-                      </Button>
-                    )}
-
-                    <Button
-                      disabled={isBusy}
-                      onClick={() =>
-                        runKeyAction(
-                          key.id,
-                          () => onRevokeKey(key.id),
-                          "API key revoked."
-                        )
-                      }
-                      size="sm"
-                      variant="ghost"
-                    >
-                      {isBusy ? <Spinner /> : <Trash2 />}
-                      Revoke
-                    </Button>
-                  </div>
-                </div>
-              );
-            })}
+                            <Button
+                              disabled={isBusy}
+                              onClick={() =>
+                                runKeyAction(
+                                  key.id,
+                                  async () => {
+                                    await onRevokeKey(key.id);
+                                    return;
+                                  },
+                                  "API key revoked."
+                                )
+                              }
+                              size="sm"
+                              variant="ghost"
+                            >
+                              {isBusy ? <Spinner /> : <Trash2 />}
+                              Revoke
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            ) : null}
           </div>
         </div>
       </DialogContent>

--- a/packages/ui/src/components/settings/ApiKeysDialog.tsx
+++ b/packages/ui/src/components/settings/ApiKeysDialog.tsx
@@ -57,6 +57,18 @@ const formatStatus = (status: ApiKeyListItem["status"]) =>
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
 
+const visibleKeyName = (name: string) => {
+  const trimmed = name.trim();
+  if (
+    trimmed === "" ||
+    trimmed === "API Keys" ||
+    trimmed === "Default API key"
+  ) {
+    return null;
+  }
+  return trimmed;
+};
+
 export function ApiKeysDialog({
   isLoading,
   keys,
@@ -195,11 +207,19 @@ export function ApiKeysDialog({
                     const isBusy = actionKey === key.id;
                     const canRotate =
                       key.status === "active" || key.status === "disabled";
+                    const label = visibleKeyName(key.name);
 
                     return (
                       <TableRow key={key.id}>
-                        <TableCell className="break-all font-mono text-muted-foreground text-xs">
-                          {key.maskedKey}
+                        <TableCell>
+                          {label ? (
+                            <div className="font-medium text-foreground text-sm">
+                              {label}
+                            </div>
+                          ) : null}
+                          <div className="break-all font-mono text-muted-foreground text-xs">
+                            {key.maskedKey}
+                          </div>
                         </TableCell>
                         <TableCell className="whitespace-nowrap text-muted-foreground">
                           {formatDate(key.lastUsedAt)}

--- a/packages/ui/src/components/settings/ApiKeysDialog.tsx
+++ b/packages/ui/src/components/settings/ApiKeysDialog.tsx
@@ -197,6 +197,7 @@ export function ApiKeysDialog({
                 <TableHeader>
                   <TableRow>
                     <TableHead>Key</TableHead>
+                    <TableHead>Created</TableHead>
                     <TableHead>Last used</TableHead>
                     <TableHead>Status</TableHead>
                     <TableHead className="text-right">Actions</TableHead>
@@ -220,6 +221,9 @@ export function ApiKeysDialog({
                           <div className="break-all font-mono text-muted-foreground text-xs">
                             {key.maskedKey}
                           </div>
+                        </TableCell>
+                        <TableCell className="whitespace-nowrap text-muted-foreground">
+                          {formatDate(key.createdAt)}
                         </TableCell>
                         <TableCell className="whitespace-nowrap text-muted-foreground">
                           {formatDate(key.lastUsedAt)}

--- a/packages/ui/src/components/settings/ApiKeysSection.tsx
+++ b/packages/ui/src/components/settings/ApiKeysSection.tsx
@@ -1,10 +1,9 @@
 import { useState } from "react";
-import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Spinner } from "../ui/spinner";
 import {
-  ApiKeysDialog,
   type ApiKeyListItem,
+  ApiKeysDialog,
   type CreatedApiKey,
 } from "./ApiKeysDialog";
 import { SettingRow } from "./SettingRow";
@@ -34,14 +33,9 @@ export function ApiKeysSection({
             <Spinner />
           </Button>
         ) : (
-          <>
-            <Badge variant={keys?.length ? "outline" : "secondary"}>
-              {keys?.length ? `${keys.length} keys` : "No keys"}
-            </Badge>
-            <Button onClick={() => setOpen(true)} size="sm" variant="link">
-              Manage
-            </Button>
-          </>
+          <Button onClick={() => setOpen(true)} size="sm" variant="link">
+            Manage
+          </Button>
         )}
       </SettingRow>
 

--- a/packages/ui/src/components/settings/ImportExportSection.tsx
+++ b/packages/ui/src/components/settings/ImportExportSection.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { type ReactNode, useState } from "react";
-import { Badge } from "../ui/badge";
+import { useState } from "react";
 import { Button } from "../ui/button";
 import type { ExportState } from "./ExportPanel";
 import { ImportExportDialog } from "./ImportExportDialog";
@@ -23,25 +22,11 @@ export function ImportExportSection({
   onStartExport,
 }: ImportExportSectionProps) {
   const [open, setOpen] = useState(false);
-  const [importActive, setImportActive] = useState(false);
-
-  const job = exportState?.job ?? null;
-  const exportActive = job?.status === "pending" || job?.status === "running";
-  const canDownload = Boolean(job?.downloadAvailable);
-
-  let badge: ReactNode = null;
-  if (importActive) {
-    badge = <Badge variant="secondary">Importing</Badge>;
-  } else if (exportActive) {
-    badge = <Badge variant="secondary">Preparing</Badge>;
-  } else if (!exportLoading && canDownload) {
-    badge = <Badge variant="outline">Export ready</Badge>;
-  }
+  const [, setImportActive] = useState(false);
 
   return (
     <>
       <SettingRow title="Import/Export Data">
-        {badge}
         <Button onClick={() => setOpen(true)} size="sm" variant="link">
           Manage
         </Button>

--- a/packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx
+++ b/packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx
@@ -16,6 +16,7 @@ mock.module("../../ui/button", () => ({
         onClick,
         "data-size": size,
         "data-variant": variant,
+        type: "button",
       },
       children
     ),
@@ -89,7 +90,8 @@ describe("ApiKeysSection", () => {
     expect(markup).toContain("API Keys");
     expect(markup).toContain(">Manage</button>");
     expect(markup).not.toContain("Manage API Keys");
-    expect(markup).toContain("2 keys");
+    expect(markup).not.toContain("2 keys");
+    expect(markup).not.toContain("No keys");
     expect(markup).not.toContain("Update required");
     expect(markup).not.toContain("Generate Key");
   });
@@ -123,17 +125,23 @@ describe("ApiKeysDialog", () => {
 
     expect(markup).toContain("Manage API Keys");
     expect(markup).toContain("Generate Key");
-    expect(markup).toContain("SDK Key");
+    expect(markup).toContain("<th");
+    expect(markup).toContain("Key");
+    expect(markup).toContain("Last used");
+    expect(markup).toContain("Status");
+    expect(markup).toContain("teakapi_secret_live_a1b2c3d4");
     expect(markup).toContain("Regenerate");
     expect(markup).not.toContain(">Disable<");
-    expect(markup).toContain("Disabled Key");
+    expect(markup).not.toContain("SDK Key");
+    expect(markup).not.toContain("Disabled Key");
+    expect(markup).toContain("Disabled");
     expect(markup).not.toContain(">Enable<");
     expect(markup).not.toContain("Update required");
-    expect(markup).not.toContain(">Active</span>");
-    expect(markup).not.toContain(">active<");
+    expect(markup).toContain("Active");
+    expect(markup).not.toContain("for API, MCP, and Raycast access");
   });
 
-  test("renames the old default key label in the modal", () => {
+  test("does not render repeated default key names in the modal", () => {
     const markup = renderToStaticMarkup(
       <ApiKeysDialog
         isLoading={false}
@@ -149,11 +157,11 @@ describe("ApiKeysDialog", () => {
       />
     );
 
-    expect(markup).toContain("Default API key");
-    expect(markup).not.toContain(">API Keys</span>");
+    expect(markup).not.toContain("Default API key");
+    expect(markup).not.toContain(">API Keys<");
   });
 
-  test("renders terminal key statuses as destructive badges", () => {
+  test("renders terminal key statuses as table text", () => {
     const markup = renderToStaticMarkup(
       <ApiKeysDialog
         isLoading={false}
@@ -171,7 +179,7 @@ describe("ApiKeysDialog", () => {
       />
     );
 
-    expect(markup).toContain('data-variant="destructive"');
-    expect(markup).toContain(">Exhausted</span>");
+    expect(markup).not.toContain('data-variant="destructive"');
+    expect(markup).toContain("Exhausted");
   });
 });

--- a/packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx
+++ b/packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx
@@ -129,11 +129,11 @@ describe("ApiKeysDialog", () => {
     expect(markup).toContain("Key");
     expect(markup).toContain("Last used");
     expect(markup).toContain("Status");
+    expect(markup).toContain("SDK Key");
     expect(markup).toContain("teakapi_secret_live_a1b2c3d4");
     expect(markup).toContain("Regenerate");
     expect(markup).not.toContain(">Disable<");
-    expect(markup).not.toContain("SDK Key");
-    expect(markup).not.toContain("Disabled Key");
+    expect(markup).toContain("Disabled Key");
     expect(markup).toContain("Disabled");
     expect(markup).not.toContain(">Enable<");
     expect(markup).not.toContain("Update required");

--- a/packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx
+++ b/packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx
@@ -127,6 +127,7 @@ describe("ApiKeysDialog", () => {
     expect(markup).toContain("Generate Key");
     expect(markup).toContain("<th");
     expect(markup).toContain("Key");
+    expect(markup).toContain("Created");
     expect(markup).toContain("Last used");
     expect(markup).toContain("Status");
     expect(markup).toContain("SDK Key");
@@ -159,6 +160,7 @@ describe("ApiKeysDialog", () => {
 
     expect(markup).not.toContain("Default API key");
     expect(markup).not.toContain(">API Keys<");
+    expect(markup).toContain("Created");
   });
 
   test("renders terminal key statuses as table text", () => {

--- a/packages/ui/src/components/settings/__tests__/ImportExportSection.contract.test.tsx
+++ b/packages/ui/src/components/settings/__tests__/ImportExportSection.contract.test.tsx
@@ -44,7 +44,7 @@ describe("ImportExportSection", () => {
     expect(markup).not.toContain("Start export");
   });
 
-  test("shows a Preparing badge while an export is active", () => {
+  test("keeps the settings row badge-free while an export is active", () => {
     const markup = renderToStaticMarkup(
       <ImportExportSection
         exportLoading={false}
@@ -62,10 +62,11 @@ describe("ImportExportSection", () => {
         {...noopHandlers}
       />
     );
-    expect(markup).toContain("Preparing");
+    expect(markup).not.toContain("Preparing");
+    expect(markup).toContain(">Manage</button>");
   });
 
-  test("shows an Export ready badge when an artifact is downloadable", () => {
+  test("keeps the settings row badge-free when an artifact is downloadable", () => {
     const markup = renderToStaticMarkup(
       <ImportExportSection
         exportLoading={false}
@@ -83,6 +84,7 @@ describe("ImportExportSection", () => {
         {...noopHandlers}
       />
     );
-    expect(markup).toContain("Export ready");
+    expect(markup).not.toContain("Export ready");
+    expect(markup).toContain(">Manage</button>");
   });
 });


### PR DESCRIPTION
## Summary
- Allow direct R2 upload hosts in the web CSP so import and paste-backed uploads can reach storage.
- Simplify the API keys modal header, remove the Generate Key icon, and render keys in a compact table.
- Remove API key and import/export badges from the Settings page rows.
- Make production E2E cleanup/revoke helpers resilient to the table layout and already-signed-in tenant cleanup.

## Validation
- bun test apps/web/src/__tests__/securityHeaders.test.ts packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx packages/ui/src/components/settings/__tests__/ImportExportSection.contract.test.tsx
- bunx biome check apps/web/src/lib/security-headers.ts apps/web/src/__tests__/securityHeaders.test.ts packages/ui/src/components/settings/ApiKeysDialog.tsx packages/ui/src/components/settings/ApiKeysSection.tsx packages/ui/src/components/settings/ImportExportSection.tsx packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx packages/ui/src/components/settings/__tests__/ImportExportSection.contract.test.tsx packages/tests/src/helpers/prod.ts
- bun run --cwd packages/ui typecheck && bun run --cwd packages/tests typecheck && bun run --cwd apps/web typecheck
- bun run --cwd packages/tests lint && bun run --cwd apps/web lint
- bun run --cwd apps/docs typecheck && bun run --cwd apps/docs lint
- git commit pre-commit affected suite: turbo run typecheck lint build --affected
