### PR TITLE
Collect production E2E failures locally

### DIFF
--- a/.github/workflows/prod-e2e.yml
+++ b/.github/workflows/prod-e2e.yml
@@ -82,7 +82,8 @@ jobs:
           retention-days: 7
 
   matrix:
-    needs: journey
+    needs: gate
+    if: always() && needs.gate.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -103,7 +104,8 @@ jobs:
           retention-days: 7
 
   extension:
-    needs: journey
+    needs: gate
+    if: always() && needs.gate.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
@@ -128,7 +130,7 @@ jobs:
           retention-days: 7
 
   sweep:
-    needs: [matrix, extension]
+    needs: [journey, matrix, extension]
     if: always() && (github.event_name == 'schedule' || inputs.sweep)
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ yarn-error.log*
 
 # turbo
 .turbo
+.tmp/
 
 # typescript
 *.tsbuildinfo

--- a/apps/docs/src/content/changelog/2026-07.mdx
+++ b/apps/docs/src/content/changelog/2026-07.mdx
@@ -9,6 +9,7 @@ date: "2026-07-06"
 - Settings and sign-in screens now show stable loading states instead of partial rows or empty cards.
 - Imports now keep progress visible after you reopen Settings, wrap long error reports inside the dialog, and stop cleanly when your card limit is reached.
 - Import uploads now connect reliably to storage, and API key management in Settings uses a cleaner table layout.
+- Search now clears stale cards when a query has no matches, so empty results show accurately instead of leaving older cards on screen.
 - The desktop app now uploads files reliably again.
 - The desktop app can now record audio notes. macOS will ask for microphone access the first time.
 - Import and Export now share one place in Settings, with a quick tab to switch between them. Imports show step-by-step progress and explain exactly which items were skipped or why any failed.

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -6,6 +6,7 @@ Run from the repo root:
 
 ```bash
 bun install
+bun run --cwd packages/tests e2e:prod:local
 bun run --cwd packages/tests e2e:prod:docs
 bun run --cwd packages/tests e2e:prod:journey
 bun run --cwd packages/tests teardown
@@ -23,6 +24,9 @@ Useful variables:
 - `PROD_SITE_URL` defaults to `https://teakvault.com`
 - `PROD_API_URL` defaults to `https://teakvault.com/api`
 - `PROD_MCP_URL` defaults to `https://teakvault.com/mcp`
+- `VITE_PUBLIC_CONVEX_URL` and `VITE_PUBLIC_CONVEX_SITE_URL` are required for the extension build. You can use matching `NEXT_PUBLIC_CONVEX_URL` and `NEXT_PUBLIC_CONVEX_SITE_URL` values locally.
+
+For local parity with GitHub Actions, put the required values in `.env.production-e2e.local` at the repo root and run `bun run --cwd packages/tests e2e:prod:local`. The local runner installs Playwright browsers, executes preflight, docs, journey, browser matrix, extension, and teardown steps, then preserves separate reports under `packages/tests/playwright-report`.
 
 Mailpit preflight:
 

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -8,6 +8,7 @@
     "e2e:prod:docs": "playwright test --project=docs",
     "e2e:prod:matrix": "playwright test --project=matrix-chromium --project=matrix-firefox --project=matrix-webkit",
     "e2e:prod:extension": "playwright test --project=extension",
+    "e2e:prod:local": "tsx src/scripts/run-prod-suite.ts",
     "preflight": "tsx src/scripts/preflight.ts",
     "teardown": "tsx src/scripts/teardown.ts",
     "sweep": "tsx src/scripts/sweep.ts",

--- a/packages/tests/src/helpers/mailpit.ts
+++ b/packages/tests/src/helpers/mailpit.ts
@@ -3,7 +3,7 @@ import { env, requireMailpit } from "./env";
 interface MailpitMessage {
   ID: string;
   Subject: string;
-  To: Array<{ Address: string }>;
+  To?: Array<{ Address: string }> | null;
 }
 
 const api = (path: string) => `${env.mailpitUrl}/api/v1${path}`;
@@ -23,6 +23,11 @@ const mailpitFetch = async (path: string, init?: RequestInit) => {
   throw lastError;
 };
 
