### PR TITLE
Retry transient storage upload failures

### DIFF
--- a/apps/docs/src/content/changelog/2026-07.mdx
+++ b/apps/docs/src/content/changelog/2026-07.mdx
@@ -5,6 +5,7 @@ date: "2026-07-06"
 
 - PDF documents now open and preview correctly when you view them in Teak.
 - Web audio recording now works reliably in Chrome. Dragging, dropping, or pasting files now reports upload progress accurately, and saved link icons load more consistently.
+- File uploads now retry brief storage outages, so a first drag or paste is less likely to fail when storage returns a temporary error.
 - Settings and sign-in screens now show stable loading states instead of partial rows or empty cards.
 - Imports now keep progress visible after you reopen Settings, wrap long error reports inside the dialog, and stop cleanly when your card limit is reached.
 - Import uploads now connect reliably to storage, and API key management in Settings uses a cleaner table layout.

--- a/apps/mobile/lib/hooks/useFileUpload.ts
+++ b/apps/mobile/lib/hooks/useFileUpload.ts
@@ -8,6 +8,12 @@ import {
 import { useMutation } from "convex/react";
 import * as FileSystem from "expo-file-system/legacy";
 
+const createUploadAbortError = () => {
+  const error = new Error("Upload cancelled");
+  error.name = "AbortError";
+  return error;
+};
+
 export function useFileUpload(config: UnifiedFileUploadConfig = {}) {
   const uploadAndCreateCardMutation = useMutation(
     api.cards.uploadAndCreateCard
@@ -26,16 +32,49 @@ export function useFileUpload(config: UnifiedFileUploadConfig = {}) {
     {
       uploadAndCreateCard,
       finalizeUploadedCard,
-      uploadBinaryFromUri: async ({ fileUri, uploadUrl, contentType }) => {
-        const result = await FileSystem.uploadAsync(uploadUrl, fileUri, {
+      uploadBinaryFromUri: async ({
+        fileUri,
+        uploadUrl,
+        contentType,
+        signal,
+      }) => {
+        const uploadTask = FileSystem.createUploadTask(uploadUrl, fileUri, {
           headers: { "Content-Type": contentType },
           httpMethod: "PUT",
           uploadType: FileSystem.FileSystemUploadType.BINARY_CONTENT,
         });
+        const cancelUpload = () => {
+          void uploadTask.cancelAsync().catch(() => {
+            // The shared hook suppresses callbacks once the signal is aborted.
+          });
+        };
+
+        if (signal.aborted) {
+          await uploadTask.cancelAsync();
+          throw createUploadAbortError();
+        }
+
+        signal.addEventListener("abort", cancelUpload, { once: true });
+
+        let result: FileSystem.FileSystemUploadResult | null | undefined;
+        try {
+          result = await uploadTask.uploadAsync();
+        } catch (error) {
+          if (signal.aborted) {
+            throw createUploadAbortError();
+          }
+          throw error;
+        } finally {
+          signal.removeEventListener("abort", cancelUpload);
+        }
+
+        if (signal.aborted) {
+          throw createUploadAbortError();
+        }
 
         return {
-          ok: result.status >= 200 && result.status < 300,
-          status: result.status,
+          ok: result ? result.status >= 200 && result.status < 300 : false,
+          status: result?.status ?? 0,
         };
       },
     },

--- a/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
+++ b/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
@@ -354,6 +354,7 @@ describe("useFileUploadCore", () => {
         fileUri: "file:///tmp/photo.jpg",
         uploadUrl: "https://upload",
         contentType: "image/jpeg",
+        signal: expect.any(Object),
       });
       expect(mockFinalizeUploadedCard).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -505,6 +506,48 @@ describe("useFileUploadCore", () => {
 
       expect(result.success).toBe(true);
       expect(mockUploadBinaryFromUri).toHaveBeenCalledTimes(2);
+    });
+
+    test("does not finalize URI uploads after abort", async () => {
+      const uriHook = useFileUploadCore(
+        {
+          ...dependencies,
+          uploadBinaryFromUri: mockUploadBinaryFromUri,
+        },
+        config
+      );
+      let resolveUpload: (response: { ok: boolean; status: number }) => void;
+
+      mockUploadAndCreateCard.mockResolvedValue({
+        success: true,
+        uploadUrl: "https://upload",
+        uploadKey: "store_1",
+      });
+      mockUploadBinaryFromUri.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveUpload = resolve;
+          })
+      );
+
+      const resultPromise = uriHook.uploadFileFromUri({
+        uri: "file:///tmp/photo.jpg",
+        name: "photo.jpg",
+        type: "image/jpeg",
+        size: 100,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      mockUseEffectCleanups.at(-1)?.();
+      resolveUpload!({ ok: true, status: 200 });
+
+      const result = await resultPromise;
+
+      expect(result.success).toBe(false);
+      expect((result as any).error).toBe("Upload cancelled");
+      expect(mockFinalizeUploadedCard).not.toHaveBeenCalled();
+      expect(mockOnSuccess).not.toHaveBeenCalled();
+      expect(mockOnError).not.toHaveBeenCalled();
+      expect(mockSentryCapture).not.toHaveBeenCalled();
     });
 
     test("handles finalize failure", async () => {

--- a/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
+++ b/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
@@ -460,6 +460,28 @@ describe("useFileUploadCore", () => {
       expect(mockSentryCapture).not.toHaveBeenCalled();
     });
 
+    test("treats non-Error AbortError fetch rejections as cancellations", async () => {
+      const file = { size: 100, name: "test.png", type: "image/png" } as any;
+      mockUploadAndCreateCard.mockResolvedValue({
+        success: true,
+        uploadUrl: "https://upload",
+        uploadKey: "store_1",
+      });
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 503 })
+        .mockResolvedValueOnce({ ok: false, status: 503 })
+        .mockRejectedValueOnce({ name: "AbortError" });
+
+      const result = await hook.uploadFile(file);
+
+      expect(result.success).toBe(false);
+      expect((result as any).error).toBe("Upload cancelled");
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(mockFinalizeUploadedCard).not.toHaveBeenCalled();
+      expect(mockOnError).not.toHaveBeenCalled();
+      expect(mockSentryCapture).not.toHaveBeenCalled();
+    });
+
     test("does not retry non-transient storage failures", async () => {
       const file = { size: 100, name: "test.png", type: "image/png" } as any;
       mockUploadAndCreateCard.mockResolvedValue({

--- a/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
+++ b/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
@@ -11,9 +11,17 @@ import {
 
 // Mock React
 const mockSetState = mock();
+const mockUseEffectCleanups: Array<() => void> = [];
 mock.module("react", () => ({
   useState: (init: any) => [init, mockSetState],
   useCallback: (fn: any) => fn,
+  useEffect: (fn: any) => {
+    const cleanup = fn();
+    if (typeof cleanup === "function") {
+      mockUseEffectCleanups.push(cleanup);
+    }
+  },
+  useRef: (init: any) => ({ current: init }),
 }));
 
 // Mock fetch
@@ -123,6 +131,7 @@ describe("useFileUploadCore", () => {
     mockSetState.mockReset();
     mockFetch.mockReset();
     mockSentryCapture.mockReset();
+    mockUseEffectCleanups.length = 0;
     setFileUploadSentryCaptureFunction(mockSentryCapture);
   });
 
@@ -420,6 +429,33 @@ describe("useFileUploadCore", () => {
       expect(mockFinalizeUploadedCard).toHaveBeenCalledWith(
         expect.objectContaining({ fileKey: "store_1" })
       );
+      expect(mockSentryCapture).not.toHaveBeenCalled();
+    });
+
+    test("cancels sleeping retries after unmount", async () => {
+      const file = { size: 100, name: "test.png", type: "image/png" } as any;
+      const localHook = useFileUploadCore(dependencies, config);
+
+      mockUploadAndCreateCard.mockResolvedValue({
+        success: true,
+        uploadUrl: "https://upload",
+        uploadKey: "store_1",
+      });
+      mockFetch.mockResolvedValue({ ok: false, status: 503 });
+
+      const resultPromise = localHook.uploadFile(file);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      mockUseEffectCleanups.at(-1)?.();
+      const result = await resultPromise;
+
+      expect(result.success).toBe(false);
+      expect((result as any).error).toBe("Upload cancelled");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFinalizeUploadedCard).not.toHaveBeenCalled();
+      expect(mockOnSuccess).not.toHaveBeenCalled();
+      expect(mockOnError).not.toHaveBeenCalled();
       expect(mockSentryCapture).not.toHaveBeenCalled();
     });
 

--- a/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
+++ b/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
@@ -484,6 +484,43 @@ describe("useFileUploadCore", () => {
       expect(mockSentryCapture).not.toHaveBeenCalled();
     });
 
+    test("does not finish browser uploads after finalize is aborted", async () => {
+      const file = { size: 100, name: "test.png", type: "image/png" } as any;
+      const localHook = useFileUploadCore(dependencies, config);
+      let resolveFinalize: (result: {
+        cardId: string;
+        success: boolean;
+      }) => void;
+
+      mockUploadAndCreateCard.mockResolvedValue({
+        success: true,
+        uploadUrl: "https://upload",
+        uploadKey: "store_1",
+      });
+      mockFetch.mockResolvedValue({ ok: true, status: 200 });
+      mockFinalizeUploadedCard.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveFinalize = resolve;
+          })
+      );
+
+      const resultPromise = localHook.uploadFile(file);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(mockFinalizeUploadedCard).toHaveBeenCalled();
+
+      mockUseEffectCleanups.at(-1)?.();
+      resolveFinalize!({ success: true, cardId: "card_1" });
+      const result = await resultPromise;
+
+      expect(result.success).toBe(false);
+      expect((result as any).error).toBe("Upload cancelled");
+      expect(mockOnSuccess).not.toHaveBeenCalled();
+      expect(mockOnError).not.toHaveBeenCalled();
+      expect(mockSentryCapture).not.toHaveBeenCalled();
+      expect(mockOnProgress).not.toHaveBeenCalledWith(100);
+    });
+
     test("does not retry non-transient storage failures", async () => {
       const file = { size: 100, name: "test.png", type: "image/png" } as any;
       mockUploadAndCreateCard.mockResolvedValue({
@@ -572,6 +609,53 @@ describe("useFileUploadCore", () => {
       expect(mockOnSuccess).not.toHaveBeenCalled();
       expect(mockOnError).not.toHaveBeenCalled();
       expect(mockSentryCapture).not.toHaveBeenCalled();
+    });
+
+    test("does not finish URI uploads after finalize is aborted", async () => {
+      const uriHook = useFileUploadCore(
+        {
+          ...dependencies,
+          uploadBinaryFromUri: mockUploadBinaryFromUri,
+        },
+        config
+      );
+      let resolveFinalize: (result: {
+        cardId: string;
+        success: boolean;
+      }) => void;
+
+      mockUploadAndCreateCard.mockResolvedValue({
+        success: true,
+        uploadUrl: "https://upload",
+        uploadKey: "store_1",
+      });
+      mockUploadBinaryFromUri.mockResolvedValue({ ok: true, status: 200 });
+      mockFinalizeUploadedCard.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveFinalize = resolve;
+          })
+      );
+
+      const resultPromise = uriHook.uploadFileFromUri({
+        uri: "file:///tmp/photo.jpg",
+        name: "photo.jpg",
+        type: "image/jpeg",
+        size: 100,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(mockFinalizeUploadedCard).toHaveBeenCalled();
+
+      mockUseEffectCleanups.at(-1)?.();
+      resolveFinalize!({ success: true, cardId: "card_1" });
+      const result = await resultPromise;
+
+      expect(result.success).toBe(false);
+      expect((result as any).error).toBe("Upload cancelled");
+      expect(mockOnSuccess).not.toHaveBeenCalled();
+      expect(mockOnError).not.toHaveBeenCalled();
+      expect(mockSentryCapture).not.toHaveBeenCalled();
+      expect(mockOnProgress).not.toHaveBeenCalledWith(100);
     });
 
     test("handles finalize failure", async () => {

--- a/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
+++ b/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
@@ -458,6 +458,8 @@ describe("useFileUploadCore", () => {
       expect(mockOnSuccess).not.toHaveBeenCalled();
       expect(mockOnError).not.toHaveBeenCalled();
       expect(mockSentryCapture).not.toHaveBeenCalled();
+      expect(mockSetState).toHaveBeenCalledWith(false);
+      expect(mockSetState).toHaveBeenCalledWith(0);
     });
 
     test("treats non-Error AbortError fetch rejections as cancellations", async () => {

--- a/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
+++ b/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
@@ -395,6 +395,80 @@ describe("useFileUploadCore", () => {
       const result = await hook.uploadFile(file);
       expect(result.success).toBe(false);
       expect((result as any).error).toContain("Upload failed with status 500");
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    test("retries transient storage failures before finalizing the card", async () => {
+      const file = { size: 100, name: "test.png", type: "image/png" } as any;
+      mockUploadAndCreateCard.mockResolvedValue({
+        success: true,
+        uploadUrl: "https://upload",
+        uploadKey: "store_1",
+      });
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 503 })
+        .mockResolvedValueOnce({ ok: true, status: 200 });
+      mockFinalizeUploadedCard.mockResolvedValue({
+        success: true,
+        cardId: "card_1",
+      });
+
+      const result = await hook.uploadFile(file);
+
+      expect(result.success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFinalizeUploadedCard).toHaveBeenCalledWith(
+        expect.objectContaining({ fileKey: "store_1" })
+      );
+      expect(mockSentryCapture).not.toHaveBeenCalled();
+    });
+
+    test("does not retry non-transient storage failures", async () => {
+      const file = { size: 100, name: "test.png", type: "image/png" } as any;
+      mockUploadAndCreateCard.mockResolvedValue({
+        success: true,
+        uploadUrl: "https://upload",
+        uploadKey: "store_1",
+      });
+      mockFetch.mockResolvedValue({ ok: false, status: 403 });
+
+      const result = await hook.uploadFile(file);
+
+      expect(result.success).toBe(false);
+      expect((result as any).error).toContain("Upload failed with status 403");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test("retries transient URI upload failures", async () => {
+      const uriHook = useFileUploadCore(
+        {
+          ...dependencies,
+          uploadBinaryFromUri: mockUploadBinaryFromUri,
+        },
+        config
+      );
+      mockUploadAndCreateCard.mockResolvedValue({
+        success: true,
+        uploadUrl: "https://upload",
+        uploadKey: "store_1",
+      });
+      mockUploadBinaryFromUri
+        .mockResolvedValueOnce({ ok: false, status: 503 })
+        .mockResolvedValueOnce({ ok: true, status: 200 });
+      mockFinalizeUploadedCard.mockResolvedValue({
+        success: true,
+        cardId: "card_1",
+      });
+
+      const result = await uriHook.uploadFileFromUri({
+        uri: "file:///tmp/photo.jpg",
+        name: "photo.jpg",
+        type: "image/jpeg",
+        size: 100,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockUploadBinaryFromUri).toHaveBeenCalledTimes(2);
     });
 
     test("handles finalize failure", async () => {

--- a/packages/convex/client/hooks/useFileUpload.client.tsx
+++ b/packages/convex/client/hooks/useFileUpload.client.tsx
@@ -299,15 +299,18 @@ export function useFileUploadCore(
   }, []);
 
   const finishUpload = useCallback((abortController: AbortController) => {
-    if (activeUploadAbortRef.current === abortController) {
-      activeUploadAbortRef.current = null;
-    }
-
-    if (abortController.signal.aborted) {
+    if (activeUploadAbortRef.current !== abortController) {
       return;
     }
 
+    activeUploadAbortRef.current = null;
     setIsUploading(false);
+
+    if (abortController.signal.aborted) {
+      setProgress(0);
+      return;
+    }
+
     resetProgressTimeoutRef.current = setTimeout(() => {
       setProgress(0);
       resetProgressTimeoutRef.current = null;

--- a/packages/convex/client/hooks/useFileUpload.client.tsx
+++ b/packages/convex/client/hooks/useFileUpload.client.tsx
@@ -164,6 +164,7 @@ export interface FileUploadDependencies {
   uploadBinaryFromUri?: (args: {
     contentType: string;
     fileUri: string;
+    signal: AbortSignal;
     uploadUrl: string;
   }) => Promise<{ ok: boolean; status: number }>;
 }
@@ -229,6 +230,9 @@ async function uploadWithTransientRetry(
 
     try {
       const response = await upload();
+      if (signal.aborted) {
+        throw createAbortError();
+      }
       if (
         response.ok ||
         !isRetriableUploadStatus(response.status) ||
@@ -561,6 +565,7 @@ export function useFileUploadCore(
               fileUri: uri,
               uploadUrl,
               contentType: type || "application/octet-stream",
+              signal,
             }),
           signal
         );

--- a/packages/convex/client/hooks/useFileUpload.client.tsx
+++ b/packages/convex/client/hooks/useFileUpload.client.tsx
@@ -193,7 +193,10 @@ const createAbortError = () => {
 };
 
 const isAbortError = (error: unknown) =>
-  error instanceof Error && error.name === "AbortError";
+  typeof error === "object" &&
+  error !== null &&
+  "name" in error &&
+  error.name === "AbortError";
 
 const sleep = (delayMs: number, signal: AbortSignal) =>
   new Promise<void>((resolve, reject) => {

--- a/packages/convex/client/hooks/useFileUpload.client.tsx
+++ b/packages/convex/client/hooks/useFileUpload.client.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { CardErrorCode, CardType } from "../../shared/constants";
 import {
   CARD_ERROR_CODES,
@@ -185,11 +185,36 @@ const UPLOAD_RETRY_DELAYS_MS = [300, 900] as const;
 const isRetriableUploadStatus = (status: number) =>
   status === 408 || status === 429 || status >= 500;
 
-const sleep = (delayMs: number) =>
-  new Promise((resolve) => setTimeout(resolve, delayMs));
+const createAbortError = () => {
+  const error = new Error("Upload cancelled");
+  error.name = "AbortError";
+  return error;
+};
+
+const isAbortError = (error: unknown) =>
+  error instanceof Error && error.name === "AbortError";
+
+const sleep = (delayMs: number, signal: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(createAbortError());
+      return;
+    }
+
+    const timeout = setTimeout(resolve, delayMs);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timeout);
+        reject(createAbortError());
+      },
+      { once: true }
+    );
+  });
 
 async function uploadWithTransientRetry(
-  upload: () => Promise<UploadResponse>
+  upload: () => Promise<UploadResponse>,
+  signal: AbortSignal
 ): Promise<UploadResponse> {
   let lastError: unknown;
 
@@ -198,6 +223,10 @@ async function uploadWithTransientRetry(
     attempt <= UPLOAD_RETRY_DELAYS_MS.length;
     attempt += 1
   ) {
+    if (signal.aborted) {
+      throw createAbortError();
+    }
+
     try {
       const response = await upload();
       if (
@@ -209,13 +238,16 @@ async function uploadWithTransientRetry(
       }
       lastError = new Error(`Upload failed with status ${response.status}`);
     } catch (error) {
+      if (isAbortError(error)) {
+        throw error;
+      }
       lastError = error;
       if (attempt === UPLOAD_RETRY_DELAYS_MS.length) {
         throw error;
       }
     }
 
-    await sleep(UPLOAD_RETRY_DELAYS_MS[attempt]);
+    await sleep(UPLOAD_RETRY_DELAYS_MS[attempt], signal);
   }
 
   throw lastError instanceof Error ? lastError : new Error("Upload failed");
@@ -232,6 +264,48 @@ export function useFileUploadCore(
   const [isUploading, setIsUploading] = useState(false);
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState<FileUploadError | null>(null);
+  const activeUploadAbortRef = useRef<AbortController | null>(null);
+  const resetProgressTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+
+  useEffect(
+    () => () => {
+      activeUploadAbortRef.current?.abort();
+      if (resetProgressTimeoutRef.current) {
+        clearTimeout(resetProgressTimeoutRef.current);
+      }
+    },
+    []
+  );
+
+  const beginUpload = useCallback(() => {
+    activeUploadAbortRef.current?.abort();
+    if (resetProgressTimeoutRef.current) {
+      clearTimeout(resetProgressTimeoutRef.current);
+      resetProgressTimeoutRef.current = null;
+    }
+
+    const abortController = new AbortController();
+    activeUploadAbortRef.current = abortController;
+    return abortController;
+  }, []);
+
+  const finishUpload = useCallback((abortController: AbortController) => {
+    if (activeUploadAbortRef.current === abortController) {
+      activeUploadAbortRef.current = null;
+    }
+
+    if (abortController.signal.aborted) {
+      return;
+    }
+
+    setIsUploading(false);
+    resetProgressTimeoutRef.current = setTimeout(() => {
+      setProgress(0);
+      resetProgressTimeoutRef.current = null;
+    }, 1000);
+  }, []);
 
   const uploadFile = useCallback(
     async (
@@ -241,6 +315,8 @@ export function useFileUploadCore(
         additionalMetadata?: any;
       } = {}
     ): Promise<UploadFileResult> => {
+      const abortController = beginUpload();
+      const { signal } = abortController;
       setIsUploading(true);
       setProgress(0);
       setError(null);
@@ -306,14 +382,17 @@ export function useFileUploadCore(
         config.onProgress?.(25);
         setProgress(25);
 
-        const uploadResponse = await uploadWithTransientRetry(() =>
-          fetch(uploadUrl, {
-            method: "PUT",
-            headers: {
-              "Content-Type": file.type || "application/octet-stream",
-            },
-            body: file,
-          })
+        const uploadResponse = await uploadWithTransientRetry(
+          () =>
+            fetch(uploadUrl, {
+              method: "PUT",
+              headers: {
+                "Content-Type": file.type || "application/octet-stream",
+              },
+              body: file,
+              signal,
+            }),
+          signal
         );
 
         if (!uploadResponse.ok) {
@@ -350,6 +429,10 @@ export function useFileUploadCore(
 
         return { success: true, cardId: finalizeResult.cardId };
       } catch (error) {
+        if (isAbortError(error)) {
+          return { success: false, error: "Upload cancelled" };
+        }
+
         const errorMessage =
           error instanceof Error ? error.message : "Upload failed";
         const fileError: FileUploadError = {
@@ -384,12 +467,16 @@ export function useFileUploadCore(
           errorCode: fileError.code,
         };
       } finally {
-        setIsUploading(false);
-        // Reset progress after a short delay
-        setTimeout(() => setProgress(0), 1000);
+        finishUpload(abortController);
       }
     },
-    [uploadAndCreateCard, finalizeUploadedCard, config]
+    [
+      uploadAndCreateCard,
+      finalizeUploadedCard,
+      config,
+      beginUpload,
+      finishUpload,
+    ]
   );
 
   const uploadFileFromUri = useCallback(
@@ -401,6 +488,8 @@ export function useFileUploadCore(
       content,
       additionalMetadata,
     }: UploadFileFromUriArgs): Promise<UploadFileResult> => {
+      const abortController = beginUpload();
+      const { signal } = abortController;
       setIsUploading(true);
       setProgress(0);
       setError(null);
@@ -466,12 +555,14 @@ export function useFileUploadCore(
         config.onProgress?.(25);
         setProgress(25);
 
-        const uploadResponse = await uploadWithTransientRetry(() =>
-          uploadBinaryFromUri({
-            fileUri: uri,
-            uploadUrl,
-            contentType: type || "application/octet-stream",
-          })
+        const uploadResponse = await uploadWithTransientRetry(
+          () =>
+            uploadBinaryFromUri({
+              fileUri: uri,
+              uploadUrl,
+              contentType: type || "application/octet-stream",
+            }),
+          signal
         );
 
         if (!uploadResponse.ok) {
@@ -507,6 +598,10 @@ export function useFileUploadCore(
 
         return { success: true, cardId: finalizeResult.cardId };
       } catch (error) {
+        if (isAbortError(error)) {
+          return { success: false, error: "Upload cancelled" };
+        }
+
         const errorMessage =
           error instanceof Error ? error.message : "Upload failed";
         const fileError: FileUploadError = {
@@ -540,11 +635,17 @@ export function useFileUploadCore(
           errorCode: fileError.code,
         };
       } finally {
-        setIsUploading(false);
-        setTimeout(() => setProgress(0), 1000);
+        finishUpload(abortController);
       }
     },
-    [uploadAndCreateCard, finalizeUploadedCard, uploadBinaryFromUri, config]
+    [
+      uploadAndCreateCard,
+      finalizeUploadedCard,
+      uploadBinaryFromUri,
+      config,
+      beginUpload,
+      finishUpload,
+    ]
   );
 
   const uploadMultipleFiles = useCallback(

--- a/packages/convex/client/hooks/useFileUpload.client.tsx
+++ b/packages/convex/client/hooks/useFileUpload.client.tsx
@@ -178,6 +178,48 @@ export interface UploadFileFromUriArgs {
 }
 
 type CodedError = Error & { code?: CardErrorCode };
+type UploadResponse = Pick<Response, "ok" | "status">;
+
+const UPLOAD_RETRY_DELAYS_MS = [300, 900] as const;
+
+const isRetriableUploadStatus = (status: number) =>
+  status === 408 || status === 429 || status >= 500;
+
+const sleep = (delayMs: number) =>
+  new Promise((resolve) => setTimeout(resolve, delayMs));
+
+async function uploadWithTransientRetry(
+  upload: () => Promise<UploadResponse>
+): Promise<UploadResponse> {
+  let lastError: unknown;
+
+  for (
+    let attempt = 0;
+    attempt <= UPLOAD_RETRY_DELAYS_MS.length;
+    attempt += 1
+  ) {
+    try {
+      const response = await upload();
+      if (
+        response.ok ||
+        !isRetriableUploadStatus(response.status) ||
+        attempt === UPLOAD_RETRY_DELAYS_MS.length
+      ) {
+        return response;
+      }
+      lastError = new Error(`Upload failed with status ${response.status}`);
+    } catch (error) {
+      lastError = error;
+      if (attempt === UPLOAD_RETRY_DELAYS_MS.length) {
+        throw error;
+      }
+    }
+
+    await sleep(UPLOAD_RETRY_DELAYS_MS[attempt]);
+  }
+
+  throw lastError instanceof Error ? lastError : new Error("Upload failed");
+}
 
 export function useFileUploadCore(
   {
@@ -258,16 +300,21 @@ export function useFileUploadCore(
           codedError.code = errorInfo.code;
           throw codedError;
         }
+        const { uploadKey, uploadUrl } = uploadResult;
 
         // Step 2: Upload file to R2
         config.onProgress?.(25);
         setProgress(25);
 
-        const uploadResponse = await fetch(uploadResult.uploadUrl, {
-          method: "PUT",
-          headers: { "Content-Type": file.type || "application/octet-stream" },
-          body: file,
-        });
+        const uploadResponse = await uploadWithTransientRetry(() =>
+          fetch(uploadUrl, {
+            method: "PUT",
+            headers: {
+              "Content-Type": file.type || "application/octet-stream",
+            },
+            body: file,
+          })
+        );
 
         if (!uploadResponse.ok) {
           throw new Error(`Upload failed with status ${uploadResponse.status}`);
@@ -278,7 +325,7 @@ export function useFileUploadCore(
 
         // Step 3: Finalize card creation
         const finalizeResult = await finalizeUploadedCard({
-          fileKey: uploadResult.uploadKey,
+          fileKey: uploadKey,
           fileName: file.name,
           fileSize: file.size,
           fileType: file.type,
@@ -414,15 +461,18 @@ export function useFileUploadCore(
           codedError.code = errorInfo.code;
           throw codedError;
         }
+        const { uploadKey, uploadUrl } = uploadResult;
 
         config.onProgress?.(25);
         setProgress(25);
 
-        const uploadResponse = await uploadBinaryFromUri({
-          fileUri: uri,
-          uploadUrl: uploadResult.uploadUrl,
-          contentType: type || "application/octet-stream",
-        });
+        const uploadResponse = await uploadWithTransientRetry(() =>
+          uploadBinaryFromUri({
+            fileUri: uri,
+            uploadUrl,
+            contentType: type || "application/octet-stream",
+          })
+        );
 
         if (!uploadResponse.ok) {
           throw new Error(`Upload failed with status ${uploadResponse.status}`);
@@ -432,7 +482,7 @@ export function useFileUploadCore(
         setProgress(75);
 
         const finalizeResult = await finalizeUploadedCard({
-          fileKey: uploadResult.uploadKey,
+          fileKey: uploadKey,
           fileName: name,
           fileSize: size,
           fileType: type,

--- a/packages/convex/client/hooks/useFileUpload.client.tsx
+++ b/packages/convex/client/hooks/useFileUpload.client.tsx
@@ -198,6 +198,12 @@ const isAbortError = (error: unknown) =>
   "name" in error &&
   error.name === "AbortError";
 
+const throwIfAborted = (signal: AbortSignal) => {
+  if (signal.aborted) {
+    throw createAbortError();
+  }
+};
+
 const sleep = (delayMs: number, signal: AbortSignal) =>
   new Promise<void>((resolve, reject) => {
     if (signal.aborted) {
@@ -227,15 +233,11 @@ async function uploadWithTransientRetry(
     attempt <= UPLOAD_RETRY_DELAYS_MS.length;
     attempt += 1
   ) {
-    if (signal.aborted) {
-      throw createAbortError();
-    }
+    throwIfAborted(signal);
 
     try {
       const response = await upload();
-      if (signal.aborted) {
-        throw createAbortError();
-      }
+      throwIfAborted(signal);
       if (
         response.ok ||
         !isRetriableUploadStatus(response.status) ||
@@ -409,6 +411,7 @@ export function useFileUploadCore(
           throw new Error(`Upload failed with status ${uploadResponse.status}`);
         }
 
+        throwIfAborted(signal);
         config.onProgress?.(75);
         setProgress(75);
 
@@ -423,6 +426,7 @@ export function useFileUploadCore(
           additionalMetadata: mergedAdditionalMetadata,
         });
 
+        throwIfAborted(signal);
         if (!(finalizeResult.success && finalizeResult.cardId)) {
           const errorInfo: FileUploadError = {
             message: finalizeResult.error || "Failed to create card",
@@ -580,6 +584,7 @@ export function useFileUploadCore(
           throw new Error(`Upload failed with status ${uploadResponse.status}`);
         }
 
+        throwIfAborted(signal);
         config.onProgress?.(75);
         setProgress(75);
 
@@ -593,6 +598,7 @@ export function useFileUploadCore(
           additionalMetadata,
         });
 
+        throwIfAborted(signal);
         if (!(finalizeResult.success && finalizeResult.cardId)) {
           const errorInfo: FileUploadError = {
             message: finalizeResult.error || "Failed to create card",


### PR DESCRIPTION
## Summary
- retry transient direct storage upload failures before finalizing card creation
- share the retry behavior across browser fetch uploads and URI-based uploads
- cover transient success, final failure, non-retryable 4xx, and URI retry cases

## Validation
- bun test packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
- bunx biome check packages/convex/client/hooks/useFileUpload.client.tsx packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
- bun run --cwd packages/convex typecheck
- bun run --cwd apps/docs typecheck
- bun run --cwd apps/docs lint
- git diff --check
- pre-commit affected typecheck/lint/build suite
