### PR TITLE
Fix Sentry filtering and prod E2E clicks

### DIFF
--- a/apps/web/src/__tests__/sentryConfig.test.ts
+++ b/apps/web/src/__tests__/sentryConfig.test.ts
@@ -67,10 +67,54 @@ describe("filterClientSentryEvent", () => {
           },
         ],
       },
+      contexts: { browser: { name: "Safari" } },
       user: { username: "e2e-matrix-matrix-webkit-1783500370949-70o5ch" },
     } satisfies ErrorEvent;
 
     expect(filterClientSentryEvent(event)).toBeNull();
+  });
+
+  test("drops pre-symbolicated Safari e2e session fetch aborts", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "Load failed (app.teakvault.com)",
+            stacktrace: {
+              frames: [
+                { filename: "app:///_next/static/chunks/0k5wuabdzwsx5.js" },
+                { filename: "app:///_next/static/chunks/0-abc.js" },
+              ],
+            },
+          },
+        ],
+      },
+      contexts: { browser: { name: "Safari" } },
+      user: { username: "e2e-matrix-matrix-webkit-1783578880540-apowrq" },
+    } satisfies ErrorEvent;
+
+    expect(filterClientSentryEvent(event)).toBeNull();
+  });
+
+  test("keeps non-Safari e2e session fetch failures", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "Load failed (app.teakvault.com)",
+            stacktrace: {
+              frames: [{ filename: "app:///_next/static/chunks/app.js" }],
+            },
+          },
+        ],
+      },
+      contexts: { browser: { name: "Chrome" } },
+      user: { username: "e2e-matrix-matrix-chromium-1783578880540-apowrq" },
+    } satisfies ErrorEvent;
+
+    expect(filterClientSentryEvent(event)).toBe(event);
   });
 
   test("keeps real-user Better Auth session fetch failures", () => {

--- a/apps/web/src/lib/sentry-config.ts
+++ b/apps/web/src/lib/sentry-config.ts
@@ -47,8 +47,29 @@ const isProductionE2eMatrixUser = (event: ErrorEvent) =>
   typeof event.user?.username === "string" &&
   event.user.username.startsWith("e2e-matrix-");
 
+const isSafariBrowser = (event: ErrorEvent) => {
+  const browser = event.contexts?.browser;
+
+  return (
+    typeof browser === "object" &&
+    browser !== null &&
+    "name" in browser &&
+    browser.name === "Safari"
+  );
+};
+
+const isBetterAuthSessionFrame = (filename?: string) =>
+  Boolean(
+    filename &&
+      (filename.includes("node_modules/@convex-dev/better-auth/") ||
+        filename.includes("node_modules/better-auth/") ||
+        filename.includes("node_modules/@better-fetch/fetch/") ||
+        filename.includes("/_next/static/chunks/"))
+  );
+
 const isSafariBetterAuthLoadFailure = (event: ErrorEvent) =>
   isProductionE2eMatrixUser(event) &&
+  isSafariBrowser(event) &&
   (event.exception?.values?.some((exception) => {
     const isWebkitLoadFailure =
       exception.type === "TypeError" &&
@@ -56,12 +77,10 @@ const isSafariBetterAuthLoadFailure = (event: ErrorEvent) =>
 
     return (
       isWebkitLoadFailure &&
-      exception.stacktrace?.frames?.some(
-        (frame) =>
-          frame.filename?.includes("node_modules/@convex-dev/better-auth/") ||
-          frame.filename?.includes("node_modules/better-auth/") ||
-          frame.filename?.includes("node_modules/@better-fetch/fetch/")
-      )
+      (exception.stacktrace?.frames?.some((frame) =>
+        isBetterAuthSessionFrame(frame.filename)
+      ) ??
+        false)
     );
   }) ??
     false);

--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -1,4 +1,9 @@
-import { type Browser, expect, type Page } from "@playwright/test";
+import {
+  type Browser,
+  expect,
+  type Locator,
+  type Page,
+} from "@playwright/test";
 import { createTeakClient } from "@teak/convex/sdk";
 import { env, requirePassword, uniqueEmail } from "./env";
 import { waitForEmail } from "./mailpit";
@@ -15,6 +20,33 @@ export const appPath = (path: string) => new URL(path, env.appUrl).toString();
 
 export const newAnonymousContext = (browser: Browser) =>
   browser.newContext({ storageState: { cookies: [], origins: [] } });
+
+const isRetryableActionabilityError = (error: unknown) =>
+  error instanceof Error &&
+  /element (is not stable|was detached)|Timeout .* exceeded/.test(
+    error.message
+  );
+
+export const clickVisibleControl = async (
+  locator: Locator,
+  options: { timeout?: number } = {}
+) => {
+  const timeout = options.timeout ?? 15_000;
+  const target = locator.first();
+  await expect(target).toBeVisible({ timeout });
+  await expect(target).toBeEnabled({ timeout });
+
+  try {
+    await target.click({ timeout: Math.min(timeout, 5000) });
+  } catch (error) {
+    if (!isRetryableActionabilityError(error)) {
+      throw error;
+    }
+    await expect(target).toBeVisible({ timeout });
+    await expect(target).toBeEnabled({ timeout });
+    await target.click({ force: true, timeout: Math.min(timeout, 5000) });
+  }
+};
 
 const settingsRow = (page: Page, label: string) =>
   page

--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -2,7 +2,7 @@ import { Buffer } from "node:buffer";
 import { expect, type Page, test } from "@playwright/test";
 import { MAX_FILE_SIZE } from "@teak/convex/shared";
 import { apiFetch } from "../helpers/api";
-import { clientFor } from "../helpers/prod";
+import { clickVisibleControl, clientFor } from "../helpers/prod";
 import { readState, updateState } from "../helpers/run-state";
 
 const png = Buffer.from(
@@ -22,7 +22,9 @@ const pdf = Buffer.from(
 const saveTextCard = async (page: Page, content: string) => {
   await page.goto("/");
   await page.getByPlaceholder(/Write a note/i).fill(content);
-  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await clickVisibleControl(
+    page.getByRole("button", { exact: true, name: "Save" })
+  );
   await expect(page.getByRole("main").getByText(content).first()).toBeVisible();
 };
 
@@ -93,7 +95,7 @@ const waitForHomeUploadSurface = async (page: Page) => {
 const showTrash = async (page: Page) => {
   await page.goto("/");
   await page.getByPlaceholder("Search for anything...").click();
-  await page.getByRole("button", { name: "Trash" }).click();
+  await clickVisibleControl(page.getByRole("button", { name: "Trash" }));
 };
 
 const primaryContext = () => {

--- a/packages/tests/src/matrix/journey-lite.e2e.ts
+++ b/packages/tests/src/matrix/journey-lite.e2e.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { createAccount } from "../helpers/prod";
+import { clickVisibleControl, createAccount } from "../helpers/prod";
 
 test.setTimeout(180_000);
 
@@ -8,7 +8,9 @@ test("signup, create, and search", async ({ page }) => {
   const marker = `matrix-${Date.now()}`;
   await page.goto("/");
   await page.getByPlaceholder(/Write a note/i).fill(marker);
-  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await clickVisibleControl(
+    page.getByRole("button", { exact: true, name: "Save" })
+  );
   const savedCard = page
     .getByRole("main")
     .getByRole("paragraph")


### PR DESCRIPTION
## Summary
- filter the raw, pre-symbolicated Safari e2e Better Auth load-failure shape before it reaches Sentry
- add regression coverage for the Sentry event shape that regressed in production
- make production E2E clicks resilient to React replacing visible controls during Playwright actionability checks

## Root cause
Sentry `beforeSend` sees browser stack frames before Sentry symbolicates them, so the previous filter only matched the post-ingestion `node_modules/...` frame shape and missed raw `/_next/static/chunks/...` frames. The production E2E failure in #225 was a separate Playwright actionability race: the controls existed and were enabled, but React detached/replaced them while Playwright waited for stability.

## Validation
- pre-commit affected checks: `turbo run typecheck lint build --affected`
- `bun run --cwd packages/tests typecheck`
- `bun run --cwd packages/tests lint`
- `bun test apps/web/src/__tests__/sentryConfig.test.ts`
- `bunx biome check apps/web/src/lib/sentry-config.ts apps/web/src/__tests__/sentryConfig.test.ts packages/tests/src/helpers/prod.ts packages/tests/src/matrix/journey-lite.e2e.ts packages/tests/src/journey/09-web-product-surfaces.e2e.ts`

Fixes #225.