+const hasRecipient = (message: MailpitMessage, email: string) =>
+  (message.To ?? []).some(
+    (recipient) => recipient.Address?.toLowerCase() === email
+  );
+
 export const assertMailpitReady = async () => {
   requireMailpit();
   const response = await mailpitFetch("/messages?limit=1");
@@ -41,8 +46,7 @@ export const waitForEmail = async (to: string, subject: string) => {
     const data = (await response.json()) as { messages?: MailpitMessage[] };
     const hit = data.messages?.find(
       (message) =>
-        message.Subject === subject &&
-        message.To.some((recipient) => recipient.Address.toLowerCase() === to)
+        message.Subject === subject && hasRecipient(message, to.toLowerCase())
     );
     if (hit) {
       const detail = await mailpitFetch(`/message/${hit.ID}`);
@@ -68,11 +72,7 @@ export const deleteMessagesFor = async (email: string) => {
     }
     const data = (await response.json()) as { messages?: MailpitMessage[] };
     for (const message of data.messages ?? []) {
-      if (
-        message.To.some(
-          (recipient) => recipient.Address.toLowerCase() === email
-        )
-      ) {
+      if (hasRecipient(message, email.toLowerCase())) {
         await mailpitFetch(`/message/${message.ID}`, { method: "DELETE" });
       }
     }

--- a/packages/tests/src/journey/05-mcp.e2e.ts
+++ b/packages/tests/src/journey/05-mcp.e2e.ts
@@ -4,7 +4,7 @@ import { connectMcp } from "../helpers/mcp";
 import { readState, updateState } from "../helpers/run-state";
 
 test("MCP lists and calls every public tool", async () => {
-  const { primary, createdCardIds } = readState();
+  const { primary } = readState();
   if (!primary?.apiKey) {
     throw new Error("Missing primary API key");
   }
@@ -55,11 +55,30 @@ test("MCP lists and calls every public tool", async () => {
       { fileName: "mcp.txt", mimeType: "text/plain", fileSize: 1 },
     ],
     ["search", { query: "mcp" }],
-    ["fetch", { id: createdCardIds[0] || cardId }],
+    ["fetch", { id: cardId }],
   ] as const;
   for (const [name, args] of calls) {
-    expect((await client.callTool({ name, arguments: args })).isError).not.toBe(
-      true
-    );
+    const result = await client.callTool({ name, arguments: args });
+    expect(
+      result.isError,
+      `${name} failed: ${JSON.stringify(result.content ?? result.structuredContent)}`
+    ).not.toBe(true);
+    if (name === "teak_v1_bulk_cards") {
+      const bulk = result.structuredContent as
+        | { results?: Array<{ cardId?: string }> }
+        | undefined;
+      for (const item of bulk?.results ?? []) {
+        if (item.cardId) {
+          updateState((s) => s.createdCardIds.push(item.cardId as string));
+        }
+      }
+    }
+    if (name === "fetch") {
+      expect(result.structuredContent ?? result.content).toBeTruthy();
+    }
+    if (name === "teak_v1_create_upload") {
+      expect(result.structuredContent ?? result.content).toBeTruthy();
+    }
   }
+  await client.close();
 });

--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -29,7 +29,6 @@ const saveTextCard = async (page: Page, content: string) => {
 const enterSearch = async (page: Page, query: string) => {
   const search = page.getByPlaceholder("Search for anything...");
   await search.fill(query);
-  await search.press("Enter");
 };
 
 const searchFor = async (page: Page, query: string) => {
@@ -58,6 +57,12 @@ const waitForHomeUploadSurface = async (page: Page) => {
     page.getByRole("button", { name: "Upload files" })
   ).toBeVisible();
   await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
+};
+
+const showTrash = async (page: Page) => {
+  await page.goto("/");
+  await page.getByPlaceholder("Search for anything...").click();
+  await page.getByRole("button", { name: "Trash" }).click();
 };
 
 const primaryContext = () => {
@@ -121,7 +126,7 @@ const hasUploadedFile = async (
 test("web editor, deep links, and link metadata stay usable", async ({
   page,
 }) => {
-  const { apiKey } = primaryContext();
+  const { api, apiKey } = primaryContext();
   const marker = markerFor("editor");
   await saveTextCard(page, `${marker} original`);
   await page.getByRole("main").getByText(`${marker} original`).click();
@@ -153,27 +158,15 @@ test("web editor, deep links, and link metadata stay usable", async ({
     searchPayload.items?.filter((card) => card.content?.includes(marker))
   ).toHaveLength(1);
 
-  const linkUrl = `https://example.com/?teak=${marker}`;
-  await saveTextCard(page, linkUrl);
-  await expect
-    .poll(
-      async () =>
-        (
-          (await (
-            await apiFetch(
-              `/v1/cards/search?q=${encodeURIComponent(marker)}`,
-              apiKey
-            )
-          ).json()) as { items?: Array<{ metadataTitle?: string }> }
-        ).items?.some((card) =>
-          /Example Domain/i.test(card.metadataTitle ?? "")
-        ),
-      { timeout: 90_000 }
-    )
-    .toBe(true);
+  const link = await api.cards.create({
+    content: `${marker} link`,
+    source: "prod-e2e",
+    url: "https://example.com",
+  });
+  updateState((s) => s.createdCardIds.push(link.cardId));
   await searchFor(page, marker);
   await expect(page.getByRole("main").getByText(/Example Domain/i)).toBeVisible(
-    { timeout: 30_000 }
+    { timeout: 90_000 }
   );
 });
 
@@ -298,7 +291,7 @@ test("web bulk actions, restore, and empty states stay coherent", async ({
   await page.keyboard.press("Escape");
   await page.getByRole("button", { name: "Delete" }).click();
   await expect(page.getByRole("dialog")).not.toBeVisible();
-  await searchFor(page, "trash");
+  await showTrash(page);
   await page.getByText(`${marker} restore-me`).click();
   await page
     .getByRole("dialog")
@@ -321,14 +314,14 @@ test("web bulk actions, restore, and empty states stay coherent", async ({
   await expect(
     page.getByRole("button", { exact: true, name: `${marker}-tag` })
   ).toBeVisible();
-  await expect(page.getByText(/nothing found/i)).toBeVisible();
+  await expect(page.getByText(`${marker} restore-me`)).toBeVisible();
   await clearFilters(page);
 
   await searchFor(page, `${marker}-no-results`);
   await expect(page.getByText(/nothing found/i)).toBeVisible();
   await clearFilters(page);
   await expect(page.getByPlaceholder("Search for anything...")).toHaveValue("");
-  await searchFor(page, "trash");
+  await showTrash(page);
   await enterSearch(page, `${marker} bulk-a`);
   await expect(page.getByText(`${marker} bulk-a`)).toBeVisible();
   await enterSearch(page, `${marker}-trash-empty`);

--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -36,6 +36,37 @@ const searchFor = async (page: Page, query: string) => {
   await enterSearch(page, query);
 };
 
+const cardText = (page: Page, text: string | RegExp) =>
+  page.getByRole("main").getByText(text).first();
+
+const expectSearchToFilterCurrentView = async (
+  page: Page,
+  query: string,
+  visibleText: string | RegExp
+) => {
+  const target = cardText(page, visibleText);
+  const missingQuery = `zzzz-no-match-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2)}`;
+  await expect(target).toBeVisible({ timeout: 30_000 });
+  await enterSearch(page, missingQuery);
+  await expect(target).not.toBeVisible();
+  await expect(
+    page.getByRole("main").getByText(/nothing found/i)
+  ).toBeVisible();
+  await enterSearch(page, query);
+  await expect(target).toBeVisible();
+};
+
+const searchForVisibleCard = async (
+  page: Page,
+  query: string,
+  visibleText: string | RegExp
+) => {
+  await page.goto("/");
+  await expectSearchToFilterCurrentView(page, query, visibleText);
+};
+
 const clearFilters = async (page: Page) => {
   await page
     .getByRole("button", { name: /Clear (All|filters)/i })
@@ -164,7 +195,7 @@ test("web editor, deep links, and link metadata stay usable", async ({
     url: "https://example.com",
   });
   updateState((s) => s.createdCardIds.push(link.cardId));
-  await searchFor(page, marker);
+  await searchForVisibleCard(page, marker, `${marker} link`);
   await expect(page.getByRole("main").getByText(/Example Domain/i)).toBeVisible(
     { timeout: 90_000 }
   );
@@ -264,7 +295,7 @@ test("web bulk actions, restore, and empty states stay coherent", async ({
     source: "prod-e2e",
   });
   updateState((s) => s.createdCardIds.push(bulkA.cardId, bulkB.cardId));
-  await searchFor(page, `${marker} bulk`);
+  await searchForVisibleCard(page, `${marker} bulk`, `${marker} bulk-a`);
   await page.getByText(`${marker} bulk-a`).click({ button: "right" });
   await page.getByRole("menuitem", { name: "Select" }).click();
   await page.getByText(`${marker} bulk-b`).click();
@@ -279,7 +310,11 @@ test("web bulk actions, restore, and empty states stay coherent", async ({
     source: "prod-e2e",
   });
   updateState((s) => s.createdCardIds.push(restoreCard.cardId));
-  await searchFor(page, `${marker} restore-me`);
+  await searchForVisibleCard(
+    page,
+    `${marker} restore-me`,
+    `${marker} restore-me`
+  );
   await page.getByText(`${marker} restore-me`).click();
   await page.getByRole("button", { name: "Favorite" }).click();
   await page.getByRole("button", { name: "Manage Tags" }).click();
@@ -298,8 +333,11 @@ test("web bulk actions, restore, and empty states stay coherent", async ({
     .getByRole("button", { exact: true, name: "Restore" })
     .click();
   await expect(page.getByRole("dialog")).not.toBeVisible();
-  await searchFor(page, `${marker} restore-me`);
-  await expect(page.getByText(`${marker} restore-me`)).toBeVisible();
+  await searchForVisibleCard(
+    page,
+    `${marker} restore-me`,
+    `${marker} restore-me`
+  );
 
   await page.getByText(`${marker} restore-me`).click();
   await page
@@ -322,8 +360,11 @@ test("web bulk actions, restore, and empty states stay coherent", async ({
   await clearFilters(page);
   await expect(page.getByPlaceholder("Search for anything...")).toHaveValue("");
   await showTrash(page);
-  await enterSearch(page, `${marker} bulk-a`);
-  await expect(page.getByText(`${marker} bulk-a`)).toBeVisible();
+  await expectSearchToFilterCurrentView(
+    page,
+    `${marker} bulk-a`,
+    `${marker} bulk-a`
+  );
   await enterSearch(page, `${marker}-trash-empty`);
   await expect(page.getByText(/nothing found/i)).toBeVisible();
   await clearFilters(page);

--- a/packages/tests/src/matrix/journey-lite.e2e.ts
+++ b/packages/tests/src/matrix/journey-lite.e2e.ts
@@ -15,6 +15,10 @@ test("signup, create, and search", async ({ page }) => {
     .filter({ hasText: marker })
     .first();
   await expect(savedCard).toBeVisible();
-  await page.getByPlaceholder("Search for anything...").fill(marker);
+  const search = page.getByPlaceholder("Search for anything...");
+  await search.fill(`${marker}-missing`);
+  await expect(savedCard).not.toBeVisible();
+  await expect(page.getByText(/nothing found/i)).toBeVisible();
+  await search.fill(marker);
   await expect(savedCard).toBeVisible();
 });

--- a/packages/tests/src/matrix/journey-lite.e2e.ts
+++ b/packages/tests/src/matrix/journey-lite.e2e.ts
@@ -16,6 +16,5 @@ test("signup, create, and search", async ({ page }) => {
     .first();
   await expect(savedCard).toBeVisible();
   await page.getByPlaceholder("Search for anything...").fill(marker);
-  await page.keyboard.press("Enter");
   await expect(savedCard).toBeVisible();
 });

--- a/packages/tests/src/scripts/run-prod-suite.ts
+++ b/packages/tests/src/scripts/run-prod-suite.ts
@@ -1,0 +1,186 @@
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+
+const repoRoot = resolve(new URL("../../../../", import.meta.url).pathname);
+const testsDir = join(repoRoot, "packages/tests");
+const reportRoot = join(testsDir, "playwright-report");
+const resultsRoot = join(testsDir, "test-results");
+const stateRoot = join(testsDir, ".state");
+const runnerTemp = process.env.RUNNER_TEMP || join(repoRoot, ".tmp/prod-e2e");
+
+const loadEnvFile = (filePath: string) => {
+  if (!existsSync(filePath)) {
+    return;
+  }
+  for (const rawLine of readFileSync(filePath, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!(line && !line.startsWith("#"))) {
+      continue;
+    }
+    const match = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
+    if (!match) {
+      continue;
+    }
+    const [, key, rawValue] = match;
+    if (process.env[key]) {
+      continue;
+    }
+    process.env[key] = rawValue
+      .replace(/^(['"])(.*)\1$/, "$2")
+      .replace(/\\n/g, "\n");
+  }
+};
+
+for (const filePath of [
+  join(repoRoot, ".env.production-e2e.local"),
+  join(testsDir, ".env.production-e2e.local"),
+]) {
+  loadEnvFile(filePath);
+}
+
+if (!process.env.VITE_PUBLIC_CONVEX_URL && process.env.NEXT_PUBLIC_CONVEX_URL) {
+  process.env.VITE_PUBLIC_CONVEX_URL = process.env.NEXT_PUBLIC_CONVEX_URL;
+}
+if (
+  !process.env.VITE_PUBLIC_CONVEX_SITE_URL &&
+  process.env.NEXT_PUBLIC_CONVEX_SITE_URL
+) {
+  process.env.VITE_PUBLIC_CONVEX_SITE_URL =
+    process.env.NEXT_PUBLIC_CONVEX_SITE_URL;
+}
+
+const required = [
+  "PROD_E2E_PASSWORD",
+  "MAILPIT_URL",
+  "E2E_EMAIL_DOMAIN",
+  "VITE_PUBLIC_CONVEX_URL",
+  "VITE_PUBLIC_CONVEX_SITE_URL",
+];
+const missing = required.filter((name) => !process.env[name]);
+if (missing.length > 0) {
+  console.error(
+    `Missing production E2E variables: ${missing.join(", ")}\n` +
+      "Create .env.production-e2e.local at the repo root or export them before running."
+  );
+  process.exit(1);
+}
+
+const run = (
+  label: string,
+  command: string,
+  args: string[],
+  options: { cwd?: string; env?: NodeJS.ProcessEnv; optional?: boolean } = {}
+) => {
+  console.log(`\n## ${label}`);
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    env: { ...process.env, RUNNER_TEMP: runnerTemp, ...options.env },
+    stdio: "inherit",
+  });
+  const code = result.status ?? 1;
+  return { code, label, optional: Boolean(options.optional) };
+};
+
+const playwright = (label: string, projects: string[]) => {
+  const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  return run(
+    label,
+    "bunx",
+    [
+      "playwright",
+      "test",
+      ...projects.flatMap((project) => [`--project=${project}`]),
+      `--output=${join(resultsRoot, slug)}`,
+    ],
+    {
+      cwd: testsDir,
+      env: {
+        CI: "1",
+        PLAYWRIGHT_HTML_OUTPUT_DIR: join(reportRoot, slug),
+      },
+    }
+  );
+};
+
+rmSync(reportRoot, { force: true, recursive: true });
+rmSync(resultsRoot, { force: true, recursive: true });
+rmSync(stateRoot, { force: true, recursive: true });
+mkdirSync(runnerTemp, { recursive: true });
+mkdirSync(resultsRoot, { recursive: true });
+
+const results = [
+  run("preflight", "bun", ["run", "--cwd", "packages/tests", "preflight"]),
+  run("smoke urls", "bash", ["scripts/smoke-urls.sh"]),
+  run("install playwright browsers", "bunx", [
+    "playwright",
+    "install",
+    "chromium",
+    "firefox",
+    "webkit",
+  ]),
+  playwright("docs", ["docs"]),
+  run("build repo cli", "bun", ["run", "build:cli"]),
+  run("install published cli", "npm", [
+    "install",
+    "--prefix",
+    join(runnerTemp, "teak-npm"),
+    "teak-cli@latest",
+  ]),
+  playwright("journey", [
+    "journey-setup",
+    "journey",
+    "journey-delete",
+    "journey-post-delete",
+  ]),
+  run(
+    "journey teardown",
+    "bun",
+    ["run", "--cwd", "packages/tests", "teardown"],
+    {
+      optional: true,
+    }
+  ),
+  playwright("matrix", ["matrix-chromium", "matrix-firefox", "matrix-webkit"]),
+  run(
+    "matrix teardown",
+    "bun",
+    ["run", "--cwd", "packages/tests", "teardown"],
+    {
+      optional: true,
+    }
+  ),
+  run("build extension", "bun", ["run", "--cwd", "apps/extension", "build"]),
+  playwright("extension", ["extension"]),
+  run(
+    "extension teardown",
+    "bun",
+    ["run", "--cwd", "packages/tests", "teardown"],
+    { optional: true }
+  ),
+];
+
+const failed = results.filter(
+  (result) => result.code !== 0 && !result.optional
+);
+writeFileSync(
+  join(resultsRoot, "prod-e2e-local-summary.json"),
+  `${JSON.stringify({ failed, results }, null, 2)}\n`
+);
+
+if (failed.length > 0) {
+  console.error(
+    `\nProduction E2E local suite failed: ${failed
+      .map((result) => result.label)
+      .join(", ")}`
+  );
+  process.exit(1);
+}
+
+console.log("\nProduction E2E local suite passed.");

--- a/packages/ui/src/hooks/useCardsSearchController.ts
+++ b/packages/ui/src/hooks/useCardsSearchController.ts
@@ -389,17 +389,38 @@ export function useCardsSearchController(
     [localCards, searchState, searchTerms]
   );
 
+  const remoteSearchResults = useMemo(() => {
+    if (!hasActiveSearch) {
+      return remoteCards;
+    }
+    return filterLocalCards(remoteCards, {
+      searchTerms,
+      types: searchState.filterTags,
+      styleFilters: searchState.styleFilters,
+      hueFilters: searchState.hueFilters,
+      hexFilters: searchState.hexFilters,
+      favoritesOnly: searchState.showFavoritesOnly,
+      showTrashOnly: searchState.showTrashOnly,
+      createdAtRange: searchState.timeFilter?.range,
+    });
+  }, [hasActiveSearch, remoteCards, searchState, searchTerms]);
+
   const suppressRemoteCards =
     hasActiveSearch && deferredSearchQuery !== searchState.searchQuery;
 
   const displayCards = useMemo(
     () =>
       mergeLocalAndRemoteSearchResults(
-        suppressRemoteCards ? [] : remoteCards,
+        suppressRemoteCards ? [] : remoteSearchResults,
         localSearchResults,
         hasActiveSearch
       ),
-    [hasActiveSearch, localSearchResults, remoteCards, suppressRemoteCards]
+    [
+      hasActiveSearch,
+      localSearchResults,
+      remoteSearchResults,
+      suppressRemoteCards,
+    ]
   );
 
   const resetKey = useMemo(


### PR DESCRIPTION
## Summary
- add a local production E2E batch runner that mirrors the GitHub workflow, installs browsers, preserves per-surface reports, and keeps running independent surfaces after failures
- let GitHub Production E2E matrix and extension jobs run after the gate instead of being skipped by journey failures
- fix stale active-search results, Mailpit cleanup for null recipients, and brittle prod E2E assertions around MCP, link metadata, search, trash, and matrix search

## Validation
- bunx biome check .github/workflows/prod-e2e.yml packages/tests/src/scripts/run-prod-suite.ts packages/tests/src/journey/09-web-product-surfaces.e2e.ts packages/tests/src/journey/05-mcp.e2e.ts packages/tests/src/helpers/mailpit.ts packages/tests/src/matrix/journey-lite.e2e.ts packages/ui/src/hooks/useCardsSearchController.ts
- bun run --cwd packages/ui typecheck
- bun run --cwd packages/tests typecheck
- bun test packages/ui/src/hooks/__tests__/useCardsSearchController.test.ts packages/convex/__tests__/shared/search/localSearch.test.ts
- local production batch runner: docs 112/112, matrix 3/3, extension 1/1 passed; journey reproduced stale production search before this branch deploys
- pre-commit affected pipeline passed: typecheck, lint, build for web, UI, docs, tests, desktop
