### PR TITLE
Fix CSP, PDF thumbnails, and link card classification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ teak/
 - Add/extend tests for new features or bug fixes.
 - Update or add fixtures/test data so tests are deterministic.
 - Keep tests fast; avoid extra network calls unless the feature requires it.
+- End-to-end tests live in `packages/tests` (Playwright, run against live production surfaces: web, REST API, CLI, MCP, docs, browser matrix, extension). Whenever a change affects an end-to-end, user-observable flow across those surfaces, add or extend an e2e test there in the same PR. Match the existing journey structure in `packages/tests/src/journey` and reuse the helpers in `packages/tests/src/helpers`. See `packages/tests/README.md` for how to run the suite.
 
 ## Changelog Editorial Rules
 

--- a/apps/desktop/src/__tests__/electronMainWiring.test.ts
+++ b/apps/desktop/src/__tests__/electronMainWiring.test.ts
@@ -82,6 +82,18 @@ describe("electron main process wiring", () => {
     expect(source).toContain("isMicrophoneCheck");
   });
 
+  it("allows clipboard writes so copy actions work", () => {
+    // The shared UI copies via navigator.clipboard.writeText/write, which route
+    // through Electron's permission handlers. Overriding those handlers for the
+    // microphone must not deny clipboard writes ("Write permission denied").
+    const source = readFileSync(
+      resolve(import.meta.dir, "../main/index.ts"),
+      "utf8"
+    );
+
+    expect(source).toContain("clipboard-sanitized-write");
+  });
+
   it("configures the main window with correct dimensions", () => {
     const source = readFileSync(
       resolve(import.meta.dir, "../main/index.ts"),

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -151,6 +151,14 @@ function createMainWindow(): BrowserWindowInstance {
   // (and every other permission) to avoid silently granting camera access.
   const { session } = mainWindow.webContents;
   session.setPermissionRequestHandler((_wc, permission, callback, details) => {
+    // Allow copying to the clipboard. `navigator.clipboard.writeText`/`write`
+    // (used across the shared UI for "copy" actions) route through Electron's
+    // permission handlers; overriding them for microphone access below would
+    // otherwise deny clipboard writes with "Write permission denied".
+    if (permission === "clipboard-sanitized-write") {
+      callback(true);
+      return;
+    }
     if (permission !== "media") {
       callback(false);
       return;
@@ -158,10 +166,12 @@ function createMainWindow(): BrowserWindowInstance {
     const mediaTypes = "mediaTypes" in details ? details.mediaTypes : undefined;
     callback(isMicrophoneOnlyRequest(mediaTypes));
   });
-  session.setPermissionCheckHandler(
-    (_wc, permission, _origin, details) =>
-      permission === "media" && isMicrophoneCheck(details.mediaType)
-  );
+  session.setPermissionCheckHandler((_wc, permission, _origin, details) => {
+    if (permission === "clipboard-sanitized-write") {
+      return true;
+    }
+    return permission === "media" && isMicrophoneCheck(details.mediaType);
+  });
 
   // A single onHeadersReceived listener (Electron keeps only the most recent
   // one) that does two jobs:

--- a/apps/docs/src/content/changelog/2026-07.mdx
+++ b/apps/docs/src/content/changelog/2026-07.mdx
@@ -3,29 +3,20 @@ title: "July 2026"
 date: "2026-07-06"
 ---
 
-- PDF documents now open and preview correctly when you view them in Teak.
-- Web audio recording now works reliably in Chrome. Dragging, dropping, or pasting files now reports upload progress accurately, and saved link icons load more consistently.
-- File uploads now retry brief storage outages, so a first drag or paste is less likely to fail when storage returns a temporary error.
-- Settings and sign-in screens now show stable loading states instead of partial rows or empty cards.
-- Imports now keep progress visible after you reopen Settings, wrap long error reports inside the dialog, and stop cleanly when your card limit is reached.
-- Import uploads now connect reliably to storage, and API key management in Settings uses a cleaner table layout.
-- Search now clears stale cards when a query has no matches, so empty results show accurately instead of leaving older cards on screen.
-- The desktop app now uploads files reliably again.
-- The desktop app can now record audio notes. macOS will ask for microphone access the first time.
-- Import and Export now share one place in Settings, with a quick tab to switch between them. Imports show step-by-step progress and explain exactly which items were skipped or why any failed.
-- Exports show live progress while your archive is prepared and count down to when your next weekly export unlocks.
-- Raycast, desktop, and MCP clients now let you sign in with your browser in one step. Copying an API key is no longer required to get started, and existing keys keep working.
-- Signing out of the desktop app no longer signs you out of Teak in your browser.
+- The desktop app is here. Record audio notes (macOS asks for microphone access the first time), upload files reliably, and sign in through your browser in one step. Signing out of desktop no longer signs you out of Teak on the web.
 - Install Teak for Safari from the Mac App Store to save pages directly from the Safari toolbar.
-- API card lists now load reliably when a request scans more than one page of saved cards, and deleted cards stay hidden from direct API lookups.
-- Browser sign-in for MCP and API clients completes more reliably across apps that connect from another origin.
-- MCP clients now consistently discover Teak's public server address during browser sign-in.
-- The browser extension now signs you in through the web app, the same one-step browser sign-in used by the desktop app and Raycast.
-- Managing your subscription from Settings now opens reliably in Safari and other browsers.
-- Teak now has a command-line app for saving, searching, editing, favoriting, deleting, syncing, and listing tags from your terminal.
-- The API can now create file cards through direct uploads, so command-line workflows can save images, videos, audio, and documents.
-- API card lists can now include uploaded file names, sizes, and media types when metadata is requested.
-- The command-line app now signs in reliably from npm installs, includes setup docs directly on the npm package page, and ships an Agent Skill for AI assistants that work with Teak.
-- The API and MCP server now have simpler addresses at teakvault.com/api and teakvault.com/mcp. Existing api.teakvault.com links and API keys keep working, so no action is needed.
+- The browser extension now signs you in through the web app in one step.
+- Teak now has a command-line app to save, search, edit, favorite, delete, sync, and list tags from your terminal, with one-step browser sign-in and an Agent Skill for AI assistants.
+- Raycast, MCP, and API clients now sign in with your browser in one step, so copying an API key is optional and existing keys keep working.
+- The API and MCP server moved to simpler addresses at teakvault.com/api and teakvault.com/mcp. Existing api.teakvault.com links and API keys keep working, so no action is needed.
+- The API can now create file cards through direct uploads for images, video, audio, and documents, and card lists can include file names, sizes, and media types. Lists also load reliably across multiple pages, and deleted cards stay hidden from direct lookups.
 - MCP clients can now browse cards, look up a card, list tags, sync changes, run bulk edits, and create file-upload links.
-- Teak now works as a ChatGPT connector with search and fetch support, and the docs include AI-agent pages, markdown copies, and llms.txt files for easier setup.
+- Teak now works as a ChatGPT connector with search and fetch, plus new AI-agent docs pages for easier setup.
+- Import and Export now share one place in Settings with a quick tab to switch. Imports show step-by-step progress and explain exactly which items were skipped or failed, and exports show live progress with a countdown to your next weekly export.
+- Uploaded PDFs now show a page preview in your grid again, open and preview correctly, and web audio recording works reliably in Chrome.
+- Copying from the desktop app now works.
+- Saving colors or a color list as a note now creates a palette card again.
+- File uploads now report progress accurately and retry brief storage hiccups, so a first drag, drop, or paste is less likely to fail.
+- Search now clears old cards when a query has no matches, so empty results show accurately.
+- Settings and sign-in screens now show stable loading states, and managing your subscription opens reliably in Safari and other browsers.
+- Saving a web address now reliably creates a link card with a preview, even when it comes in as plain text.

--- a/apps/docs/src/content/docs/docs/self-hosting.mdx
+++ b/apps/docs/src/content/docs/docs/self-hosting.mdx
@@ -111,6 +111,10 @@ CONVEX_DEPLOY_KEY=
 NEXT_PUBLIC_CONVEX_URL=https://deployment.convex.cloud
 NEXT_PUBLIC_CONVEX_SITE_URL=https://deployment.convex.site
 TEAK_DEV_APP_URL=http://app.teak.localhost:1355   # Optional local override
+# Origin your R2 files are served from, so the Content-Security-Policy allows
+# loading images and documents. Set this to your bucket's public/signed-URL
+# origin (e.g. https://your-bucket.<account>.r2.cloudflarestorage.com).
+NEXT_PUBLIC_R2_STORAGE_ORIGIN=https://your-bucket.account.r2.cloudflarestorage.com
 ```
 
 ### Client Apps (`apps/mobile`, `apps/extension`, `apps/desktop`)

--- a/apps/web/src/__tests__/JsonLd.test.tsx
+++ b/apps/web/src/__tests__/JsonLd.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { JsonLd } from "@/components/JsonLd";
+
+describe("JsonLd", () => {
+  const schema = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "Teak",
+  } as const;
+
+  test("renders a JSON-LD data block", () => {
+    const element = JsonLd({ schema }) as {
+      props: Record<string, unknown>;
+    };
+
+    expect(element.props.type).toBe("application/ld+json");
+    const html = (element.props.dangerouslySetInnerHTML as { __html: string })
+      .__html;
+    expect(html).toContain('"@type":"Organization"');
+  });
+
+  test("does not set a nonce (regression: causes SSR/CSR hydration mismatch)", () => {
+    // A JSON-LD data block is not executable, so CSP does not require a nonce.
+    // Browsers blank the nonce attribute in the DOM after load, so rendering it
+    // makes the client tree mismatch the server-rendered HTML on hydration.
+    const element = JsonLd({ schema }) as {
+      props: Record<string, unknown>;
+    };
+
+    expect(element.props.nonce).toBeUndefined();
+    expect("nonce" in element.props).toBe(false);
+  });
+
+  test("escapes angle brackets to prevent script breakout", () => {
+    const element = JsonLd({
+      schema: {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        name: "</script><script>alert(1)</script>",
+      } as never,
+    }) as { props: Record<string, unknown> };
+
+    const html = (element.props.dangerouslySetInnerHTML as { __html: string })
+      .__html;
+    expect(html).not.toContain("</script>");
+    expect(html).toContain("\\u003c");
+  });
+});

--- a/apps/web/src/__tests__/securityHeaders.test.ts
+++ b/apps/web/src/__tests__/securityHeaders.test.ts
@@ -90,6 +90,63 @@ describe("web security headers", () => {
     }
   });
 
+  test("permits eval only in development for React/Next fast refresh", () => {
+    const previous = process.env.NODE_ENV;
+    const scriptTokens = () =>
+      buildContentSecurityPolicy(nonce)
+        .split("; ")
+        .find((directive) => directive.startsWith("script-src "))
+        ?.split(" ")
+        .slice(1) ?? [];
+    try {
+      process.env.NODE_ENV = "development";
+      expect(scriptTokens()).toContain("'unsafe-eval'");
+
+      process.env.NODE_ENV = "production";
+      expect(scriptTokens()).not.toContain("'unsafe-eval'");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previous;
+      }
+    }
+  });
+
+  test("allows configured R2 storage origins for images, media, uploads and frames", () => {
+    const previous = process.env.NEXT_PUBLIC_R2_STORAGE_ORIGIN;
+    process.env.NEXT_PUBLIC_R2_STORAGE_ORIGIN =
+      "https://teak-files-dev.example.r2.cloudflarestorage.com/path, http://unsafe.example, not-a-url";
+    try {
+      const policy = buildContentSecurityPolicy(nonce);
+      const tokens = (name: string) =>
+        policy
+          .split("; ")
+          .find((directive) => directive.startsWith(`${name} `))
+          ?.split(" ")
+          .slice(1) ?? [];
+
+      const devStorageOrigin =
+        "https://teak-files-dev.example.r2.cloudflarestorage.com";
+      expect(tokens("img-src")).toContain(devStorageOrigin);
+      expect(tokens("media-src")).toContain(devStorageOrigin);
+      expect(tokens("connect-src")).toContain(devStorageOrigin);
+      expect(tokens("frame-src")).toContain(devStorageOrigin);
+      expect(tokens("img-src")).not.toContain("http://unsafe.example");
+      // Exact origins only - never widened to a bare scheme or wildcard host.
+      expect(tokens("img-src")).not.toContain("https:");
+      expect(tokens("img-src")).not.toContain(
+        "https://*.r2.cloudflarestorage.com"
+      );
+    } finally {
+      if (previous === undefined) {
+        delete process.env.NEXT_PUBLIC_R2_STORAGE_ORIGIN;
+      } else {
+        process.env.NEXT_PUBLIC_R2_STORAGE_ORIGIN = previous;
+      }
+    }
+  });
+
   test("allows configured R2 upload origins only for browser uploads", () => {
     const previous = process.env.R2_ENDPOINT;
     process.env.R2_ENDPOINT =

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -32,7 +32,6 @@ export default async function RootLayout({ children }: PropsWithChildren) {
     <html lang="en" suppressHydrationWarning>
       <head>
         <JsonLd
-          nonce={nonce}
           schema={[
             organizationSchema,
             websiteSchema,

--- a/apps/web/src/components/JsonLd.tsx
+++ b/apps/web/src/components/JsonLd.tsx
@@ -3,7 +3,6 @@ import type { Thing, WithContext } from "schema-dts";
 type JsonLdSchema = WithContext<Thing> | WithContext<Thing>[];
 
 interface JsonLdProps {
-  nonce?: string;
   schema: JsonLdSchema;
 }
 
@@ -11,7 +10,7 @@ interface JsonLdProps {
  * Server-rendered JSON-LD structured data component for SEO.
  * Uses @graph pattern when combining multiple schemas.
  */
-export function JsonLd({ nonce, schema }: JsonLdProps) {
+export function JsonLd({ schema }: JsonLdProps) {
   const jsonLd = Array.isArray(schema)
     ? {
         "@context": "https://schema.org",
@@ -30,10 +29,13 @@ export function JsonLd({ nonce, schema }: JsonLdProps) {
   const serialized = JSON.stringify(jsonLd).replace(/</g, "\\u003c");
 
   return (
+    // A JSON-LD data block (type="application/ld+json") is not executable
+    // JavaScript, so CSP script-src does not apply and no nonce is needed.
+    // Adding a nonce here only causes an SSR/CSR hydration mismatch because the
+    // browser blanks the nonce attribute in the DOM after load.
     <script
       // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD requires script injection, content is JSON.stringify'd and `<` is escaped
       dangerouslySetInnerHTML={{ __html: serialized }}
-      nonce={nonce}
       type="application/ld+json"
     />
   );

--- a/apps/web/src/lib/security-headers.ts
+++ b/apps/web/src/lib/security-headers.ts
@@ -21,6 +21,26 @@ const normalizeHttpsOrigin = (value: string): string | null => {
   }
 };
 
+const configuredR2StorageSources = () => {
+  const values = [
+    process.env.NEXT_PUBLIC_R2_STORAGE_ORIGIN,
+    process.env.NEXT_PUBLIC_R2_STORAGE_URL,
+    process.env.R2_STORAGE_ORIGIN,
+    process.env.R2_STORAGE_URL,
+  ];
+  return Array.from(
+    new Set(
+      values.flatMap(
+        (value) =>
+          value
+            ?.split(",")
+            .map((item) => normalizeHttpsOrigin(item.trim()))
+            .filter((item): item is string => Boolean(item)) ?? []
+      )
+    )
+  );
+};
+
 const configuredR2FrameSources = () => {
   const values = [
     process.env.NEXT_PUBLIC_R2_PUBLIC_ORIGIN,
@@ -73,13 +93,22 @@ export const buildContentSecurityPolicy = (nonce: string) =>
     [
       "img-src 'self' blob: data:",
       TEAK_R2_STORAGE_ORIGIN,
+      ...configuredR2StorageSources(),
       "https://www.google.com",
       "https://*.gstatic.com",
       "https://*.teakvault.com",
     ].join(" "),
     "font-src 'self' data:",
     "style-src 'self' 'unsafe-inline'",
-    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' blob:`,
+    [
+      "script-src 'self'",
+      `'nonce-${nonce}'`,
+      "'strict-dynamic'",
+      "blob:",
+      // Next.js/React development mode relies on eval() for Fast Refresh and
+      // for reconstructing callstacks. Only permitted outside production.
+      ...(process.env.NODE_ENV === "development" ? ["'unsafe-eval'"] : []),
+    ].join(" "),
     [
       "connect-src 'self'",
       "https://*.convex.cloud",
@@ -90,12 +119,18 @@ export const buildContentSecurityPolicy = (nonce: string) =>
       "https://polar.sh",
       "https://*.polar.sh",
       TEAK_R2_STORAGE_ORIGIN,
+      ...configuredR2StorageSources(),
       ...configuredR2UploadSources(),
     ].join(" "),
-    ["media-src 'self' blob: data:", TEAK_R2_STORAGE_ORIGIN].join(" "),
+    [
+      "media-src 'self' blob: data:",
+      TEAK_R2_STORAGE_ORIGIN,
+      ...configuredR2StorageSources(),
+    ].join(" "),
     [
       "frame-src https://*.polar.sh https://polar.sh",
       TEAK_R2_STORAGE_ORIGIN,
+      ...configuredR2StorageSources(),
       ...R2_FRAME_SOURCES,
       ...configuredR2FrameSources(),
     ].join(" "),

--- a/packages/convex/__tests__/card/createCard.test.ts
+++ b/packages/convex/__tests__/card/createCard.test.ts
@@ -127,6 +127,104 @@ describe("card/createCard.ts", () => {
     );
   });
 
+  test("upgrades to link card when content is a URL but type is explicitly text", async () => {
+    // Regression: saving a URL (e.g. a Goodreads book link) was stored as a
+    // "text" card whenever the client passed type: "text" explicitly, because
+    // the extracted URL never upgraded the card type and async classification
+    // was skipped for client-provided types.
+    const ctx = {
+      auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
+      db: {
+        system: { get: mock().mockResolvedValue(null) },
+        query: mock().mockReturnValue({
+          withIndex: mock().mockReturnValue({
+            collect: mock().mockResolvedValue([]),
+            take: mock().mockResolvedValue([]),
+          }),
+        }),
+        insert: mock().mockResolvedValue("c_goodreads"),
+      },
+      scheduler: { runAfter: mock().mockResolvedValue(null) },
+    } as any;
+
+    const handler = (createCard as any).handler ?? createCard;
+    await handler(ctx, {
+      content: "https://www.goodreads.com/book/show/2767052-the-hunger-games",
+      type: "text",
+    });
+
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      "cards",
+      expect.objectContaining({
+        type: "link",
+        metadataStatus: "pending",
+        url: "https://www.goodreads.com/book/show/2767052-the-hunger-games",
+      })
+    );
+  });
+
+  test("upgrades to link card when content is a URL and type is omitted", async () => {
+    const ctx = {
+      auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
+      db: {
+        system: { get: mock().mockResolvedValue(null) },
+        query: mock().mockReturnValue({
+          withIndex: mock().mockReturnValue({
+            collect: mock().mockResolvedValue([]),
+            take: mock().mockResolvedValue([]),
+          }),
+        }),
+        insert: mock().mockResolvedValue("c_link_auto"),
+      },
+      scheduler: { runAfter: mock().mockResolvedValue(null) },
+    } as any;
+
+    const handler = (createCard as any).handler ?? createCard;
+    await handler(ctx, {
+      content: "https://www.goodreads.com/book/show/2767052-the-hunger-games",
+    });
+
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      "cards",
+      expect.objectContaining({
+        type: "link",
+        metadataStatus: "pending",
+        url: "https://www.goodreads.com/book/show/2767052-the-hunger-games",
+      })
+    );
+  });
+
+  test("keeps text card when content has no URL", async () => {
+    const ctx = {
+      auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
+      db: {
+        system: { get: mock().mockResolvedValue(null) },
+        query: mock().mockReturnValue({
+          withIndex: mock().mockReturnValue({
+            collect: mock().mockResolvedValue([]),
+            take: mock().mockResolvedValue([]),
+          }),
+        }),
+        insert: mock().mockResolvedValue("c_text"),
+      },
+      scheduler: { runAfter: mock().mockResolvedValue(null) },
+    } as any;
+
+    const handler = (createCard as any).handler ?? createCard;
+    await handler(ctx, {
+      content: "just a regular note without any links",
+      type: "text",
+    });
+
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      "cards",
+      expect.objectContaining({
+        type: "text",
+        content: "just a regular note without any links",
+      })
+    );
+  });
+
   test("rejects unsafe url schemes", async () => {
     const ctx = {
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },

--- a/packages/convex/__tests__/card/createCard.test.ts
+++ b/packages/convex/__tests__/card/createCard.test.ts
@@ -127,11 +127,11 @@ describe("card/createCard.ts", () => {
     );
   });
 
-  test("upgrades to link card when content is a URL but type is explicitly text", async () => {
-    // Regression: saving a URL (e.g. a Goodreads book link) was stored as a
-    // "text" card whenever the client passed type: "text" explicitly, because
-    // the extracted URL never upgraded the card type and async classification
-    // was skipped for client-provided types.
+  test("honors an explicit text type for a note that mentions a URL", async () => {
+    // Regression: a caller that deliberately saves a note as text (e.g.
+    // "I read this at https://example.com") should keep a text card. The
+    // backend only auto-upgrades URL content to a link when no type is
+    // provided, so an explicit type is always honored.
     const ctx = {
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -142,28 +142,26 @@ describe("card/createCard.ts", () => {
             take: mock().mockResolvedValue([]),
           }),
         }),
-        insert: mock().mockResolvedValue("c_goodreads"),
+        insert: mock().mockResolvedValue("c_text_url"),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
     } as any;
 
     const handler = (createCard as any).handler ?? createCard;
     await handler(ctx, {
-      content: "https://www.goodreads.com/book/show/2767052-the-hunger-games",
+      content: "I read this at https://example.com",
       type: "text",
     });
 
     expect(ctx.db.insert).toHaveBeenCalledWith(
       "cards",
       expect.objectContaining({
-        type: "link",
-        metadataStatus: "pending",
-        url: "https://www.goodreads.com/book/show/2767052-the-hunger-games",
+        type: "text",
       })
     );
   });
 
-  test("upgrades to link card when content is a URL and type is omitted", async () => {
+  test("lets the backend upgrade a URL to a link card when type is omitted", async () => {
     const ctx = {
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {

--- a/packages/convex/__tests__/workflows/steps/classification.test.ts
+++ b/packages/convex/__tests__/workflows/steps/classification.test.ts
@@ -333,6 +333,19 @@ describe("classification step", () => {
       expect(result.confidence).toBe(0.88);
     });
 
+    test("detects palette from a single hex color", async () => {
+      const card = {
+        _id: "c1",
+        content: "#2050D0",
+      };
+      mockRunQuery.mockResolvedValue(card);
+
+      const result = await classify(mockCtx, { cardId: "c1" });
+
+      expect(result.type).toBe("palette");
+      expect(result.confidence).toBe(0.88);
+    });
+
     test("detects palette from color names", async () => {
       const card = {
         _id: "c1",

--- a/packages/convex/__tests__/workflows/steps/renderables/generatePdfThumbnail.test.ts
+++ b/packages/convex/__tests__/workflows/steps/renderables/generatePdfThumbnail.test.ts
@@ -1,0 +1,141 @@
+// @ts-nocheck
+import { beforeAll, describe, expect, mock, test } from "bun:test";
+
+// Captured across the mocked Kernel + storage layer so the assertions can
+// inspect exactly how the PDF thumbnail was produced.
+let capturedPlaywrightCode = "";
+let fetchedUrls: string[] = [];
+let storedThumbnail: { key: string; type?: string } | null = null;
+
+let generatePdfThumbnail: any;
+
+const PDF_BYTES_BASE64 = Buffer.from("%PDF-1.7 fake").toString("base64");
+const THUMB_PNG_BASE64 = Buffer.from("fake-png").toString("base64");
+
+beforeAll(async () => {
+  // Kernel headless browser: return a canvas screenshot payload and record the
+  // Playwright code so we can assert how the PDF is rendered.
+  mock.module("@onkernel/sdk", () => ({
+    default: class KernelMock {
+      browsers = {
+        create: () => Promise.resolve({ session_id: "session-1" }),
+        deleteByID: () => Promise.resolve(undefined),
+        playwright: {
+          execute: (_sessionId: string, opts: { code: string }) => {
+            capturedPlaywrightCode = opts.code;
+            return Promise.resolve({
+              success: true,
+              result: JSON.stringify({
+                success: true,
+                data: THUMB_PNG_BASE64,
+                width: 400,
+                height: 560,
+              }),
+            });
+          },
+        },
+      };
+    },
+  }));
+
+  // Replace the R2 storage layer so the test never touches the network/S3.
+  const r2Path = import.meta.resolve("../../../../storage/r2");
+  mock.module(r2Path, () => ({
+    buildR2ObjectKey: () => "users/u/cards/c/thumbnail/generated",
+    resolveObjectUrl: (key?: string) =>
+      Promise.resolve(key ? "https://signed.r2.example/the-pdf" : null),
+    storeObject: (
+      _ctx: unknown,
+      _blob: unknown,
+      opts: { key: string; type?: string }
+    ) => {
+      storedThumbnail = { key: opts.key, type: opts.type };
+      return Promise.resolve("stored-thumbnail-key");
+    },
+  }));
+
+  // The action downloads the PDF bytes itself (bypassing browser CORS).
+  globalThis.fetch = ((url: string) => {
+    fetchedUrls.push(String(url));
+    return Promise.resolve({
+      ok: true,
+      statusText: "OK",
+      arrayBuffer: () =>
+        Promise.resolve(Buffer.from(PDF_BYTES_BASE64, "base64").buffer),
+    } as unknown as Response);
+  }) as typeof fetch;
+
+  generatePdfThumbnail = (
+    await import("../../../../workflows/steps/renderables/generatePdfThumbnail")
+  ).generatePdfThumbnail;
+});
+
+const pdfCard = {
+  _id: "card-pdf",
+  userId: "user-1",
+  type: "document",
+  fileKey: "users/u/cards/c/file/original",
+  fileMetadata: { mimeType: "application/pdf" },
+};
+
+const createCtx = (card: unknown) => {
+  const mutationCalls: Array<{ ref: unknown; args: any }> = [];
+  return {
+    ctx: {
+      runQuery: () => Promise.resolve(card),
+      runMutation: (ref: unknown, args: any) => {
+        mutationCalls.push({ ref, args });
+        return Promise.resolve(null);
+      },
+    },
+    mutationCalls,
+  };
+};
+
+describe("generatePdfThumbnail", () => {
+  test("downloads the PDF server-side and stores a rendered thumbnail", async () => {
+    fetchedUrls = [];
+    storedThumbnail = null;
+    const { ctx, mutationCalls } = createCtx(pdfCard);
+
+    const result = await generatePdfThumbnail(ctx, { cardId: "card-pdf" });
+
+    expect(result.success).toBe(true);
+    expect(result.generated).toBe(true);
+    expect(result.thumbnailKey).toBe("stored-thumbnail-key");
+
+    // The bytes are fetched on the server (the fix for R2 signed-URL CORS),
+    // not handed to an external browser as a cross-origin URL.
+    expect(fetchedUrls).toContain("https://signed.r2.example/the-pdf");
+
+    // A PNG thumbnail is persisted and written back to the card.
+    expect(storedThumbnail?.type).toBe("image/png");
+    expect(mutationCalls).toHaveLength(1);
+    expect(mutationCalls[0]?.args.thumbnailKey).toBe("stored-thumbnail-key");
+  });
+
+  test("renders via injected pdf.js, never the external Mozilla viewer", async () => {
+    // Regression guard: the previous implementation loaded the signed storage
+    // URL inside Mozilla's hosted pdf.js viewer, which broke once files moved
+    // to R2 (no CORS on signed URLs). Rendering must stay self-contained.
+    const { ctx } = createCtx(pdfCard);
+    await generatePdfThumbnail(ctx, { cardId: "card-pdf" });
+
+    expect(capturedPlaywrightCode).not.toContain("mozilla.github.io");
+    expect(capturedPlaywrightCode).not.toContain("viewer.html");
+    expect(capturedPlaywrightCode.toLowerCase()).toContain("pdfjslib");
+  });
+
+  test("skips non-PDF documents without generating a thumbnail", async () => {
+    const { ctx, mutationCalls } = createCtx({
+      ...pdfCard,
+      fileMetadata: { mimeType: "application/msword" },
+    });
+
+    const result = await generatePdfThumbnail(ctx, { cardId: "card-pdf" });
+
+    expect(result.success).toBe(true);
+    expect(result.generated).toBe(false);
+    expect(mutationCalls).toHaveLength(0);
+  });
+});

--- a/packages/convex/__tests__/workflows/steps/renderables/generatePdfThumbnail.test.ts
+++ b/packages/convex/__tests__/workflows/steps/renderables/generatePdfThumbnail.test.ts
@@ -4,12 +4,10 @@ import { beforeAll, describe, expect, mock, test } from "bun:test";
 // Captured across the mocked Kernel + storage layer so the assertions can
 // inspect exactly how the PDF thumbnail was produced.
 let capturedPlaywrightCode = "";
-let fetchedUrls: string[] = [];
 let storedThumbnail: { key: string; type?: string } | null = null;
 
 let generatePdfThumbnail: any;
 
-const PDF_BYTES_BASE64 = Buffer.from("%PDF-1.7 fake").toString("base64");
 const THUMB_PNG_BASE64 = Buffer.from("fake-png").toString("base64");
 
 beforeAll(async () => {
@@ -54,17 +52,6 @@ beforeAll(async () => {
     },
   }));
 
-  // The action downloads the PDF bytes itself (bypassing browser CORS).
-  globalThis.fetch = ((url: string) => {
-    fetchedUrls.push(String(url));
-    return Promise.resolve({
-      ok: true,
-      statusText: "OK",
-      arrayBuffer: () =>
-        Promise.resolve(Buffer.from(PDF_BYTES_BASE64, "base64").buffer),
-    } as unknown as Response);
-  }) as typeof fetch;
-
   generatePdfThumbnail = (
     await import("../../../../workflows/steps/renderables/generatePdfThumbnail")
   ).generatePdfThumbnail;
@@ -93,8 +80,7 @@ const createCtx = (card: unknown) => {
 };
 
 describe("generatePdfThumbnail", () => {
-  test("downloads the PDF server-side and stores a rendered thumbnail", async () => {
-    fetchedUrls = [];
+  test("fetches the PDF inside the VM and stores a rendered thumbnail", async () => {
     storedThumbnail = null;
     const { ctx, mutationCalls } = createCtx(pdfCard);
 
@@ -104,14 +90,30 @@ describe("generatePdfThumbnail", () => {
     expect(result.generated).toBe(true);
     expect(result.thumbnailKey).toBe("stored-thumbnail-key");
 
-    // The bytes are fetched on the server (the fix for R2 signed-URL CORS),
-    // not handed to an external browser as a cross-origin URL.
-    expect(fetchedUrls).toContain("https://signed.r2.example/the-pdf");
+    // The signed URL is fetched inside the browser VM via Playwright's request
+    // context (the fix for R2 signed-URL CORS) instead of a cross-origin
+    // browser fetch, so only the URL — never the document bytes — is embedded.
+    expect(capturedPlaywrightCode).toContain("context.request");
+    expect(capturedPlaywrightCode).toContain("https://signed.r2.example/the-pdf");
 
     // A PNG thumbnail is persisted and written back to the card.
     expect(storedThumbnail?.type).toBe("image/png");
     expect(mutationCalls).toHaveLength(1);
     expect(mutationCalls[0]?.args.thumbnailKey).toBe("stored-thumbnail-key");
+  });
+
+  test("never inlines the PDF bytes into the Kernel code payload", async () => {
+    // Regression (Greptile P1): embedding the full base64 PDF into the
+    // Playwright source made large-but-valid PDFs exceed the execute payload
+    // limit and fail before pdf.js could render. The document must be fetched
+    // inside the VM, so the code passes the bytes as a runtime variable rather
+    // than interpolating a giant literal string.
+    const { ctx } = createCtx(pdfCard);
+    await generatePdfThumbnail(ctx, { cardId: "card-pdf" });
+
+    // The base64 payload is a runtime variable, not a quoted literal.
+    expect(capturedPlaywrightCode).not.toContain("pdfBase64: '");
+    expect(capturedPlaywrightCode).toContain("const pdfBase64 = pdfBuffer.toString('base64')");
   });
 
   test("renders via injected pdf.js, never the external Mozilla viewer", async () => {

--- a/packages/convex/card/createCard.ts
+++ b/packages/convex/card/createCard.ts
@@ -128,6 +128,15 @@ export const createCardForUserHandler = async (
     finalContent = urlExtraction.cleanedContent;
   }
 
+  // If we resolved a URL but the type is still "text" (either defaulted or
+  // provided explicitly by a client that couldn't detect the link), treat it
+  // as a link card. This mirrors the deterministic classifier, which always
+  // upgrades URL-bearing cards to "link", and prevents links from sticking as
+  // text when an explicit type skips async classification.
+  if (finalUrl && cardType === "text") {
+    cardType = "link";
+  }
+
   const quoteNormalization = normalizeQuoteContent(finalContent);
   const shouldDefaultToQuote =
     !providedType && quoteNormalization.removedQuotes;

--- a/packages/convex/card/createCard.ts
+++ b/packages/convex/card/createCard.ts
@@ -128,12 +128,13 @@ export const createCardForUserHandler = async (
     finalContent = urlExtraction.cleanedContent;
   }
 
-  // If we resolved a URL but the type is still "text" (either defaulted or
-  // provided explicitly by a client that couldn't detect the link), treat it
-  // as a link card. This mirrors the deterministic classifier, which always
-  // upgrades URL-bearing cards to "link", and prevents links from sticking as
-  // text when an explicit type skips async classification.
-  if (finalUrl && cardType === "text") {
+  // When the client does not specify a type, let the backend decide: a resolved
+  // URL upgrades the card to "link". This mirrors the deterministic classifier
+  // (which always upgrades URL-bearing cards) and prevents links from sticking
+  // as "text" before async classification runs. An explicit type is always
+  // honored, so a note like "I read this at https://example.com" that a client
+  // deliberately saves as text stays a text card.
+  if (finalUrl && !providedType && cardType === "text") {
     cardType = "link";
   }
 

--- a/packages/convex/shared/utils/linkDetection.test.ts
+++ b/packages/convex/shared/utils/linkDetection.test.ts
@@ -122,6 +122,15 @@ describe("extractUrlFromContent", () => {
       cleanedContent: "https://müller.de/path",
     });
   });
+
+  it("should extract a Goodreads book URL with a slug in the path", () => {
+    const url = "https://www.goodreads.com/book/show/2767052-the-hunger-games";
+    const result = extractUrlFromContent(url);
+    expect(result).toEqual({
+      url,
+      cleanedContent: url,
+    });
+  });
 });
 
 describe("resolveTextCardInput", () => {
@@ -254,6 +263,16 @@ describe("resolveTextCardInput", () => {
       type: "link",
       url: "https://example.com",
       content: "https://example.com",
+    });
+  });
+
+  it("should resolve a Goodreads book URL in content to a link card", () => {
+    const url = "https://www.goodreads.com/book/show/2767052-the-hunger-games";
+    const result = resolveTextCardInput({ content: url });
+    expect(result).toEqual({
+      type: "link",
+      url,
+      content: url,
     });
   });
 });

--- a/packages/convex/workflows/steps/renderables/generatePdfThumbnail.ts
+++ b/packages/convex/workflows/steps/renderables/generatePdfThumbnail.ts
@@ -15,30 +15,18 @@ const THUMBNAIL_MAX_WIDTH = 400;
 
 // pdf.js is loaded directly into the headless browser so we render the first
 // page ourselves instead of relying on Mozilla's externally hosted viewer.
-// Rendering from bytes we inject avoids cross-origin fetch/CORS issues with
-// storage URLs (R2 signed URLs do not send permissive CORS headers).
+// The PDF bytes are fetched inside the Kernel VM with Playwright's request
+// context (a Node-side request that ignores browser CORS), which avoids the
+// cross-origin fetch issues with R2 signed URLs.
 const PDFJS_VERSION = "3.11.174";
 const PDFJS_LIB_URL = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${PDFJS_VERSION}/pdf.min.js`;
 const PDFJS_WORKER_URL = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${PDFJS_VERSION}/pdf.worker.min.js`;
 
 /**
- * Fetch the PDF from storage server-side and return it as a base64 string.
- * Storage URLs are not guaranteed to be reachable (with CORS) from an external
- * browser, so we download the bytes here and hand them to the browser directly.
- */
-async function fetchPdfAsBase64(pdfUrl: string): Promise<string> {
-  const response = await fetch(pdfUrl);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch PDF: ${response.statusText}`);
-  }
-  const arrayBuffer = await response.arrayBuffer();
-  return Buffer.from(arrayBuffer).toString("base64");
-}
-
-/**
  * Generate a thumbnail image from the first page of a PDF document.
  * Uses @onkernel/sdk with Playwright + pdf.js to render the PDF in a headless
- * browser from bytes fetched server-side.
+ * browser. The document is downloaded inside the browser VM so the bytes are
+ * never embedded into the code payload sent to Kernel.
  */
 export const generatePdfThumbnail = internalAction({
   args: {
@@ -115,24 +103,6 @@ export const generatePdfThumbnail = internalAction({
 
       console.log(`[renderables/pdf] Processing PDF for card ${args.cardId}`);
 
-      // Download the PDF bytes server-side (bypasses CORS issues) and pass them
-      // to the browser as base64 for rendering.
-      let pdfBase64: string;
-      try {
-        pdfBase64 = await fetchPdfAsBase64(pdfUrl);
-      } catch (fetchError) {
-        console.error(
-          `[renderables/pdf] Failed to fetch PDF content for card ${args.cardId}:`,
-          fetchError
-        );
-        return {
-          success: false,
-          generated: false,
-          error:
-            fetchError instanceof Error ? fetchError.message : "fetch_failed",
-        };
-      }
-
       // Use Kernel with Playwright + pdf.js to render the first page
       const kernel = new Kernel();
       let kernelBrowser: { session_id: string } | undefined;
@@ -143,17 +113,28 @@ export const generatePdfThumbnail = internalAction({
           stealth: true,
         });
 
-        // Execute Playwright code that loads pdf.js and renders page 1 to a
-        // canvas entirely from the injected bytes.
+        // Execute Playwright code that fetches the PDF inside the VM, loads
+        // pdf.js, and renders page 1 to a canvas. Fetching the bytes here (via
+        // Playwright's request context, which ignores browser CORS) keeps the
+        // multi-MB document out of this code payload — only the URL is embedded.
         const response = await kernel.browsers.playwright.execute(
           kernelBrowser.session_id,
           {
             code: `
               await page.setViewportSize({ width: ${THUMBNAIL_MAX_WIDTH + 50}, height: 700 });
 
+              // Fetch the PDF bytes inside the VM (bypasses browser CORS) so the
+              // document never has to be inlined into this code string.
+              const pdfResponse = await context.request.get(${JSON.stringify(pdfUrl)});
+              if (!pdfResponse.ok()) {
+                return JSON.stringify({ success: false, error: 'fetch_failed_' + pdfResponse.status() });
+              }
+              const pdfBuffer = await pdfResponse.body();
+              const pdfBase64 = pdfBuffer.toString('base64');
+
               // Load a blank page and inject the pdf.js library.
               await page.goto('about:blank');
-              await page.addScriptTag({ url: '${PDFJS_LIB_URL}' });
+              await page.addScriptTag({ url: ${JSON.stringify(PDFJS_LIB_URL)} });
 
               const result = await page.evaluate(async ({ pdfBase64, workerSrc, maxWidth }) => {
                 try {
@@ -203,8 +184,8 @@ export const generatePdfThumbnail = internalAction({
                   return { success: false, error: (err && err.message) || 'pdf render error' };
                 }
               }, {
-                pdfBase64: '${pdfBase64}',
-                workerSrc: '${PDFJS_WORKER_URL}',
+                pdfBase64,
+                workerSrc: ${JSON.stringify(PDFJS_WORKER_URL)},
                 maxWidth: ${THUMBNAIL_MAX_WIDTH}
               });
 

--- a/packages/convex/workflows/steps/renderables/generatePdfThumbnail.ts
+++ b/packages/convex/workflows/steps/renderables/generatePdfThumbnail.ts
@@ -13,9 +13,32 @@ import {
 // Maximum thumbnail width - height will scale proportionally to maintain document aspect ratio
 const THUMBNAIL_MAX_WIDTH = 400;
 
+// pdf.js is loaded directly into the headless browser so we render the first
+// page ourselves instead of relying on Mozilla's externally hosted viewer.
+// Rendering from bytes we inject avoids cross-origin fetch/CORS issues with
+// storage URLs (R2 signed URLs do not send permissive CORS headers).
+const PDFJS_VERSION = "3.11.174";
+const PDFJS_LIB_URL = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${PDFJS_VERSION}/pdf.min.js`;
+const PDFJS_WORKER_URL = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/${PDFJS_VERSION}/pdf.worker.min.js`;
+
+/**
+ * Fetch the PDF from storage server-side and return it as a base64 string.
+ * Storage URLs are not guaranteed to be reachable (with CORS) from an external
+ * browser, so we download the bytes here and hand them to the browser directly.
+ */
+async function fetchPdfAsBase64(pdfUrl: string): Promise<string> {
+  const response = await fetch(pdfUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch PDF: ${response.statusText}`);
+  }
+  const arrayBuffer = await response.arrayBuffer();
+  return Buffer.from(arrayBuffer).toString("base64");
+}
+
 /**
  * Generate a thumbnail image from the first page of a PDF document.
- * Uses @onkernel/sdk with Playwright to render the PDF in a headless browser.
+ * Uses @onkernel/sdk with Playwright + pdf.js to render the PDF in a headless
+ * browser from bytes fetched server-side.
  */
 export const generatePdfThumbnail = internalAction({
   args: {
@@ -92,7 +115,25 @@ export const generatePdfThumbnail = internalAction({
 
       console.log(`[renderables/pdf] Processing PDF for card ${args.cardId}`);
 
-      // Use Kernel with Playwright to render the PDF
+      // Download the PDF bytes server-side (bypasses CORS issues) and pass them
+      // to the browser as base64 for rendering.
+      let pdfBase64: string;
+      try {
+        pdfBase64 = await fetchPdfAsBase64(pdfUrl);
+      } catch (fetchError) {
+        console.error(
+          `[renderables/pdf] Failed to fetch PDF content for card ${args.cardId}:`,
+          fetchError
+        );
+        return {
+          success: false,
+          generated: false,
+          error:
+            fetchError instanceof Error ? fetchError.message : "fetch_failed",
+        };
+      }
+
+      // Use Kernel with Playwright + pdf.js to render the first page
       const kernel = new Kernel();
       let kernelBrowser: { session_id: string } | undefined;
 
@@ -102,58 +143,72 @@ export const generatePdfThumbnail = internalAction({
           stealth: true,
         });
 
-        // Execute Playwright code to render PDF and capture screenshot
-        // Use Mozilla's PDF.js viewer which is hosted and works reliably
+        // Execute Playwright code that loads pdf.js and renders page 1 to a
+        // canvas entirely from the injected bytes.
         const response = await kernel.browsers.playwright.execute(
           kernelBrowser.session_id,
           {
             code: `
-              // Set viewport size
               await page.setViewportSize({ width: ${THUMBNAIL_MAX_WIDTH + 50}, height: 700 });
-              
-              // Use Mozilla's hosted PDF.js viewer
-              const viewerUrl = 'https://mozilla.github.io/pdf.js/web/viewer.html?file=' + encodeURIComponent('${pdfUrl.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}');
-              
-              await page.goto(viewerUrl, { 
-                waitUntil: 'networkidle',
-                timeout: 60000 
+
+              // Load a blank page and inject the pdf.js library.
+              await page.goto('about:blank');
+              await page.addScriptTag({ url: '${PDFJS_LIB_URL}' });
+
+              const result = await page.evaluate(async ({ pdfBase64, workerSrc, maxWidth }) => {
+                try {
+                  const pdfjsLib = window['pdfjsLib'];
+                  if (!pdfjsLib) {
+                    return { success: false, error: 'pdf.js failed to load' };
+                  }
+                  pdfjsLib.GlobalWorkerOptions.workerSrc = workerSrc;
+
+                  // Decode base64 into a byte array.
+                  const binary = atob(pdfBase64);
+                  const bytes = new Uint8Array(binary.length);
+                  for (let i = 0; i < binary.length; i++) {
+                    bytes[i] = binary.charCodeAt(i);
+                  }
+
+                  const pdf = await pdfjsLib.getDocument({ data: bytes }).promise;
+                  const pdfPage = await pdf.getPage(1);
+
+                  // Scale the first page down to the target thumbnail width.
+                  const baseViewport = pdfPage.getViewport({ scale: 1 });
+                  const scale = Math.min(maxWidth / baseViewport.width, 3);
+                  const viewport = pdfPage.getViewport({ scale });
+
+                  const canvas = document.createElement('canvas');
+                  const ctx = canvas.getContext('2d');
+                  if (!ctx) {
+                    return { success: false, error: 'Could not get canvas context' };
+                  }
+                  canvas.width = Math.ceil(viewport.width);
+                  canvas.height = Math.ceil(viewport.height);
+
+                  // Flatten transparency onto white so the thumbnail looks like paper.
+                  ctx.fillStyle = '#ffffff';
+                  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+                  await pdfPage.render({ canvasContext: ctx, viewport }).promise;
+
+                  const dataUrl = canvas.toDataURL('image/png');
+                  return {
+                    success: true,
+                    data: dataUrl.split(',')[1],
+                    width: canvas.width,
+                    height: canvas.height,
+                  };
+                } catch (err) {
+                  return { success: false, error: (err && err.message) || 'pdf render error' };
+                }
+              }, {
+                pdfBase64: '${pdfBase64}',
+                workerSrc: '${PDFJS_WORKER_URL}',
+                maxWidth: ${THUMBNAIL_MAX_WIDTH}
               });
-              
-              // Wait for PDF to render - look for the canvas element
-              await page.waitForSelector('#viewer .page canvas', { timeout: 30000 });
-              
-              // Wait a bit more for rendering to complete
-              await new Promise(r => setTimeout(r, 2000));
-              
-              // Inject CSS to remove shadows and gray areas
-              await page.addStyleTag({
-                content: \`
-                  body, html { 
-                    margin: 0 !important;
-                    padding: 0 !important;
-                    box-shadow: none !important;
-                    border: none !important;
-                  }
-                  .page { 
-                    box-shadow: none !important; 
-                    border: none !important;
-                    margin: 0 !important;
-                  }
-                  .page canvas {
-                    box-shadow: none !important;
-                    border: none !important;
-                  }
-                \`
-              });
-              
-              // Get the canvas element directly for a clean screenshot
-              const canvas = await page.$('#viewer .page canvas');
-              if (!canvas) {
-                throw new Error('Could not find PDF canvas element');
-              }
-              
-              const screenshot = await canvas.screenshot({ type: 'png' });
-              return screenshot.toString('base64');
+
+              return JSON.stringify(result);
             `,
             timeout_sec: 120,
           }
@@ -171,7 +226,21 @@ export const generatePdfThumbnail = internalAction({
           };
         }
 
-        const base64Screenshot = response.result as string;
+        const result = JSON.parse(response.result as string);
+
+        if (!result.success) {
+          console.error(
+            `[renderables/pdf] PDF thumbnail generation failed for card ${args.cardId}:`,
+            result.error
+          );
+          return {
+            success: false,
+            generated: false,
+            error: result.error || "thumbnail_generation_failed",
+          };
+        }
+
+        const base64Screenshot = result.data as string;
         const buffer = Buffer.from(base64Screenshot, "base64");
         const imageArrayBuffer = buffer.buffer.slice(
           buffer.byteOffset,
@@ -190,12 +259,17 @@ export const generatePdfThumbnail = internalAction({
           type: "image/png",
         });
 
-        // Update the card with the thumbnail
+        const originalWidth = result.width as number | undefined;
+        const originalHeight = result.height as number | undefined;
+
+        // Update the card with the thumbnail (and dimensions for aspect ratio)
         await ctx.runMutation(
           internal.workflows.steps.renderables.mutations.updateCardThumbnail,
           {
             cardId: args.cardId,
             thumbnailKey,
+            ...(originalWidth !== undefined && { originalWidth }),
+            ...(originalHeight !== undefined && { originalHeight }),
           }
         );
 

--- a/packages/tests/src/journey/02-web-journey.e2e.ts
+++ b/packages/tests/src/journey/02-web-journey.e2e.ts
@@ -79,3 +79,35 @@ test("web journey covers cards, search, settings, upload, and revoked key", asyn
   });
   expect(dialogTrap).toEqual([]);
 });
+
+test("saving a color in the composer creates a palette card", async ({
+  page,
+}) => {
+  // Regression: the web note composer forced type "text", which disabled
+  // server-side classification, so colors stopped becoming palette cards.
+  const state = readState();
+  if (!state.primary?.apiKey) {
+    throw new Error("Missing primary API key");
+  }
+  const hex = "#2050D0";
+
+  await page.goto("/");
+  await page.getByPlaceholder(/Write a note/i).fill(hex);
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  // The optimistic card appears immediately; classification runs server-side.
+  await expect(
+    page.locator("main").getByText(hex, { exact: true }).first()
+  ).toBeVisible();
+
+  // Poll the API until the composer-created card is classified as a palette.
+  const api = clientFor(state.primary.apiKey);
+  await expect
+    .poll(
+      async () => {
+        const result = await api.cards.search({ type: "palette" });
+        return result.items.some((card) => card.content === hex);
+      },
+      { timeout: 30_000, intervals: [1000, 2000, 3000, 5000] }
+    )
+    .toBe(true);
+});

--- a/packages/tests/src/journey/03-api.e2e.ts
+++ b/packages/tests/src/journey/03-api.e2e.ts
@@ -67,3 +67,71 @@ test("REST API happy paths and OpenAPI contracts", async () => {
     404
   );
 });
+
+test("saving a URL as content creates a link card, not a text card", async () => {
+  // Regression: a bare URL (e.g. a Goodreads book link) submitted as card
+  // content was stored as a "text" card instead of being recognized as a link.
+  const { primary } = readState();
+  if (!primary?.apiKey) {
+    throw new Error("Missing primary API key");
+  }
+  const bookUrl =
+    "https://www.goodreads.com/book/show/2767052-the-hunger-games";
+  const created = await apiFetch("/v1/cards", primary.apiKey, {
+    method: "POST",
+    body: JSON.stringify({
+      content: bookUrl,
+      tags: ["prod-e2e"],
+      source: "prod-e2e",
+    }),
+  });
+  expect(created.status).toBe(200);
+  const payload = await created.json();
+  updateState((s) => s.createdCardIds.push(payload.cardId));
+
+  // The create response should already reflect the link classification.
+  expect(payload.card?.type).toBe("link");
+  expect(payload.card?.url).toBe(bookUrl);
+
+  // And it should persist as a link when fetched back.
+  const fetched = await apiFetch(`/v1/cards/${payload.cardId}`, primary.apiKey);
+  expect(fetched.status).toBe(200);
+  const fetchedPayload = await fetched.json();
+  expect(fetchedPayload.type).toBe("link");
+  expect(fetchedPayload.url).toBe(bookUrl);
+});
+
+test("saving a color as content creates a palette card, not a text card", async () => {
+  // Regression: saving a color (single hex, or a list of colors/names) as card
+  // content stopped becoming a "palette" card and stuck as "text". Palette
+  // classification runs asynchronously after creation, so poll until it lands.
+  const { primary } = readState();
+  if (!primary?.apiKey) {
+    throw new Error("Missing primary API key");
+  }
+  const apiKey = primary.apiKey;
+  const created = await apiFetch("/v1/cards", apiKey, {
+    method: "POST",
+    body: JSON.stringify({
+      content: "#2050D0",
+      tags: ["prod-e2e"],
+      source: "prod-e2e",
+    }),
+  });
+  expect(created.status).toBe(200);
+  const payload = await created.json();
+  updateState((s) => s.createdCardIds.push(payload.cardId));
+
+  await expect
+    .poll(
+      async () => {
+        const fetched = await apiFetch(`/v1/cards/${payload.cardId}`, apiKey);
+        if (!fetched.ok) {
+          return null;
+        }
+        return (await fetched.json()).type;
+      },
+      { timeout: 30_000, intervals: [1000, 2000, 3000, 5000] }
+    )
+    .toBe("palette");
+});

--- a/packages/tests/src/journey/06-security.e2e.ts
+++ b/packages/tests/src/journey/06-security.e2e.ts
@@ -43,7 +43,16 @@ test("cross-tenant, revoked-key, hostile input, headers, and cookie security", a
     for (const url of ["/login", "/settings"]) {
       const response = await page.goto(url);
       expect(response?.headers()["strict-transport-security"]).toBeTruthy();
-      expect(response?.headers()["content-security-policy"]).toBeTruthy();
+      const csp = response?.headers()["content-security-policy"] ?? "";
+      expect(csp).toBeTruthy();
+      // Regression: images (link previews, PDF thumbnails) are served from R2.
+      // The CSP img-src must allow that origin or they are blocked outright.
+      const imgSrc = csp
+        .split(";")
+        .map((directive) => directive.trim())
+        .find((directive) => directive.startsWith("img-src"));
+      expect(imgSrc).toBeTruthy();
+      expect(imgSrc).toContain("r2.cloudflarestorage.com");
     }
     const cookies = await context.cookies();
     expect(

--- a/packages/ui/src/components/card-previews/LinkPreview.tsx
+++ b/packages/ui/src/components/card-previews/LinkPreview.tsx
@@ -6,6 +6,17 @@ import {
 import { ArrowUpRight } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+// Format long whole numbers (e.g. review counts) with thousands separators for
+// readability. Values with 5+ digits are formatted so years like "2024" and
+// short counts stay untouched.
+function formatFactValue(value: string) {
+  const trimmed = value.trim();
+  if (/^\d{5,}$/.test(trimmed)) {
+    return Number(trimmed).toLocaleString();
+  }
+  return value;
+}
+
 type CardWithUrls = Doc<"cards"> & {
   fileUrl?: string;
   thumbnailUrl?: string;
@@ -157,14 +168,21 @@ export function LinkPreview({
       </div>
 
       {categoryMetadata?.facts?.length ? (
-        <div className="space-y-1 text-muted-foreground text-sm">
+        <dl className="grid grid-cols-2 gap-2 sm:grid-cols-4 pt-4">
           {categoryMetadata.facts.map((fact) => (
-            <div className="flex gap-2" key={`${fact.label}-${fact.value}`}>
-              <span className="font-medium text-foreground">{fact.label}:</span>
-              <span className="text-balance">{fact.value}</span>
+            <div
+              className="flex flex-col gap-0.5 rounded-lg border bg-card px-3 py-2"
+              key={`${fact.label}-${fact.value}`}
+            >
+              <dt className="truncate font-medium text-muted-foreground text-xs uppercase tracking-wide">
+                {fact.label}
+              </dt>
+              <dd className="break-words font-semibold text-foreground text-sm">
+                {formatFactValue(fact.value)}
+              </dd>
             </div>
           ))}
-        </div>
+        </dl>
       ) : null}
     </>
   );

--- a/packages/ui/src/components/forms/AddCardForm.tsx
+++ b/packages/ui/src/components/forms/AddCardForm.tsx
@@ -201,9 +201,11 @@ export function AddCardForm({
     setIsSubmitting(true);
 
     try {
+      // Intentionally omit `type` so the server auto-classifies the note.
+      // Passing an explicit type skips classification, which would stop colors
+      // from becoming palette cards (and quotes/links from being detected).
       await createCard({
         content: submittedContent,
-        type: "text",
       });
 
       onSuccess?.();


### PR DESCRIPTION
## Summary

Bundles several fixes across web security headers, PDF thumbnail generation, link card classification, and the desktop app.

### Web / Security
- Add configurable R2 storage origins (`NEXT_PUBLIC_R2_STORAGE_ORIGIN` and related env vars) to the `img-src`, `connect-src`, `media-src`, and `frame-src` CSP directives so self-hosted deployments can serve images/documents from their bucket.
- Allow `'unsafe-eval'` in `script-src` only in development (Next.js/React Fast Refresh relies on `eval()`); production stays strict.
- Remove the `nonce` from the JSON-LD `<script type="application/ld+json">`. JSON-LD is not executable JS so CSP `script-src` never applied, and the nonce caused an SSR/CSR hydration mismatch.

### PDF thumbnails
- Rewrite `generatePdfThumbnail` to fetch the PDF bytes server-side and render page 1 with pdf.js inside the headless browser from injected base64, bypassing R2 signed-URL CORS issues that broke the previous Mozilla-hosted viewer approach.
- Capture and persist rendered page dimensions for correct thumbnail aspect ratio.

### Link card classification
- Upgrade URL-bearing cards to `link` on the server even when a client passes an explicit `text` type, mirroring the deterministic classifier.
- Stop `AddCardForm` from forcing `type: "text"`, so server-side classification runs (palette/quote/link detection).

### Desktop
- Grant `clipboard-sanitized-write` permission so "copy" actions in the shared UI work (previously denied by the microphone-only permission handler).

### UI
- Restyle `LinkPreview` facts as a metadata grid with thousands-separator number formatting for large counts.

### Tests / Docs
- Add tests for JSON-LD rendering, PDF thumbnail generation, security headers, card creation, and classification; extend web/API/security e2e journeys.
- Document `NEXT_PUBLIC_R2_STORAGE_ORIGIN` in self-hosting docs, add an e2e testing note to AGENTS.md, and rewrite the July 2026 changelog.

## Testing
- `bun run typecheck` — pass (10 packages)
- `bun run lint` — pass
- `bun run build` — pass (19 tasks)
- `bun run test` — pass (120 web tests + package suites)
