### PR TITLE
Filter expected web Sentry noise

### DIFF
--- a/apps/web/src/__tests__/sentryConfig.test.ts
+++ b/apps/web/src/__tests__/sentryConfig.test.ts
@@ -48,6 +48,56 @@ describe("filterClientSentryEvent", () => {
     expect(filterClientSentryEvent(event)).toBeNull();
   });
 
+  test("drops Safari Better Auth session fetch aborts", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "Load failed (app.teakvault.com)",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "node_modules/@convex-dev/better-auth/src/react/index.tsx",
+                },
+                { filename: "node_modules/@better-fetch/fetch/dist/index.js" },
+              ],
+            },
+          },
+        ],
+      },
+      user: { username: "e2e-matrix-matrix-webkit-1783500370949-70o5ch" },
+    } satisfies ErrorEvent;
+
+    expect(filterClientSentryEvent(event)).toBeNull();
+  });
+
+  test("keeps real-user Better Auth session fetch failures", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "Load failed (app.teakvault.com)",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "node_modules/@convex-dev/better-auth/src/react/index.tsx",
+                },
+                { filename: "node_modules/@better-fetch/fetch/dist/index.js" },
+              ],
+            },
+          },
+        ],
+      },
+      user: { username: "Praveen" },
+    } satisfies ErrorEvent;
+
+    expect(filterClientSentryEvent(event)).toBe(event);
+  });
+
   test("keeps app-origin fetch failures", () => {
     const event = {
       exception: {
@@ -55,6 +105,24 @@ describe("filterClientSentryEvent", () => {
           {
             type: "TypeError",
             value: "Failed to fetch",
+            stacktrace: {
+              frames: [{ filename: "app:///src/app/HomePageClient.tsx" }],
+            },
+          },
+        ],
+      },
+    } satisfies ErrorEvent;
+
+    expect(filterClientSentryEvent(event)).toBe(event);
+  });
+
+  test("keeps app-origin Safari load failures", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "Load failed (app.teakvault.com)",
             stacktrace: {
               frames: [{ filename: "app:///src/app/HomePageClient.tsx" }],
             },

--- a/apps/web/src/lib/sentry-config.ts
+++ b/apps/web/src/lib/sentry-config.ts
@@ -43,8 +43,31 @@ const isExtensionFetchFailure = (event: ErrorEvent) =>
     );
   }) ?? false;
 
