### PR TITLE
Polish API key table layout

### DIFF
--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -166,7 +166,7 @@ export const revokeVisibleKey = async (page: Page, rawKey: string) => {
   const dialog = page.getByRole("dialog", { name: "Manage API Keys" });
   const row = dialog.getByRole("row").filter({ hasText: visiblePrefix });
   await expect(row).toBeVisible();
-  await row.getByRole("button", { name: "Revoke" }).click();
+  await row.getByRole("button", { name: /^Revoke key created / }).click();
   await expect(
     row,
     "revoked API keys should disappear from the settings table"

--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -166,7 +166,7 @@ export const revokeVisibleKey = async (page: Page, rawKey: string) => {
   const dialog = page.getByRole("dialog", { name: "Manage API Keys" });
   const row = dialog.getByRole("row").filter({ hasText: visiblePrefix });
   await expect(row).toBeVisible();
-  await row.getByRole("button", { name: /^Revoke key created / }).click();
+  await row.getByRole("button", { name: /^Revoke / }).click();
   await expect(
     row,
     "revoked API keys should disappear from the settings table"

--- a/packages/ui/src/components/settings/ApiKeysDialog.tsx
+++ b/packages/ui/src/components/settings/ApiKeysDialog.tsx
@@ -193,14 +193,13 @@ export function ApiKeysDialog({
             )}
 
             {keys && keys.length > 0 ? (
-              <Table>
+              <Table className="table-fixed">
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Key</TableHead>
-                    <TableHead>Created</TableHead>
-                    <TableHead>Last used</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead className="text-right">Actions</TableHead>
+                    <TableHead className="w-[48%]">Key</TableHead>
+                    <TableHead className="w-[22%]">Used</TableHead>
+                    <TableHead className="w-[14%]">Status</TableHead>
+                    <TableHead className="w-[16%]" />
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -212,18 +211,21 @@ export function ApiKeysDialog({
 
                     return (
                       <TableRow key={key.id}>
-                        <TableCell>
+                        <TableCell className="max-w-0">
                           {label ? (
-                            <div className="font-medium text-foreground text-sm">
+                            <div className="truncate font-medium text-foreground text-sm">
                               {label}
                             </div>
                           ) : null}
-                          <div className="break-all font-mono text-muted-foreground text-xs">
+                          <div
+                            className="truncate font-mono text-muted-foreground text-xs"
+                            title={key.maskedKey}
+                          >
                             {key.maskedKey}
                           </div>
-                        </TableCell>
-                        <TableCell className="whitespace-nowrap text-muted-foreground">
-                          {formatDate(key.createdAt)}
+                          <div className="truncate text-muted-foreground text-xs">
+                            Created {formatDate(key.createdAt)}
+                          </div>
                         </TableCell>
                         <TableCell className="whitespace-nowrap text-muted-foreground">
                           {formatDate(key.lastUsedAt)}
@@ -235,6 +237,7 @@ export function ApiKeysDialog({
                           <div className="flex justify-end gap-1.5">
                             {canRotate && (
                               <Button
+                                aria-label={`Regenerate key created ${formatDate(key.createdAt)}`}
                                 disabled={isBusy}
                                 onClick={() =>
                                   runKeyAction(
@@ -243,15 +246,16 @@ export function ApiKeysDialog({
                                     "API key regenerated. Copy the new key now."
                                   )
                                 }
-                                size="sm"
+                                size="icon"
+                                title="Regenerate"
                                 variant="outline"
                               >
                                 {isBusy ? <Spinner /> : <RotateCw />}
-                                Regenerate
                               </Button>
                             )}
 
                             <Button
+                              aria-label={`Revoke key created ${formatDate(key.createdAt)}`}
                               disabled={isBusy}
                               onClick={() =>
                                 runKeyAction(
@@ -263,11 +267,11 @@ export function ApiKeysDialog({
                                   "API key revoked."
                                 )
                               }
-                              size="sm"
+                              size="icon"
+                              title="Revoke"
                               variant="ghost"
                             >
                               {isBusy ? <Spinner /> : <Trash2 />}
-                              Revoke
                             </Button>
                           </div>
                         </TableCell>

--- a/packages/ui/src/components/settings/ApiKeysDialog.tsx
+++ b/packages/ui/src/components/settings/ApiKeysDialog.tsx
@@ -208,6 +208,13 @@ export function ApiKeysDialog({
                     const canRotate =
                       key.status === "active" || key.status === "disabled";
                     const label = visibleKeyName(key.name);
+                    const keyIdentity = [
+                      label,
+                      key.maskedKey,
+                      `created ${formatDate(key.createdAt)}`,
+                    ]
+                      .filter(Boolean)
+                      .join(", ");
 
                     return (
                       <TableRow key={key.id}>
@@ -217,10 +224,7 @@ export function ApiKeysDialog({
                               {label}
                             </div>
                           ) : null}
-                          <div
-                            className="truncate font-mono text-muted-foreground text-xs"
-                            title={key.maskedKey}
-                          >
+                          <div className="break-all font-mono text-muted-foreground text-xs">
                             {key.maskedKey}
                           </div>
                           <div className="truncate text-muted-foreground text-xs">
@@ -237,7 +241,7 @@ export function ApiKeysDialog({
                           <div className="flex justify-end gap-1.5">
                             {canRotate && (
                               <Button
-                                aria-label={`Regenerate key created ${formatDate(key.createdAt)}`}
+                                aria-label={`Regenerate ${keyIdentity}`}
                                 disabled={isBusy}
                                 onClick={() =>
                                   runKeyAction(
@@ -255,7 +259,7 @@ export function ApiKeysDialog({
                             )}
 
                             <Button
-                              aria-label={`Revoke key created ${formatDate(key.createdAt)}`}
+                              aria-label={`Revoke ${keyIdentity}`}
                               disabled={isBusy}
                               onClick={() =>
                                 runKeyAction(

--- a/packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx
+++ b/packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx
@@ -133,7 +133,7 @@ describe("ApiKeysDialog", () => {
     expect(markup).toContain("Status");
     expect(markup).toContain("SDK Key");
     expect(markup).toContain("teakapi_secret_live_a1b2c3d4");
-    expect(markup).toContain("Regenerate key created");
+    expect(markup).toContain("Regenerate SDK Key");
     expect(markup).not.toContain(">Disable<");
     expect(markup).toContain("Disabled Key");
     expect(markup).toContain("Disabled");

--- a/packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx
+++ b/packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx
@@ -8,7 +8,7 @@ mock.module("../../ui/badge", () => ({
 }));
 
 mock.module("../../ui/button", () => ({
-  Button: ({ children, disabled, onClick, size, variant }: any) =>
+  Button: ({ children, disabled, onClick, size, variant, ...props }: any) =>
     React.createElement(
       "button",
       {
@@ -17,6 +17,7 @@ mock.module("../../ui/button", () => ({
         "data-size": size,
         "data-variant": variant,
         type: "button",
+        ...props,
       },
       children
     ),
@@ -127,12 +128,12 @@ describe("ApiKeysDialog", () => {
     expect(markup).toContain("Generate Key");
     expect(markup).toContain("<th");
     expect(markup).toContain("Key");
+    expect(markup).toContain("Used");
     expect(markup).toContain("Created");
-    expect(markup).toContain("Last used");
     expect(markup).toContain("Status");
     expect(markup).toContain("SDK Key");
     expect(markup).toContain("teakapi_secret_live_a1b2c3d4");
-    expect(markup).toContain("Regenerate");
+    expect(markup).toContain("Regenerate key created");
     expect(markup).not.toContain(">Disable<");
     expect(markup).toContain("Disabled Key");
     expect(markup).toContain("Disabled");
@@ -161,6 +162,7 @@ describe("ApiKeysDialog", () => {
     expect(markup).not.toContain("Default API key");
     expect(markup).not.toContain(">API Keys<");
     expect(markup).toContain("Created");
+    expect(markup).not.toContain("Last used");
   });
 
   test("renders terminal key statuses as table text", () => {


### PR DESCRIPTION
## Summary
- keep API key management minimal by folding the created-time cue into the key cell
- make row actions icon-only with accessible labels
- update production E2E helper selectors for the compact actions

## Validation
- bun test packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx
- bunx biome check packages/ui/src/components/settings/ApiKeysDialog.tsx packages/ui/src/components/settings/__tests__/ApiKeysSection.contract.test.tsx packages/tests/src/helpers/prod.ts
- bun run --cwd packages/ui typecheck
- bun run --cwd packages/tests typecheck
- bun run --cwd packages/tests lint
- pre-commit affected turbo run: typecheck, lint, build