### PR TITLE
Fix WebKit session error filtering

### DIFF
--- a/apps/web/src/__tests__/sentryConfig.test.ts
+++ b/apps/web/src/__tests__/sentryConfig.test.ts
@@ -67,7 +67,6 @@ describe("filterClientSentryEvent", () => {
           },
         ],
       },
-      contexts: { browser: { name: "Safari" } },
       user: { username: "e2e-matrix-matrix-webkit-1783500370949-70o5ch" },
     } satisfies ErrorEvent;
 
@@ -90,14 +89,13 @@ describe("filterClientSentryEvent", () => {
           },
         ],
       },
-      contexts: { browser: { name: "Safari" } },
       user: { username: "e2e-matrix-matrix-webkit-1783578880540-apowrq" },
     } satisfies ErrorEvent;
 
     expect(filterClientSentryEvent(event)).toBeNull();
   });
 
-  test("keeps non-Safari e2e session fetch failures", () => {
+  test("keeps non-WebKit e2e session fetch failures", () => {
     const event = {
       exception: {
         values: [
@@ -110,7 +108,6 @@ describe("filterClientSentryEvent", () => {
           },
         ],
       },
-      contexts: { browser: { name: "Chrome" } },
       user: { username: "e2e-matrix-matrix-chromium-1783578880540-apowrq" },
     } satisfies ErrorEvent;
 

--- a/apps/web/src/lib/sentry-config.ts
+++ b/apps/web/src/lib/sentry-config.ts
@@ -43,20 +43,9 @@ const isExtensionFetchFailure = (event: ErrorEvent) =>
     );
   }) ?? false;
 
-const isProductionE2eMatrixUser = (event: ErrorEvent) =>
+const isProductionE2eWebkitUser = (event: ErrorEvent) =>
   typeof event.user?.username === "string" &&
-  event.user.username.startsWith("e2e-matrix-");
-
-const isSafariBrowser = (event: ErrorEvent) => {
-  const browser = event.contexts?.browser;
-
-  return (
-    typeof browser === "object" &&
-    browser !== null &&
-    "name" in browser &&
-    browser.name === "Safari"
-  );
-};
+  event.user.username.startsWith("e2e-matrix-matrix-webkit-");
 
 const isBetterAuthSessionFrame = (filename?: string) =>
   Boolean(
@@ -68,8 +57,7 @@ const isBetterAuthSessionFrame = (filename?: string) =>
   );
 
 const isSafariBetterAuthLoadFailure = (event: ErrorEvent) =>
-  isProductionE2eMatrixUser(event) &&
-  isSafariBrowser(event) &&
+  isProductionE2eWebkitUser(event) &&
   (event.exception?.values?.some((exception) => {
     const isWebkitLoadFailure =
       exception.type === "TypeError" &&


### PR DESCRIPTION
## Summary
- identify the production E2E WebKit account directly when filtering the known Better Auth session fetch abort
- avoid relying on browser context that is enriched after the client beforeSend hook runs
- preserve reporting for real users and non-WebKit E2E failures

## Sentry
- fixes the regressed TEAK-WEB-PROD-EA event shape observed on release 8e4fa120

## Validation
- bun test apps/web/src/__tests__/sentryConfig.test.ts
- bunx biome check apps/web/src/lib/sentry-config.ts apps/web/src/__tests__/sentryConfig.test.ts
- bun run --cwd apps/web typecheck
- bun run pre-commit