### PR TITLE
Fix shared UI query caching

### DIFF
--- a/packages/ui/src/components/card-modal/ConnectedCardModal.tsx
+++ b/packages/ui/src/components/card-modal/ConnectedCardModal.tsx
@@ -1,6 +1,6 @@
 import { api } from "@teak/convex";
-import { useQuery } from "convex/react";
 import { useEffect, useState } from "react";
+import { useQuery } from "../../convexQueryHooks";
 import { useCardModal } from "../../hooks/useCardModal";
 import { MoreInformationModal } from "../modals/MoreInformationModal";
 import { NotesEditModal } from "../modals/NotesEditModal";

--- a/packages/ui/src/components/forms/AddCardActions.tsx
+++ b/packages/ui/src/components/forms/AddCardActions.tsx
@@ -18,10 +18,11 @@ import {
   TOAST_IDS,
 } from "@teak/ui/constants/toast";
 import { useGlobalFileDrop } from "@teak/ui/hooks";
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
 import { Mic, Square, Upload } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { useQuery } from "../../convexQueryHooks";
 
 interface AddCardActionsProps {
   onSuccess?: () => void;

--- a/packages/ui/src/components/forms/AddCardForm.tsx
+++ b/packages/ui/src/components/forms/AddCardForm.tsx
@@ -10,10 +10,11 @@ import {
   TOAST_IDS,
 } from "@teak/ui/constants/toast";
 import type { OptimisticLocalStore } from "convex/browser";
-import { useMutation, useQuery } from "convex/react";
+import { useMutation } from "convex/react";
 import { Maximize2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { useQuery } from "../../convexQueryHooks";
 import { FullScreenAddCardDialog } from "./FullScreenAddCardDialog";
 
 function addCardToSearchQueries(

--- a/packages/ui/src/components/settings/ImportPanel.tsx
+++ b/packages/ui/src/components/settings/ImportPanel.tsx
@@ -6,7 +6,7 @@ import {
   MAX_BOOKMARK_BYTES,
   MAX_RAINDROP_BYTES,
 } from "@teak/convex/import/constants";
-import { useAction, useQuery } from "convex/react";
+import { useAction } from "convex/react";
 import {
   Archive,
   Bookmark,
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { type ChangeEvent, type ComponentType, useRef, useState } from "react";
 import { toast } from "sonner";
+import { useQuery } from "../../convexQueryHooks";
 import { Button } from "../ui/button";
 import { Spinner } from "../ui/spinner";
 import { formatBytes, formatRelativeTime } from "./importExportFormat";

--- a/packages/ui/src/components/settings/__tests__/ImportPanel.contract.test.tsx
+++ b/packages/ui/src/components/settings/__tests__/ImportPanel.contract.test.tsx
@@ -7,6 +7,8 @@ let importQueryResult: unknown = null;
 mock.module("convex/react", () => ({
   ...convexReact,
   useAction: () => mock(),
+}));
+mock.module("../../../convexQueryHooks", () => ({
   useQuery: () => importQueryResult,
 }));
 mock.module("../../ui/button", () => ({
@@ -23,16 +25,20 @@ mock.module("sonner", () => ({
 const { ImportPanel, ImportProgressSummary } = await import("../ImportPanel");
 const { putParts } = await import("../importUpload");
 
+function renderImportPanel() {
+  return renderToStaticMarkup(<ImportPanel />);
+}
+
 describe("ImportPanel", () => {
   test("renders all backend import modes", () => {
-    const markup = renderToStaticMarkup(<ImportPanel />);
+    const markup = renderImportPanel();
     expect(markup).toContain("Import Bookmarks");
     expect(markup).toContain("Import Teak Archive");
     expect(markup).toContain("Import from Raindrop");
   });
 
   test("shows an empty last-import state when there are no imports", () => {
-    const markup = renderToStaticMarkup(<ImportPanel />);
+    const markup = renderImportPanel();
     expect(markup).toContain("No imports yet.");
   });
 
@@ -51,7 +57,7 @@ describe("ImportPanel", () => {
       updatedAt: 0,
     };
     try {
-      const markup = renderToStaticMarkup(<ImportPanel />);
+      const markup = renderImportPanel();
       expect(markup).toContain("Upload interrupted");
       expect(markup).toContain("Resume upload");
       // The interrupted upload can also be discarded.
@@ -129,7 +135,7 @@ describe("ImportPanel", () => {
       updatedAt: 0,
     };
     try {
-      const markup = renderToStaticMarkup(<ImportPanel />);
+      const markup = renderImportPanel();
       expect(markup).toContain("Import stopped");
       expect(markup).toContain(
         "Card limit reached. Please upgrade to Pro for unlimited cards."


### PR DESCRIPTION
## Summary
- Route shared UI reads through the existing cache-enabled query hooks.
- Cover the modal hydration, card-creation status, and import status queries.
- Update the import-panel contract test to mock the canonical query path.

## Validation
- `bun run typecheck --filter=@teak/ui`
- `bun run test --filter=@teak/ui`
- Pre-commit: affected typecheck, lint, and builds (with non-secret build-safe Convex URLs).

## Root cause
Several shared UI components imported `useQuery` directly from `convex/react`, bypassing the cache provider already installed around authenticated web UI.