+const isProductionE2eMatrixUser = (event: ErrorEvent) =>
+  typeof event.user?.username === "string" &&
+  event.user.username.startsWith("e2e-matrix-");
+
+const isSafariBetterAuthLoadFailure = (event: ErrorEvent) =>
+  isProductionE2eMatrixUser(event) &&
+  (event.exception?.values?.some((exception) => {
+    const isWebkitLoadFailure =
+      exception.type === "TypeError" &&
+      exception.value === "Load failed (app.teakvault.com)";
+
+    return (
+      isWebkitLoadFailure &&
+      exception.stacktrace?.frames?.some(
+        (frame) =>
+          frame.filename?.includes("node_modules/@convex-dev/better-auth/") ||
+          frame.filename?.includes("node_modules/better-auth/") ||
+          frame.filename?.includes("node_modules/@better-fetch/fetch/")
+      )
+    );
+  }) ??
+    false);
+
 export function filterClientSentryEvent(event: ErrorEvent, _hint?: EventHint) {
-  if (isExtensionFetchFailure(event)) {
+  if (isExtensionFetchFailure(event) || isSafariBetterAuthLoadFailure(event)) {
     return null;
   }
 

--- a/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
+++ b/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
@@ -190,6 +190,7 @@ describe("useFileUploadCore", () => {
       const result = await hook.uploadFile(file);
       expect(result.success).toBe(false);
       expect((result as any).errorCode).toBe(CARD_ERROR_CODES.FILE_TOO_LARGE);
+      expect(mockSentryCapture).not.toHaveBeenCalled();
     });
 
     test("returns correct error message for oversized file", async () => {
@@ -376,6 +377,28 @@ describe("useFileUploadCore", () => {
 
       expect(result.success).toBe(false);
       expect((result as any).errorCode).toBe(CARD_ERROR_CODES.UNSUPPORTED_TYPE);
+      expect(mockUploadAndCreateCard).not.toHaveBeenCalled();
+    });
+
+    test("does not capture oversized URI uploads in Sentry", async () => {
+      const uriHook = useFileUploadCore(
+        {
+          ...dependencies,
+          uploadBinaryFromUri: mockUploadBinaryFromUri,
+        },
+        config
+      );
+
+      const result = await uriHook.uploadFileFromUri({
+        uri: "file:///tmp/large.jpg",
+        name: "large.jpg",
+        type: "image/jpeg",
+        size: MAX_FILE_SIZE + 1,
+      });
+
+      expect(result.success).toBe(false);
+      expect((result as any).errorCode).toBe(CARD_ERROR_CODES.FILE_TOO_LARGE);
+      expect(mockSentryCapture).not.toHaveBeenCalled();
       expect(mockUploadAndCreateCard).not.toHaveBeenCalled();
     });
   });

--- a/packages/convex/client/hooks/useFileUpload.client.tsx
+++ b/packages/convex/client/hooks/useFileUpload.client.tsx
@@ -198,6 +198,9 @@ const isAbortError = (error: unknown) =>
   "name" in error &&
   error.name === "AbortError";
 
+const shouldCaptureUploadError = (errorCode?: CardErrorCode) =>
+  errorCode !== CARD_ERROR_CODES.FILE_TOO_LARGE;
+
 const throwIfAborted = (signal: AbortSignal) => {
   if (signal.aborted) {
     throw createAbortError();
@@ -462,16 +465,17 @@ export function useFileUploadCore(
           fileError.code = (error as CodedError).code;
         }
 
-        // Capture upload errors in Sentry
-        captureException(error, {
-          tags: { source: "convex", operation: "fileUpload" },
-          extra: {
-            fileName: file.name,
-            fileType: file.type,
-            fileSize: file.size,
-            errorCode: fileError.code,
-          },
-        });
+        if (shouldCaptureUploadError(fileError.code)) {
+          captureException(error, {
+            tags: { source: "convex", operation: "fileUpload" },
+            extra: {
+              fileName: file.name,
+              fileType: file.type,
+              fileSize: file.size,
+              errorCode: fileError.code,
+            },
+          });
+        }
 
         setError(fileError);
         config.onError?.(fileError);
@@ -634,15 +638,17 @@ export function useFileUploadCore(
           fileError.code = (error as CodedError).code;
         }
 
-        captureException(error, {
-          tags: { source: "convex", operation: "fileUpload" },
-          extra: {
-            fileName: name,
-            fileType: type,
-            fileSize: size,
-            errorCode: fileError.code,
-          },
-        });
+        if (shouldCaptureUploadError(fileError.code)) {
+          captureException(error, {
+            tags: { source: "convex", operation: "fileUpload" },
+            extra: {
+              fileName: name,
+              fileType: type,
+              fileSize: size,
+              errorCode: fileError.code,
+            },
+          });
+        }
 
         setError(fileError);
         config.onError?.(fileError);

--- a/packages/ui/src/components/forms/AddCardActions.tsx
+++ b/packages/ui/src/components/forms/AddCardActions.tsx
@@ -328,7 +328,7 @@ export function AddCardActions({
 
         toast.error(
           `Failed to upload ${file.name}: ${result.error || "Upload failed"}`,
-          { id: toastId }
+          { ...MANUAL_CLOSE_TOAST_OPTIONS, id: toastId }
         );
       }
     };


### PR DESCRIPTION
## Summary
- stop capturing expected oversized-file upload validation failures in Sentry while preserving the existing user-facing error result
- keep manual upload failure toasts closable in the file-picker fallback
- drop the narrowly observed Safari/WebKit Better Auth session fetch abort shape that only appears as production E2E noise, while keeping app-origin load failures

## Sentry context
- Fixes TEAK-WEB-PROD-J9 by treating the 20 MB limit as intended validation, not an application error
- Fixes TEAK-WEB-PROD-EA by filtering the exact Better Auth/WebKit aborted session fetch shape seen in production E2E events
- Leaves TEAK-WEB-PROD-MF untouched

## Validation
- bun test packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
- bun test apps/web/src/__tests__/sentryConfig.test.ts
- bunx biome check apps/web/src/lib/sentry-config.ts apps/web/src/__tests__/sentryConfig.test.ts packages/convex/client/hooks/useFileUpload.client.tsx packages/convex/__tests__/shared/hooks/useFileUpload.test.ts packages/ui/src/components/forms/AddCardActions.tsx
- bun run --cwd apps/web typecheck
- bun run --cwd packages/ui typecheck
- bun run --cwd packages/convex typecheck
- bun run test
- NEXT_PUBLIC_CONVEX_URL=https://example.convex.cloud NEXT_PUBLIC_CONVEX_SITE_URL=https://example.convex.site SITE_URL=https://app.teakvault.com GOOGLE_CLIENT_ID=test GOOGLE_CLIENT_SECRET=test APPLE_CLIENT_ID=test APPLE_CLIENT_SECRET=test bun run pre-commit