### PR TITLE
Name tag modal icon buttons

### DIFF
--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -257,9 +257,11 @@ test("web product surfaces cover edit, deep links, rich cards, import/export, bu
   await page.getByText(`${marker} restore-me`).click();
   await page.getByRole("button", { name: "Favorite" }).click();
   await page.getByRole("button", { name: "Manage Tags" }).click();
-  await page.locator("#new-tag").fill(`${marker}-tag`);
-  await page.getByRole("button", { name: "Add" }).click();
-  await expect(page.getByText(`${marker}-tag`)).toBeVisible();
+  const tagsDialog = page.getByRole("dialog", { name: "Manage Tags" });
+  await expect(tagsDialog).toBeVisible();
+  await tagsDialog.getByLabel("Add New Tag").fill(`${marker}-tag`);
+  await tagsDialog.getByRole("button", { name: "Add tag" }).click();
+  await expect(tagsDialog.getByText(`${marker}-tag`)).toBeVisible();
   await page.keyboard.press("Escape");
   await page.getByRole("button", { name: "Delete" }).click();
   await expect(page.getByRole("dialog")).not.toBeVisible();

--- a/packages/ui/src/components/modals/TagManagementModal.tsx
+++ b/packages/ui/src/components/modals/TagManagementModal.tsx
@@ -71,6 +71,7 @@ export function TagManagementModal({
                 value={tagInput}
               />
               <Button
+                aria-label="Add tag"
                 disabled={!tagInput.trim()}
                 onClick={onAddTag}
                 size="icon"
@@ -94,6 +95,7 @@ export function TagManagementModal({
                       {tag}
                     </Button>
                     <Button
+                      aria-label={`Remove user tag ${tag}`}
                       className="rounded-l-none"
                       onClick={() => onRemoveTag(tag)}
                       size="sm"
@@ -122,6 +124,7 @@ export function TagManagementModal({
                       {tag}
                     </Button>
                     <Button
+                      aria-label={`Remove Teak tag ${tag}`}
                       className="rounded-l-none"
                       onClick={() => onRemoveAiTag(tag)}
                       size="sm"


### PR DESCRIPTION
## Summary
- add accessible names to tag modal icon-only add/remove buttons
- scope the product-surface E2E tag assertion to the Manage Tags dialog
- keep the tag workflow covered through a role-based selector

## Validation
- bunx biome check packages/ui/src/components/modals/TagManagementModal.tsx packages/tests/src/journey/09-web-product-surfaces.e2e.ts
- bun run --cwd packages/ui typecheck
- bun run --cwd packages/tests typecheck
- bun run pre-commit