### PR TITLE
Batch product-surface E2E failure reporting

### DIFF
--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -305,7 +305,10 @@ test("web bulk actions, restore, and empty states stay coherent", async ({
   await expect(page.getByText(/nothing found/i)).toBeVisible();
   await page.getByRole("button", { name: "Clear All" }).click();
   await expect(page.getByPlaceholder("Search for anything...")).toHaveValue("");
-  await searchFor(page, `${marker}-missing-tag`);
+  await searchFor(page, `${marker}missingtag`);
+  await expect(
+    page.getByRole("button", { exact: true, name: `${marker}missingtag` })
+  ).toBeVisible();
   await expect(page.getByText(/nothing found/i)).toBeVisible();
   await page.getByRole("button", { name: "Clear All" }).click();
   await page.getByRole("button", { name: /Trash/i }).first().click();
@@ -349,7 +352,16 @@ test("settings import and export surface terminal states", async ({ page }) => {
   await expect(importPanel.getByText(`${marker}-bookmarks.html`)).toBeVisible();
   await importPanel.getByRole("button", { name: "Start import" }).click();
   await expect
-    .poll(async () => importPanel.textContent(), { timeout: 120_000 })
-    .toMatch(/Last import: [1-9]\d* created/i);
+    .poll(
+      async () => {
+        const text = (await importPanel.textContent()) ?? "";
+        return (
+          /Last import: [1-9]\d* created/i.test(text) &&
+          !/Import stopped|failed/i.test(text)
+        );
+      },
+      { timeout: 120_000 }
+    )
+    .toBe(true);
   await page.keyboard.press("Escape");
 });

--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -37,6 +37,13 @@ const searchFor = async (page: Page, query: string) => {
   await enterSearch(page, query);
 };
 
+const clearFilters = async (page: Page) => {
+  await page
+    .getByRole("button", { name: /Clear (All|filters)/i })
+    .first()
+    .click();
+};
+
 const uploadFiles = async (page: Page, files: FilePayload | FilePayload[]) => {
   const [chooser] = await Promise.all([
     page.waitForEvent("filechooser"),
@@ -301,20 +308,32 @@ test("web bulk actions, restore, and empty states stay coherent", async ({
   await searchFor(page, `${marker} restore-me`);
   await expect(page.getByText(`${marker} restore-me`)).toBeVisible();
 
-  await searchFor(page, `${marker}-no-results`);
-  await expect(page.getByText(/nothing found/i)).toBeVisible();
-  await page.getByRole("button", { name: "Clear All" }).click();
-  await expect(page.getByPlaceholder("Search for anything...")).toHaveValue("");
-  await searchFor(page, `${marker}missingtag`);
+  await page.getByText(`${marker} restore-me`).click();
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { exact: true, name: `${marker}-tag` })
+    .click();
   await expect(
-    page.getByRole("button", { exact: true, name: `${marker}missingtag` })
+    page.getByRole("button", { exact: true, name: `${marker}-tag` })
+  ).toBeVisible();
+  await expect(page.getByText(`${marker} restore-me`)).toBeVisible();
+  await enterSearch(page, `${marker}-tag-empty`);
+  await expect(
+    page.getByRole("button", { exact: true, name: `${marker}-tag` })
   ).toBeVisible();
   await expect(page.getByText(/nothing found/i)).toBeVisible();
-  await page.getByRole("button", { name: "Clear All" }).click();
-  await page.getByRole("button", { name: /Trash/i }).first().click();
+  await clearFilters(page);
+
+  await searchFor(page, `${marker}-no-results`);
+  await expect(page.getByText(/nothing found/i)).toBeVisible();
+  await clearFilters(page);
+  await expect(page.getByPlaceholder("Search for anything...")).toHaveValue("");
+  await searchFor(page, "trash");
+  await enterSearch(page, `${marker} bulk-a`);
+  await expect(page.getByText(`${marker} bulk-a`)).toBeVisible();
   await enterSearch(page, `${marker}-trash-empty`);
   await expect(page.getByText(/nothing found/i)).toBeVisible();
-  await page.getByRole("button", { name: "Clear All" }).click();
+  await clearFilters(page);
 });
 
 test("settings import and export surface terminal states", async ({ page }) => {

--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -26,11 +26,15 @@ const saveTextCard = async (page: Page, content: string) => {
   await expect(page.getByRole("main").getByText(content).first()).toBeVisible();
 };
 
-const searchFor = async (page: Page, query: string) => {
-  await page.goto("/");
+const enterSearch = async (page: Page, query: string) => {
   const search = page.getByPlaceholder("Search for anything...");
   await search.fill(query);
   await search.press("Enter");
+};
+
+const searchFor = async (page: Page, query: string) => {
+  await page.goto("/");
+  await enterSearch(page, query);
 };
 
 const uploadFiles = async (page: Page, files: FilePayload | FilePayload[]) => {
@@ -301,6 +305,13 @@ test("web bulk actions, restore, and empty states stay coherent", async ({
   await expect(page.getByText(/nothing found/i)).toBeVisible();
   await page.getByRole("button", { name: "Clear All" }).click();
   await expect(page.getByPlaceholder("Search for anything...")).toHaveValue("");
+  await searchFor(page, `${marker}-missing-tag`);
+  await expect(page.getByText(/nothing found/i)).toBeVisible();
+  await page.getByRole("button", { name: "Clear All" }).click();
+  await page.getByRole("button", { name: /Trash/i }).first().click();
+  await enterSearch(page, `${marker}-trash-empty`);
+  await expect(page.getByText(/nothing found/i)).toBeVisible();
+  await page.getByRole("button", { name: "Clear All" }).click();
 });
 
 test("settings import and export surface terminal states", async ({ page }) => {
@@ -339,6 +350,6 @@ test("settings import and export surface terminal states", async ({ page }) => {
   await importPanel.getByRole("button", { name: "Start import" }).click();
   await expect
     .poll(async () => importPanel.textContent(), { timeout: 120_000 })
-    .toMatch(/Last import: .*created|Last import: .*skipped|Import stopped/i);
+    .toMatch(/Last import: [1-9]\d* created/i);
   await page.keyboard.press("Escape");
 });

--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -49,58 +49,69 @@ const waitForHomeUploadSurface = async (page: Page) => {
   await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
 };
 
-test("web product surfaces cover edit, deep links, rich cards, import/export, bulk, and empty states", async ({
-  page,
-}) => {
+const primaryContext = () => {
   const state = readState();
   if (!state.primary?.apiKey) {
     throw new Error("Missing primary API key");
   }
-  const api = clientFor(state.primary.apiKey);
-  const marker = `prod-surface-${Date.now()}`;
-  const hasUploadedFile = async (fileName: string, createdAfter: number) => {
-    let cursor: string | undefined;
-    for (let pageIndex = 0; pageIndex < 5; pageIndex += 1) {
-      const params = new URLSearchParams({
-        createdAfter: String(createdAfter),
-        include: "metadata",
-        limit: "100",
-        type: "image",
-      });
-      if (cursor) {
-        params.set("cursor", cursor);
-      }
-      const response = await apiFetch(
-        `/v1/cards?${params.toString()}`,
-        state.primary!.apiKey!
-      );
-      const payload = (await response.json()) as {
-        items?: Array<{
-          fileName?: string | null;
-          fileUrl?: string | null;
-          thumbnailUrl?: string | null;
-          type?: string;
-        }>;
-        pageInfo?: { nextCursor?: string | null };
-      };
-      if (
-        payload.items?.some(
-          (card) =>
-            card.type === "image" &&
-            card.fileName === fileName &&
-            (card.fileUrl ?? card.thumbnailUrl)
-        )
-      ) {
-        return true;
-      }
-      cursor = payload.pageInfo?.nextCursor ?? undefined;
-      if (!cursor) {
-        return false;
-      }
-    }
-    return false;
+  return {
+    api: clientFor(state.primary.apiKey),
+    apiKey: state.primary.apiKey,
   };
+};
 
+const markerFor = (scope: string) =>
+  `prod-surface-${scope}-${Date.now().toString(36)}`;
+
+const hasUploadedFile = async (
+  apiKey: string,
+  fileName: string,
+  createdAfter: number
+) => {
+  let cursor: string | undefined;
+  for (let pageIndex = 0; pageIndex < 5; pageIndex += 1) {
+    const params = new URLSearchParams({
+      createdAfter: String(createdAfter),
+      include: "metadata",
+      limit: "100",
+      type: "image",
+    });
+    if (cursor) {
+      params.set("cursor", cursor);
+    }
+    const response = await apiFetch(`/v1/cards?${params.toString()}`, apiKey);
+    const payload = (await response.json()) as {
+      items?: Array<{
+        fileName?: string | null;
+        fileUrl?: string | null;
+        thumbnailUrl?: string | null;
+        type?: string;
+      }>;
+      pageInfo?: { nextCursor?: string | null };
+    };
+    if (
+      payload.items?.some(
+        (card) =>
+          card.type === "image" &&
+          card.fileName === fileName &&
+          (card.fileUrl ?? card.thumbnailUrl)
+      )
+    ) {
+      return true;
+    }
+    cursor = payload.pageInfo?.nextCursor ?? undefined;
+    if (!cursor) {
+      return false;
+    }
+  }
+  return false;
+};
+
+test("web editor, deep links, and link metadata stay usable", async ({
+  page,
+}) => {
+  const { apiKey } = primaryContext();
+  const marker = markerFor("editor");
   await saveTextCard(page, `${marker} original`);
   await page.getByRole("main").getByText(`${marker} original`).click();
   const editor = page.getByPlaceholder("Enter your text...");
@@ -122,7 +133,7 @@ test("web product surfaces cover edit, deep links, rich cards, import/export, bu
   await page.keyboard.press("Escape");
   const searchResponse = await apiFetch(
     `/v1/cards/search?q=${encodeURIComponent(marker)}`,
-    state.primary.apiKey
+    apiKey
   );
   const searchPayload = (await searchResponse.json()) as {
     items?: Array<{ content?: string }>;
@@ -131,15 +142,16 @@ test("web product surfaces cover edit, deep links, rich cards, import/export, bu
     searchPayload.items?.filter((card) => card.content?.includes(marker))
   ).toHaveLength(1);
 
-  await saveTextCard(page, "https://example.com/");
+  const linkUrl = `https://example.com/?teak=${marker}`;
+  await saveTextCard(page, linkUrl);
   await expect
     .poll(
       async () =>
         (
           (await (
             await apiFetch(
-              "/v1/cards/search?q=example.com",
-              state.primary!.apiKey!
+              `/v1/cards/search?q=${encodeURIComponent(marker)}`,
+              apiKey
             )
           ).json()) as { items?: Array<{ metadataTitle?: string }> }
         ).items?.some((card) =>
@@ -148,11 +160,15 @@ test("web product surfaces cover edit, deep links, rich cards, import/export, bu
       { timeout: 90_000 }
     )
     .toBe(true);
-  await searchFor(page, "example.com");
+  await searchFor(page, marker);
   await expect(page.getByRole("main").getByText(/Example Domain/i)).toBeVisible(
     { timeout: 30_000 }
   );
+});
 
+test("web uploads and paste-created files complete", async ({ page }) => {
+  const { apiKey } = primaryContext();
+  const marker = markerFor("uploads");
   await waitForHomeUploadSurface(page);
   await uploadFiles(page, [
     { buffer: pdf, mimeType: "application/pdf", name: `${marker}.pdf` },
@@ -224,11 +240,17 @@ test("web product surfaces cover edit, deep links, rich cards, import/export, bu
     itemCount: 1,
   });
   await expect
-    .poll(() => hasUploadedFile(pastedFileName, pasteStartedAt), {
+    .poll(() => hasUploadedFile(apiKey, pastedFileName, pasteStartedAt), {
       timeout: 90_000,
     })
     .toBe(true);
+});
 
+test("web bulk actions, restore, and empty states stay coherent", async ({
+  page,
+}) => {
+  const { api } = primaryContext();
+  const marker = markerFor("bulk");
   const bulkA = await api.cards.create({
     content: `${marker} bulk-a`,
     source: "prod-e2e",
@@ -275,6 +297,15 @@ test("web product surfaces cover edit, deep links, rich cards, import/export, bu
   await searchFor(page, `${marker} restore-me`);
   await expect(page.getByText(`${marker} restore-me`)).toBeVisible();
 
+  await searchFor(page, `${marker}-no-results`);
+  await expect(page.getByText(/nothing found/i)).toBeVisible();
+  await page.getByRole("button", { name: "Clear All" }).click();
+  await expect(page.getByPlaceholder("Search for anything...")).toHaveValue("");
+});
+
+test("settings import and export surface terminal states", async ({ page }) => {
+  test.setTimeout(180_000);
+  const marker = markerFor("import");
   await page.goto("/settings");
   await page.getByText("Import/Export Data").waitFor();
   await page
@@ -282,38 +313,32 @@ test("web product surfaces cover edit, deep links, rich cards, import/export, bu
     .locator("xpath=ancestor::div[.//button][1]")
     .getByRole("button", { name: "Manage" })
     .click();
-  await expect(page.getByRole("dialog")).toContainText("Import or export");
-  await page.getByRole("tab", { name: "Export" }).click();
+  const dialog = page.getByRole("dialog", { name: "Manage Data" });
+  await expect(dialog).toContainText("Import or export");
+  await dialog.getByRole("tab", { name: "Export" }).click();
   await expect(
-    page.getByText(/Export your data|Your export is ready/)
+    dialog.getByText(/Export your data|Your export is ready/)
   ).toBeVisible();
-  await page.getByRole("tab", { name: "Import" }).click();
+  await dialog.getByRole("tab", { name: "Import" }).click();
+  const importPanel = dialog.getByRole("tabpanel", { name: "Import" });
   await expect(
-    page.getByRole("button", { name: "Import Bookmarks" })
+    importPanel.getByRole("button", { name: "Import Bookmarks" })
   ).toBeVisible();
   const [bookmarkChooser] = await Promise.all([
     page.waitForEvent("filechooser"),
-    page.getByRole("button", { name: "Import Bookmarks" }).click(),
+    importPanel.getByRole("button", { name: "Import Bookmarks" }).click(),
   ]);
   await bookmarkChooser.setFiles({
     buffer: Buffer.from(
-      '<!doctype NETSCAPE-Bookmark-file-1><TITLE>Bookmarks</TITLE><H1>Bookmarks</H1><DL><DT><A HREF="https://example.com/">Example import</A></DT></DL>'
+      `<!doctype NETSCAPE-Bookmark-file-1><TITLE>Bookmarks</TITLE><H1>Bookmarks</H1><DL><DT><A HREF="https://example.com/?teak=${marker}">Example import ${marker}</A></DT></DL>`
     ),
     mimeType: "text/html",
     name: `${marker}-bookmarks.html`,
   });
-  await expect(page.getByText(`${marker}-bookmarks.html`)).toBeVisible();
-  await page.getByRole("button", { name: "Start import" }).click();
-  await expect(page.getByText(/created|skipped|Import/i)).toBeVisible({
-    timeout: 120_000,
-  });
+  await expect(importPanel.getByText(`${marker}-bookmarks.html`)).toBeVisible();
+  await importPanel.getByRole("button", { name: "Start import" }).click();
+  await expect
+    .poll(async () => importPanel.textContent(), { timeout: 120_000 })
+    .toMatch(/Last import: .*created|Last import: .*skipped|Import stopped/i);
   await page.keyboard.press("Escape");
-
-  await searchFor(page, `${marker}-no-results`);
-  await expect(page.getByText(/nothing found/i)).toBeVisible();
-  await page.getByRole("button", { name: "Clear All" }).click();
-  await searchFor(page, `${marker}-tag`);
-  await expect(page.getByText(/nothing found/i)).toBeVisible();
-  await searchFor(page, "trash");
-  await expect(page.getByText(/nothing found|restore-me/i)).toBeVisible();
 });

--- a/packages/ui/src/components/settings/__tests__/ImportPanel.contract.test.tsx
+++ b/packages/ui/src/components/settings/__tests__/ImportPanel.contract.test.tsx
@@ -196,7 +196,37 @@ describe("ImportPanel", () => {
           controllers
         )
       ).rejects.toThrow("Upload part 1 failed (500)");
-      expect(uploadFetch).toHaveBeenCalledTimes(3);
+      expect(uploadFetch).toHaveBeenCalledTimes(5);
+      expect(controllers.size).toBe(0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("retries transient multipart upload failures", async () => {
+    const originalFetch = globalThis.fetch;
+    const uploadFetch = mock()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    globalThis.fetch = uploadFetch as typeof fetch;
+    const controllers = new Set<AbortController>();
+    const onProgress = mock();
+
+    try {
+      await putParts(
+        new File([new Uint8Array([1])], "bookmarks.html"),
+        {
+          jobId: "job",
+          partSize: 1,
+          parts: [{ partNumber: 1, url: "https://uploads.example/1" }],
+          uploadedParts: [],
+        },
+        onProgress,
+        controllers
+      );
+      expect(uploadFetch).toHaveBeenCalledTimes(2);
+      expect(onProgress).toHaveBeenCalledWith(0);
+      expect(onProgress).toHaveBeenCalledWith(100);
       expect(controllers.size).toBe(0);
     } finally {
       globalThis.fetch = originalFetch;

--- a/packages/ui/src/components/settings/importUpload.ts
+++ b/packages/ui/src/components/settings/importUpload.ts
@@ -1,4 +1,6 @@
 const UPLOAD_CONCURRENCY = 3;
+const UPLOAD_PART_TIMEOUT_MS = 30_000;
+const UPLOAD_RETRY_DELAYS_MS = [300, 900] as const;
 
 export interface UploadPlan {
   jobId: string;
@@ -13,12 +15,13 @@ export async function putParts(
   onProgress: (percent: number) => void,
   controllers: Set<AbortController>
 ) {
+  const totalBytes = Math.max(file.size, 1);
   const completeBytes = plan.uploadedParts.reduce((total, partNumber) => {
     const start = (partNumber - 1) * plan.partSize;
     return total + Math.min(plan.partSize, file.size - start);
   }, 0);
   let uploadedBytes = completeBytes;
-  onProgress(Math.round((uploadedBytes / file.size) * 100));
+  onProgress(Math.round((uploadedBytes / totalBytes) * 100));
   let nextIndex = 0;
   let failed = false;
   let failure: unknown;
@@ -47,31 +50,18 @@ export async function putParts(
         start,
         Math.min(start + plan.partSize, file.size)
       );
-      const controller = new AbortController();
-      controllers.add(controller);
       try {
         // Each worker uploads its assigned parts sequentially; cross-part
         // concurrency comes from running UPLOAD_CONCURRENCY workers in parallel.
         // react-doctor-disable-next-line react-doctor/async-await-in-loop
-        const response = await fetch(part.url, {
-          method: "PUT",
-          body: chunk,
-          signal: controller.signal,
-        });
-        if (!response.ok) {
-          throw new Error(
-            `Upload part ${part.partNumber} failed (${response.status})`
-          );
-        }
+        await putPartWithRetry(part, chunk, controllers);
         uploadedBytes += chunk.size;
         onProgress(
-          Math.min(100, Math.round((uploadedBytes / file.size) * 100))
+          Math.min(100, Math.round((uploadedBytes / totalBytes) * 100))
         );
       } catch (error) {
         stopWorkers(error);
         return;
-      } finally {
-        controllers.delete(controller);
       }
     }
   };
@@ -87,4 +77,107 @@ export async function putParts(
   if (failed) {
     throw failure;
   }
+}
+
+async function putPartWithRetry(
+  part: UploadPlan["parts"][number],
+  chunk: Blob,
+  controllers: Set<AbortController>
+) {
+  let lastError: unknown;
+  for (
+    let attempt = 0;
+    attempt <= UPLOAD_RETRY_DELAYS_MS.length;
+    attempt += 1
+  ) {
+    try {
+      const response = await putPart(part, chunk, controllers);
+      if (
+        response.ok ||
+        !isRetriableUploadStatus(response.status) ||
+        attempt === UPLOAD_RETRY_DELAYS_MS.length
+      ) {
+        if (!response.ok) {
+          throw uploadPartError(part.partNumber, response.status);
+        }
+        return;
+      }
+      lastError = uploadPartError(part.partNumber, response.status);
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw error;
+      }
+      lastError = error;
+      if (attempt === UPLOAD_RETRY_DELAYS_MS.length) {
+        throw error;
+      }
+    }
+
+    // Retry sleeps must also be abortable by the Cancel import button.
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop
+    await sleep(UPLOAD_RETRY_DELAYS_MS[attempt], controllers);
+  }
+  throw lastError instanceof Error ? lastError : new Error("Upload failed");
+}
+
+async function putPart(
+  part: UploadPlan["parts"][number],
+  chunk: Blob,
+  controllers: Set<AbortController>
+) {
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, UPLOAD_PART_TIMEOUT_MS);
+  controllers.add(controller);
+  try {
+    return await fetch(part.url, {
+      body: chunk,
+      method: "PUT",
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (timedOut && isAbortError(error)) {
+      throw new Error(`Upload part ${part.partNumber} timed out`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+    controllers.delete(controller);
+  }
+}
+
+function sleep(delayMs: number, controllers: Set<AbortController>) {
+  const controller = new AbortController();
+  controllers.add(controller);
+  return new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(resolve, delayMs);
+    controller.signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timeout);
+        reject(new DOMException("Aborted", "AbortError"));
+      },
+      { once: true }
+    );
+  }).finally(() => {
+    controllers.delete(controller);
+  });
+}
+
+function isRetriableUploadStatus(status: number) {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+function isAbortError(error: unknown) {
+  return (
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError")
+  );
+}
+
+function uploadPartError(partNumber: number, status: number) {
+  return new Error(`Upload part ${partNumber} failed (${status})`);
 }


### PR DESCRIPTION
## Summary
- split the broad product-surfaces production journey into independent editor/link, upload/paste, bulk/restore, and import/export tests so one failure no longer hides the rest of the surface
- scope the import/export assertions to the Manage Data dialog/tab panel and wait for terminal import states instead of broad page text
- add transient retry, timeout, and abort-safe cleanup to multipart import uploads

## Validation
- bunx biome check packages/tests/src/journey/09-web-product-surfaces.e2e.ts packages/ui/src/components/settings/importUpload.ts packages/ui/src/components/settings/__tests__/ImportPanel.contract.test.tsx
- bun test packages/ui/src/components/settings/__tests__/ImportPanel.contract.test.tsx
- bun run --cwd packages/ui typecheck
- bun run --cwd packages/tests typecheck
- bunx playwright test src/journey/09-web-product-surfaces.e2e.ts --project=journey --list
- git commit pre-commit hook: turbo run typecheck lint build --affected
