### PR TITLE
docs: reorganize sidebar and tighten product copy

### DIFF
--- a/apps/docs/astro.config.ts
+++ b/apps/docs/astro.config.ts
@@ -88,19 +88,22 @@ export default defineConfig({
             { label: "Browser Extension", slug: "docs/extension" },
             { label: "Raycast Extension", slug: "docs/raycast" },
             { label: "Command Line", slug: "docs/cli" },
-            { label: "Agent Skill", slug: "docs/skills" },
+          ],
+        },
+        {
+          label: "Data",
+          items: [
+            { label: "Import", slug: "docs/import" },
+            { label: "Export", slug: "docs/export" },
           ],
         },
         {
           label: "Developers",
           items: [
             { label: "API", slug: "docs/api" },
-            {
-              label: "MCP",
-              slug: "docs/mcp",
-              badge: { text: "New", variant: "success" },
-            },
+            { label: "MCP", slug: "docs/mcp" },
             { label: "Teak for AI Agents", slug: "docs/ai-agents" },
+            { label: "Agent Skill", slug: "docs/skills" },
             { label: "Development Guide", slug: "docs/development" },
             {
               label: "Self-Hosting",
@@ -117,8 +120,6 @@ export default defineConfig({
             { label: "Support", slug: "docs/support" },
           ],
         },
-        { label: "Import Your Data", slug: "docs/import" },
-        { label: "Export Your Data", slug: "docs/export" },
       ],
       head: [
         {

--- a/apps/docs/src/content/docs/docs/features.mdx
+++ b/apps/docs/src/content/docs/docs/features.mdx
@@ -1,149 +1,91 @@
 ---
 title: Features
-description: Core features of Teak visual bookmarking platform
+description: Card types, search, AI enrichment, and sync in Teak
 ---
 
-## Card System
+## Card types
 
-Eight card types cover common design workflows. Each type is optimized for its content with automatic processing and rich previews.
+Eight types cover common save workflows. Each gets automatic processing and a rich preview.
 
-### 📝 Design Notes
+| Type | What you save | Auto-features |
+| --- | --- | --- |
+| **Text** | Notes, decisions, feedback | Full-text search |
+| **Link** | Articles, Dribbble shots, tools | Metadata, screenshot, preview |
+| **Image** | Screenshots, mockups, photos | Color palette extraction |
+| **Video** | Tutorials, animations, clips | Inline player, thumbnails |
+| **Audio** | Voice memos, recordings | Transcription |
+| **Document** | PDFs and other files | Thumbnail previews |
+| **Palette** | Color swatches from images | Hex values per color |
+| **Quote** | Highlighted passages | Source context |
 
-Capture project decisions, meeting notes, and feedback. Full Markdown support with syntax highlighting for code snippets.
+## Search and organization
 
-### 🔗 Design Resources
+### Smart search
 
-Save links with automatic metadata extraction and full-page screenshots. Teak captures the title, description, favicon, and a visual preview.
+Search titles, descriptions, tags, transcripts, and extracted text. Special tokens work automatically:
 
-### 📷 Visual References
+| Token | Examples | Effect |
+| --- | --- | --- |
+| **Color name** | `red`, `blue`, `teal` | Dominant palette color |
+| **Visual style** | `minimal`, `dark`, `cinematic`, `pastel`, `vibrant` | Visual aesthetic |
+| **Hex color** | `#FF5733`, `#3B82F6` | Exact color match |
+| **Date** | `today`, `this week`, `january`, `last year` | Creation date |
+| **Quick view** | `favorites` / `fav`, `trash` / `bin` / `deleted` | Favorites or trash |
+| **Keyword** | anything else | Full-text match |
 
-Store screenshots, mockups, and mood board images. Automatic color palette extraction helps you find images by dominant colors.
-
-### 🎬 Animation References
-
-Save video files with an inline player and auto-generated thumbnails. Perfect for motion design references and tutorial clips.
-
-### 🎙️ Voice Notes
-
-Record audio directly or upload files. Automatic transcription makes voice notes fully searchable.
-
-### 📁 Design Files
-
-Upload PDFs, Sketch files, Figma exports, and other assets. Thumbnail previews help you browse without opening each file.
-
-### 🎨 Color Palettes
-
-Extract and save color palettes from any image. Each color includes hex values for easy copying.
-
-### 💬 Quote Cards
-
-Save highlighted quotes with source context. Perfect for design principles, testimonials, and notable passages.
-
----
-
-## Search & Organization
-
-### Smart Search
-
-Type any word or phrase to search across card titles, descriptions, tags, transcriptions, and extracted text. Teak also recognizes special search tokens automatically:
-
-| Token type         | Examples                                                                                                                                              | What it does                             |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| **Color name**     | `red`, `blue`, `teal`, `purple`, `pink`                                                                                                               | Filters cards by dominant palette color  |
-| **Visual style**   | `minimal`, `dark`, `cinematic`, `pastel`, `vibrant`, `moody`, `retro`, `vintage`, `abstract`, `illustrative`, `monochrome`, `photographic`, `surreal` | Filters cards by visual aesthetic        |
-| **Hex color**      | `#FF5733`, `#3B82F6`                                                                                                                                  | Filters cards by exact color match       |
-| **Date shorthand** | `today`, `this week`, `january`, `last year`                                                                                                          | Filters cards by creation date           |
-| **Quick view**     | `favorites` (or `fav`), `trash` (or `bin`, `deleted`)                                                                                                 | Switches to your favorites or trash view |
-| **Keyword**        | anything else                                                                                                                                         | Full-text match on card content          |
-
-Mix multiple tokens in one search — Teak applies all recognized filters simultaneously.
+Mix tokens in one query — all recognized filters apply together.
 
 ```
-Examples:
-- "blue button hover state"
-- "minimal dark"
-- "#3B82F6"
-- "feedback from Sarah this week"
-- "onboarding flow mobile"
+blue button hover state
+minimal dark
+#3B82F6
+feedback this week
 ```
 
-### Smart Tagging
+### Tags and filters
 
-AI automatically analyzes your content and applies relevant tags. You can also add custom tags manually.
-
-### Filtering
-
-Filter by card type, favorites, visual style, color, or date. Active filters appear as removable pills in the search bar. Combine multiple filters to narrow down large collections quickly.
+AI applies tags automatically; you can add your own. Filter by type, favorites, style, color, or date. Active filters show as removable pills in the search bar.
 
 ### Trash
 
-Deleted cards are moved to trash instead of being removed immediately. From the trash view you can:
+Deleted cards go to trash first. Restore them, or delete permanently (including files). Open trash with `trash`, `bin`, or `deleted` in the search bar.
 
-- **Restore** — sends the card back to your main library
-- **Delete permanently** — removes the card and any associated files for good
+### Import and export
 
-Access trash by typing `trash` (or `bin`, `deleted`) in the search bar and pressing Enter.
+From Settings on web and desktop:
 
-### Data Import
+- [Import](/docs/import) bookmarks, Raindrop CSV, or a Teak archive
+- [Export](/docs/export) a portable ZIP of active cards and original files
 
-Bring in links from a browser bookmarks export, a Raindrop.io CSV export, or a previous Teak archive, all from Settings on web and desktop. See [Import Your Data](/docs/import) for supported formats, duplicate handling, and limits.
+### Grid
 
-### Data Export
+Cards show in a masonry grid that adapts to different sizes and aspect ratios.
 
-Export a portable ZIP of your active cards and original files from Settings on web and desktop. See [Export Your Data](/docs/export) for archive contents, limits, and download availability.
+## AI enrichment
 
-### Masonry Grid
+Each card is processed automatically:
 
-Browse your inspiration in a Pinterest-style grid that adapts to different content sizes and aspect ratios.
+| Feature | Description |
+| --- | --- |
+| **Auto-tagging** | Keywords and concepts |
+| **Summaries** | Short descriptions for scanning |
+| **Categorization** | Link type (design, development, article, tool) |
+| **Color extraction** | Dominant colors in images |
+| **Transcription** | Audio → searchable text |
+| **Thumbnails** | Previews for video and documents |
 
----
+## Apps and access
 
-## AI Enrichment
+Everything syncs in real time. Pick the surface that fits:
 
-Teak's AI pipeline processes each card automatically:
+| Surface | Docs |
+| --- | --- |
+| Web | Full library, drag-and-drop, bulk actions |
+| [Desktop (macOS)](/docs/desktop) | Native app with auto-updates |
+| [Mobile (iOS)](/docs/mobile) | Share sheet, camera, voice notes |
+| [Browser extension](/docs/extension) | One-click save from Chrome, Safari, Edge, and more |
+| [Raycast](/docs/raycast) | Keyboard-first save and search |
+| [CLI](/docs/cli) | Terminal save, search, and manage |
+| [API](/docs/api) / [MCP](/docs/mcp) | Programmatic access for tools and agents |
 
-| Feature                  | Description                                               |
-| ------------------------ | --------------------------------------------------------- |
-| **Auto-tagging**         | Extracts relevant keywords and concepts                   |
-| **Summaries**            | Generates brief descriptions for quick scanning           |
-| **Categorization**       | Groups links by type (design, development, article, tool) |
-| **Color extraction**     | Identifies dominant colors in images                      |
-| **Transcription**        | Converts audio to searchable text                         |
-| **Thumbnail generation** | Creates previews for videos and documents                 |
-
----
-
-## Cross-Platform Sync
-
-Your inspiration syncs in real-time across all platforms:
-
-### 🌐 Web App
-
-Full-featured dashboard with drag-and-drop uploads, bulk selection, full-screen card previews, and URL-synced card modal state for direct deep links.
-
-### 🖥️ Desktop App
-
-Signed and notarized native macOS app (Apple Silicon, macOS 13+) with auto-updates and a native menu bar. Download from [GitHub Releases](https://github.com/praveenjuge/teak/releases/latest) — no App Store required. See the [Desktop App guide](/docs/desktop) for install and troubleshooting details.
-
-### 📱 Mobile App
-
-Native iOS app with share sheet integration, camera capture, one-tap voice recording, and offline viewing. Share directly from any app to save instantly.
-
-### 🧩 Browser Extensions
-
-Save the current page from the Safari toolbar with [Teak for Safari](https://apps.apple.com/us/app/teak-for-safari/id6770003409?mt=12). On Chrome and Chromium-based browsers, you can also right-click to save pages or selected text and use inline save buttons on supported social sites. See the [Browser Extension guide](/docs/extension) for setup and full details.
-
-### ⚡ Raycast, CLI, API & MCP
-
-Save and search without leaving your keyboard using the [Raycast extension](/docs/raycast) or [command line](/docs/cli), or connect your own tools with the [public API](/docs/api) and [MCP server](/docs/mcp). Sign in with your browser or generate a long-lived key from the dedicated API Keys window in Settings, where you can view status, copy, revoke, disable, and regenerate keys.
-
----
-
-## Who It's For
-
-| Audience             | Use                                                                                   |
-| -------------------- | ------------------------------------------------------------------------------------- |
-| **Designers**        | Build a personal library of UI patterns, interactions, and visual references          |
-| **Developers**       | Save documentation, code examples, and technical references                           |
-| **Creative Teams**   | Share inspiration collections; keep everyone aligned on visual direction              |
-| **Content Creators** | Organize research, quotes, and visual assets for articles, videos, and social content |
+Sign in with your browser, or create a long-lived key under **Settings → API Keys**.

--- a/apps/docs/src/content/docs/docs/index.mdx
+++ b/apps/docs/src/content/docs/docs/index.mdx
@@ -1,143 +1,106 @@
 ---
 title: Welcome to Teak
-description: Your personal design library that never loses anything
+description: Save inspiration in one click and find it in seconds
 ---
 
 import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
-Teak helps you save inspiration in 1 click and find it in 2 seconds—no more lost bookmarks or messy folders.
+Teak is a personal library for links, notes, images, files, and more. Save from any device; AI tags and organizes so you can find things with a short search.
 
-## Why Teak?
-
-Everyone who collects references has the same problem: you find the perfect example—then lose it forever in a sea of bookmarks, screenshots, and "inspiration" folders.
-
-Teak fixes this by:
-
-- **Instant saving** — One click from any browser, phone, or app
-- **Smart organization** — AI auto-tags and categorizes everything
-- **Lightning search** — Type "blue button" and find it in 2 seconds
-- **Cross-platform sync** — Save on mobile, find on desktop
-
-## Common Use Cases
-
-### Building a Design System
-
-Save UI patterns, component examples, and interaction references. Search by component type to find exactly what you need when building new features.
-
-### Client Mood Boards
-
-Collect visual references for client projects. Share curated collections or export for presentations.
-
-### Learning & Reference
-
-Save tutorials, code snippets, and documentation. Voice notes let you capture quick ideas on the go.
-
-### Color & Typography Research
-
-Extract color palettes from any image. Save font pairings and typography examples with full context.
-
-## Start Here
+## Get started
 
 <CardGrid>
   <LinkCard
-    title="Desktop App"
-    href="/docs/desktop"
-    description="Native macOS app with automatic updates and real-time sync."
-  />
-  <LinkCard
-    title="Mobile App"
-    href="/docs/mobile"
-    description="Save on the go from iOS, including the system share sheet."
-  />
-  <LinkCard
-    title="Browser Extensions"
-    href="/docs/extension"
-    description="One-click saves from Chrome, Safari, Edge, Brave, and Arc."
-  />
-  <LinkCard
-    title="Raycast Extension"
-    href="/docs/raycast"
-    description="Save and search cards without leaving your keyboard."
-  />
-  <LinkCard
-    title="Command Line"
-    href="/docs/cli"
-    description="Save, search, and manage cards from your terminal."
-  />
-  <LinkCard
     title="Features"
     href="/docs/features"
-    description="Tour every card type, AI pipeline step, and search surface."
+    description="Card types, search, AI enrichment, and sync."
   />
   <LinkCard
-    title="Import Your Data"
+    title="Desktop"
+    href="/docs/desktop"
+    description="Native macOS app with automatic updates."
+  />
+  <LinkCard
+    title="Mobile"
+    href="/docs/mobile"
+    description="iOS app with share sheet and voice notes."
+  />
+  <LinkCard
+    title="Browser extension"
+    href="/docs/extension"
+    description="One-click save from Chrome, Safari, Edge, and more."
+  />
+  <LinkCard
+    title="Raycast"
+    href="/docs/raycast"
+    description="Save and search without leaving the keyboard."
+  />
+  <LinkCard
+    title="Command line"
+    href="/docs/cli"
+    description="Manage cards from your terminal."
+  />
+  <LinkCard
+    title="Import"
     href="/docs/import"
-    description="Bring in bookmarks, a Raindrop export, or a Teak archive."
+    description="Bookmarks, Raindrop, or a Teak archive."
   />
   <LinkCard
-    title="Export Your Data"
+    title="Export"
     href="/docs/export"
-    description="Download a portable archive of your cards and original files."
+    description="Download a portable ZIP of your library."
   />
   <LinkCard
     title="API"
     href="/docs/api"
-    description="Programmatic access to your cards over HTTP."
+    description="HTTP API for cards, uploads, and sync."
   />
   <LinkCard
-    title="MCP"
-    href="/docs/mcp"
-    description="Connect Teak to any MCP-compatible AI client."
+    title="MCP & agents"
+    href="/docs/ai-agents"
+    description="MCP, CLI, and Agent Skill for AI tools."
   />
   <LinkCard
     title="Development"
     href="/docs/development"
-    description="Clone, install, and run the monorepo locally."
+    description="Run the monorepo locally."
   />
   <LinkCard
-    title="Self-Hosting"
+    title="Self-hosting"
     href="/docs/self-hosting"
-    description="Run Teak on your own Convex deployment."
+    description="Run Teak on your own deployment."
   />
 </CardGrid>
 
-## How It Works
+## What you can save
 
-1. **Install desktop, browser extension, mobile app, or CLI**
-2. **Save anything** with one click—images, links, notes, files
-3. **Let Teak organize** with automatic tagging and categorization
-4. **Search visually** using keywords, colors, or content type
-5. **Access anywhere** with real-time sync across all devices
+| Type | Examples | Auto-features |
+| --- | --- | --- |
+| Text | Notes, decisions | Full-text search |
+| Link | Articles, tools, references | Screenshot, metadata |
+| Image | Screenshots, mockups | Color palette |
+| Video | Tutorials, clips | Thumbnails |
+| Audio | Voice memos | Transcription |
+| Document | PDFs and files | Thumbnail previews |
+| Palette | Color swatches | Hex values |
+| Quote | Passages with source | Source context |
 
-## What You Can Save
-
-| Type     | Examples                                | Auto-Features                   |
-| -------- | --------------------------------------- | ------------------------------- |
-| Links    | Articles, Dribbble shots, CodePen demos | Screenshot, metadata extraction |
-| Images   | Screenshots, mockups, photos            | Color palette extraction        |
-| Notes    | Ideas, feedback, decisions              | Full-text search                |
-| Files    | PDFs, design files, assets              | Thumbnail previews              |
-| Audio    | Voice memos, feedback recordings        | Transcription                   |
-| Video    | Tutorials, animations, references       | Thumbnail generation            |
-| Palettes | Brand colors, inspiration swatches      | Hex values extracted per color  |
-| Quotes   | Design principles, notable passages     | Saved with source context       |
-
-## Policies & Help
+## Help
 
 <CardGrid>
   <LinkCard
+    title="Support"
+    href="/docs/support"
+    description="Contact and bug reports."
+  />
+  <LinkCard
     title="Privacy Policy"
     href="/docs/privacy-policy"
-    description="How we collect, use, and safeguard your data."
+    description="How we handle your data."
   />
   <LinkCard
     title="Terms of Service"
     href="/docs/terms-of-service"
-    description="The rules for using Teak."
-  />
-  <LinkCard
-    title="Support"
-    href="/docs/support"
-    description="Contact channels and how to get help fast."
+    description="Rules for using Teak."
   />
 </CardGrid>

--- a/apps/docs/src/content/docs/docs/privacy-policy.mdx
+++ b/apps/docs/src/content/docs/docs/privacy-policy.mdx
@@ -1,31 +1,30 @@
 ---
 title: Privacy Policy
-description: Privacy policy for Teak web app, mobile app, and browser extension
+description: Privacy policy for Teak apps, API, and integrations
 ---
 
 ## Overview
 
-Teak protects your privacy across the web app, mobile app, and browser extension. We store and process your personal design inspiration securely.
+Teak protects your privacy across the web app, desktop app, mobile app, browser extensions, Raycast extension, CLI, public API, and MCP server. We store and process the content you save securely.
 
 ## Data We Collect
 
-- **Account data:** Better Auth authentication, profile info (name, email, optional photo), account preferences.
-- **Your content:** Cards (notes, links, images, videos, audio, documents), metadata (timestamps, tags, favorites), and securely stored file uploads.
+- **Account data:** Authentication details, profile info (name, email, optional photo), and account preferences.
+- **Your content:** Cards (notes, links, images, videos, audio, documents, palettes, quotes), metadata (timestamps, tags, favorites), and securely stored file uploads.
 - **Usage data:** How you interact with our services, device/browser info for compatibility, and error logs for service improvement.
-- **Extension data:** Current page URL when you save content, text you explicitly select to save, and context menu interactions.
+- **Extension and client data:** Page URL or text you explicitly choose to save, and similar capture data from share sheets, Raycast, CLI, API, or MCP when you use those surfaces.
 
 ## How We Use Your Data
 
-- **Primary uses:** Store, organize, and sync your content; enable cross-platform access; process metadata and thumbnails; power search functionality.
+- **Primary uses:** Store, organize, and sync your content; enable cross-platform access; process metadata and thumbnails; power search.
 - **Secondary uses:** Improve service quality, provide technical support, maintain security, and meet legal requirements.
 
 ## Data Security
 
-- Storage on secure Convex servers (US-based)
-- Industry-standard encryption in transit and at rest
-- Better Auth-managed secure login
+- Hosted storage in the United States with industry-standard encryption in transit and at rest
+- Secure login sessions
 - Isolation so your data stays private from other users
-- Automated backups for data durability
+- Automated backups for durability
 
 ## Sharing & Disclosure
 
@@ -35,17 +34,18 @@ Teak protects your privacy across the web app, mobile app, and browser extension
 ## Your Rights & Controls
 
 - Access: view all your content through our apps.
-- Export: download your data in standard formats.
+- Export: download your data from Settings (web and desktop).
 - Delete: remove individual cards or your entire account.
-- Control: manage privacy preferences.
+- Control: manage privacy preferences and API keys.
 
 **Deletion timeline:** soft delete provides a 30-day recovery period; permanent deletion happens after 30 days; full account deletion completes within 30 days of request.
 
 ## Platform Practices
 
-- **Web app:** essential cookies for authentication, local storage for performance, secure session management.
-- **Mobile app:** device permissions only when used (camera, mic, photos), local caching for offline access, optional push notifications.
-- **Browser extension:** active tab access only when saving content, no background monitoring, activates only on user interaction.
+- **Web and desktop:** essential cookies or local storage for authentication and performance; secure session management.
+- **Mobile app:** device permissions only when used (camera, mic, photos); local caching for offline viewing.
+- **Browser extension:** active tab access only when saving content; no background monitoring; activates on user interaction.
+- **CLI, Raycast, API, MCP:** authenticate with browser sign-in or an API key you control; revoke keys anytime in Settings.
 
 ## International Data
 

--- a/apps/docs/src/content/docs/docs/skills.mdx
+++ b/apps/docs/src/content/docs/docs/skills.mdx
@@ -3,9 +3,9 @@ title: Agent Skill
 description: Install the Teak Agent Skill for Codex, Claude Code, Cursor, and other skills-compatible agents
 ---
 
-The Teak Agent Skill gives AI agents a reliable playbook for using Teak through the CLI, API, MCP server, and TypeScript SDK.
+The Teak Agent Skill teaches AI agents how to save, search, and manage Teak cards through the CLI, API, MCP server, and TypeScript SDK.
 
-View it on Skills.sh: [skills.sh/praveenjuge/teak](https://skills.sh/praveenjuge/teak)
+[skills.sh/praveenjuge/teak](https://skills.sh/praveenjuge/teak)
 
 ## Install
 
@@ -13,29 +13,27 @@ View it on Skills.sh: [skills.sh/praveenjuge/teak](https://skills.sh/praveenjuge
 npx skills add praveenjuge/teak --skill teak
 ```
 
-The skill installs from Teak's public GitHub repository and works with skills-compatible agents such as Codex, Claude Code, Cursor, GitHub Copilot, Windsurf, and others. Skills.sh lists public skills after successful installs are reported by the `skills` CLI, so installing the command above also makes Teak discoverable there.
+Works with skills-compatible agents such as Codex, Claude Code, Cursor, GitHub Copilot, and Windsurf.
 
-## What It Teaches Agents
+## What it covers
 
-- When to use the Teak CLI, public API, MCP server, or SDK.
-- How to authenticate with browser sign-in or a Teak API key.
-- How to save text, links, files, tags, and notes.
-- How to search, inspect, update, favorite, delete, and sync cards.
-- How to use production-safe smoke-test markers and clean up test cards.
-- How to avoid leaking API keys, OAuth tokens, or private saved content.
+- When to use CLI vs API vs MCP vs SDK
+- Browser sign-in or API key auth
+- Save text, links, files, tags, and notes
+- Search, update, favorite, delete, and sync cards
+- Keep API keys and private content out of logs and prompts
 
 ## Use
-
-After installing, ask your agent to use the Teak skill:
 
 ```text
 Use the Teak skill to save this research link with the tags ai and reference.
 ```
 
-Agents that support implicit skill activation can also choose it automatically when a task mentions Teak cards, the Teak CLI, Teak MCP, or the Teak API.
+Agents with implicit skill activation may pick it up when a task mentions Teak.
 
-## Related Docs
+## Related
 
-- [Command Line](/docs/cli/)
-- [API](/docs/api/)
-- [MCP](/docs/mcp/)
+- [Teak for AI Agents](/docs/ai-agents)
+- [CLI](/docs/cli)
+- [API](/docs/api)
+- [MCP](/docs/mcp)

--- a/apps/docs/src/content/docs/docs/support.mdx
+++ b/apps/docs/src/content/docs/docs/support.mdx
@@ -3,27 +3,30 @@ title: Support
 description: Get help and support for Teak
 ---
 
-## Troubleshooting First
+## Troubleshooting first
 
-- **Browser extension:** update your browser, temporarily disable other extensions, then clear cache/cookies.
-- **Mobile app:** confirm you're on the latest version, restart the app, and check for a stable internet connection.
+- **Web / desktop:** refresh or relaunch, confirm you are signed in, check network.
+- **Browser extension:** update the browser, disable other extensions temporarily, clear cache for the site you are saving.
+- **Mobile:** latest App Store version, restart the app, stable connection; for share sheet issues see [Mobile](/docs/mobile#troubleshooting).
+- **CLI / Raycast / API / MCP:** confirm sign-in or that your API key is still active in Settings; see [CLI](/docs/cli), [Raycast](/docs/raycast), [API](/docs/api), [MCP](/docs/mcp).
 
-## Contact Us
+## Contact
 
-- Email support: hi@praveenjuge.com (typical response 24–48 hours)
+- Email: hi@praveenjuge.com (typical response 24–48 hours)
+- Billing and account: Settings → Upgrade / Billing, or email the address above
 
-## Bug Reports
+## Bug reports
 
-1. Go to [GitHub Issues](https://github.com/praveenjuge/teak/issues)
-2. Include steps to reproduce the issue
-3. Describe what you expected to happen
-4. Add browser/OS version if relevant
+1. [GitHub Issues](https://github.com/praveenjuge/teak/issues)
+2. Steps to reproduce
+3. Expected vs actual behavior
+4. App, browser, or OS version if relevant
 
-## Feature Requests
+## Feature requests
 
-- Submit ideas on [GitHub Issues](https://github.com/praveenjuge/teak/issues) and use the **enhancement** label.
+[GitHub Issues](https://github.com/praveenjuge/teak/issues) with the **enhancement** label.
 
 ## Community
 
-- Follow on [X/Twitter](https://x.com/praveenjuge) for updates and tips
-- Explore the [GitHub repository](https://github.com/praveenjuge/teak) for open-source contributions
+- [X/Twitter](https://x.com/praveenjuge)
+- [GitHub](https://github.com/praveenjuge/teak)

--- a/apps/docs/src/content/docs/docs/terms-of-service.mdx
+++ b/apps/docs/src/content/docs/docs/terms-of-service.mdx
@@ -1,15 +1,15 @@
 ---
 title: Terms of Service
-description: Terms and conditions for using Teak web app, mobile app, and browser extension
+description: Terms and conditions for using Teak
 ---
 
 ## 1. Overview & Acceptance
 
-These Terms of Service ("Terms") govern your use of Teak's web app, mobile app, and browser extension (collectively, the "Service"). By creating an account, installing our apps, or using the Service, you agree to these Terms and our Privacy Policy.
+These Terms of Service ("Terms") govern your use of Teak's web app, desktop app, mobile app, browser extensions, Raycast extension, CLI, public API, and MCP server (collectively, the "Service"). By creating an account, installing our apps, or using the Service, you agree to these Terms and our Privacy Policy.
 
 ## 2. Service Description
 
-Teak is a visual bookmarking platform that helps designers capture, organize, and search inspiration across web, mobile, and browser extension platforms.
+Teak is a personal knowledge hub that helps you capture, organize, and search inspiration and references across devices and integrations.
 
 ## 3. User Accounts
 
@@ -18,8 +18,8 @@ Teak is a visual bookmarking platform that helps designers capture, organize, an
 
 ## 4. Acceptable Use
 
-- **Permitted:** store and organize your personal design inspiration; use across web, mobile, and extension; share content through built-in sharing features.
-- **Prohibited:** store illegal, harmful, or offensive content; violate intellectual property rights; reverse engineer or hack our systems; use for commercial redistribution without permission; spam, harass, or abuse other users; upload malware or malicious code.
+- **Permitted:** store and organize your personal content; use across supported apps and integrations; export your data through built-in export.
+- **Prohibited:** store illegal, harmful, or offensive content; violate intellectual property rights; reverse engineer or hack our systems; use for commercial redistribution without permission; spam, harass, or abuse other users; upload malware or malicious code; abuse the API, MCP, or free-tier limits.
 
 ## 5. Content & Intellectual Property
 
@@ -33,7 +33,8 @@ Your privacy is important to us. Review the Privacy Policy to understand how we 
 ## 7. Subscription & Billing
 
 - **Free tier:** basic features with reasonable usage limits; no credit card required; available for personal use.
-- **Paid plans:** premium features and higher usage limits; billed through Polar subscription service; auto-renews unless cancelled; no refunds for partial months.
+- **Paid plans:** premium features and higher usage limits; billed through our subscription provider; auto-renews unless cancelled.
+- **Refunds:** new Pro subscriptions include a 30-day full refund if you are not satisfied. After that window, charges are non-refundable for unused time or partial months unless required by law.
 - **Payment terms:** provide current, complete payment information; you authorize charges to your payment method; update expired payment methods promptly; pricing changes may be given with 30 days' notice.
 
 ## 8. Service Availability
@@ -49,7 +50,7 @@ Your privacy is important to us. Review the Privacy Policy to understand how we 
 
 ## 10. Termination
 
-- **By you:** you may delete your account at any time; data is removed according to our deletion policy; no refunds for unused subscription time.
+- **By you:** you may delete your account at any time; data is removed according to our deletion policy; refunds follow the policy in Section 7.
 - **By us:** we may suspend access for violations; we may terminate accounts for repeated violations; we may terminate accounts inactive for 2+ years.
 
 ## 11. Governing Law
@@ -82,5 +83,5 @@ These Terms and the Privacy Policy are the entire agreement between you and Teak
 
 ---
 
-**Last Updated:** November 9, 2025  
+**Last Updated:** July 9, 2026  
 **Effective Date:** November 9, 2025

--- a/apps/docs/src/pages/pricing.astro
+++ b/apps/docs/src/pages/pricing.astro
@@ -65,7 +65,7 @@ const selfHostedPlan = {
   description: "Run Teak yourself. Unlimited cards, total control, zero cost.",
   cta: {
     text: "Setup Guide →",
-    href: "/docs",
+    href: "/docs/self-hosting",
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- Reorganize docs sidebar: group Import/Export under a Data section, move Agent Skill into Developers, and drop the MCP "New" badge.
- Tighten Features, Getting Started, Skills, and Support pages for clearer, more scannable product copy.
- Refresh Privacy Policy and Terms of Service for current surfaces (desktop, Raycast, CLI, API, MCP) and refund language; point self-hosted pricing CTA at the self-hosting guide.

## Test plan
- [x] Pre-commit typecheck/lint/build for `@teak/docs` passed
- [ ] Confirm docs sidebar groups Apps / Data / Developers / Company as expected
- [ ] Spot-check features, privacy, terms, support, skills, and pricing pages after deploy
- [ ] Verify internal links (import, export, self-hosting, mobile troubleshooting) resolve