### PR TITLE
Make production E2E faster and safer

### DIFF
--- a/.github/workflows/prod-e2e.yml
+++ b/.github/workflows/prod-e2e.yml
@@ -25,8 +25,10 @@ env:
   PROD_API_URL: https://teakvault.com/api
   PROD_MCP_URL: https://teakvault.com/mcp
   PROD_E2E_PASSWORD: ${{ secrets.PROD_E2E_PASSWORD }}
+  E2E_CLEANUP_TOKEN: ${{ secrets.E2E_CLEANUP_TOKEN }}
   MAILPIT_URL: ${{ secrets.MAILPIT_URL }}
   E2E_EMAIL_DOMAIN: ${{ secrets.E2E_EMAIL_DOMAIN }}
+  VITE_PUBLIC_CONVEX_SITE_URL: ${{ vars.VITE_PUBLIC_CONVEX_SITE_URL }}
 
 jobs:
   gate:
@@ -34,8 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
-      - run: bun run --cwd packages/tests preflight
+      - run: bun packages/tests/src/scripts/preflight.ts
       - run: curl -fsS "$PROD_APP_URL/login" >/dev/null
       - run: bash scripts/smoke-urls.sh
 
@@ -52,7 +53,7 @@ jobs:
       - run: bunx playwright install --with-deps chromium
       - run: bun run --cwd packages/tests e2e:prod:journey
       - if: always()
-        run: bun run --cwd packages/tests teardown
+        run: bun packages/tests/src/scripts/teardown.ts
       - if: always()
         uses: actions/upload-artifact@v6
         with:
@@ -93,8 +94,6 @@ jobs:
       - run: bunx playwright install --with-deps chromium firefox webkit
       - run: bun run --cwd packages/tests e2e:prod:matrix
       - if: always()
-        run: bun run --cwd packages/tests teardown
-      - if: always()
         uses: actions/upload-artifact@v6
         with:
           name: prod-e2e-matrix-results
@@ -119,8 +118,6 @@ jobs:
       - run: bunx playwright install --with-deps chromium
       - run: bun run --cwd packages/tests e2e:prod:extension
       - if: always()
-        run: bun run --cwd packages/tests teardown
-      - if: always()
         uses: actions/upload-artifact@v6
         with:
           name: prod-e2e-extension-results
@@ -130,16 +127,14 @@ jobs:
           retention-days: 7
 
   sweep:
-    needs: [journey, matrix, extension]
-    if: always() && (github.event_name == 'schedule' || inputs.sweep)
+    needs: gate
+    if: always() && needs.gate.result == 'success' && (github.event_name == 'schedule' || inputs.sweep)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
-      - run: bunx playwright install --with-deps chromium
-      - run: bun run --cwd packages/tests sweep
+      - run: bun packages/tests/src/scripts/sweep.ts
 
   notify:
     needs: [gate, journey, docs, matrix, extension, sweep]

--- a/apps/mobile/app/(tabs)/settings/index.tsx
+++ b/apps/mobile/app/(tabs)/settings/index.tsx
@@ -20,7 +20,6 @@ import {
   tag,
 } from "@expo/ui/swift-ui/modifiers";
 import { api } from "@teak/convex";
-import { useMutation } from "convex/react";
 import { useQuery } from "convex-helpers/react/cache/hooks";
 import { Stack, useRouter } from "expo-router";
 import { useMemo, useState } from "react";
@@ -36,7 +35,6 @@ export default function SettingsScreen() {
   const { preference, setPreference, isLoaded } = useThemePreference();
   const router = useRouter();
   const currentUser = useQuery(api.auth.getCurrentUser, {});
-  const deleteAccount = useMutation(api.auth.deleteAccount);
 
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -110,8 +108,6 @@ export default function SettingsScreen() {
     setIsDeleting(true);
 
     try {
-      await deleteAccount({});
-
       let deleteUserFailed = false;
       await authClient.deleteUser(undefined, {
         onError: (ctx) => {

--- a/apps/web/src/app/(settings)/settings/page.tsx
+++ b/apps/web/src/app/(settings)/settings/page.tsx
@@ -9,7 +9,7 @@ import { getPolarPlanIds } from "@teak/ui/constants/billing";
 import { TOAST_IDS } from "@teak/ui/constants/toast";
 import { useSettingsController } from "@teak/ui/hooks";
 import { SettingsContent, SubscriptionSection } from "@teak/ui/settings";
-import { useAction, useMutation } from "convex/react";
+import { useAction } from "convex/react";
 import { useRouter } from "next/navigation";
 import { useTheme } from "next-themes";
 import { useEffect, useRef, useState } from "react";
@@ -17,7 +17,6 @@ import { toast } from "sonner";
 import { authClient } from "@/lib/auth-client";
 
 export default function ProfileSettingsPage() {
-  const deleteAccount = useMutation(api.auth.deleteAccount);
   const [subscriptionOpen, setSubscriptionOpen] = useState(false);
   const [loadingPlanId, setLoadingPlanId] = useState<string | null>(null);
   const checkoutInstanceRef = useRef<PolarEmbedCheckout | null>(null);
@@ -39,8 +38,6 @@ export default function ProfileSettingsPage() {
       });
     },
     onDeleteAccount: async () => {
-      await deleteAccount({});
-
       let deleteError: string | null = null;
       // The awaited call's onError callback assigns `deleteError`; the guard
       // below reads that side effect, so this await cannot be deferred past it.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "pre-commit": "turbo run typecheck lint build --affected",
     "prepare": "simple-git-hooks || exit 0",
     "start": "turbo run start",
-    "test": "turbo run test --filter=!@teak/tests",
+    "test": "turbo run test",
     "typecheck": "turbo run typecheck",
     "check": "ultracite check",
     "fix": "ultracite fix",

--- a/packages/convex/__tests__/__tests__/auth.test.ts
+++ b/packages/convex/__tests__/__tests__/auth.test.ts
@@ -32,7 +32,7 @@ mock.module("@convex-dev/better-auth/utils", () => ({
   isActionCtx: () => true,
 }));
 
-// Mock the R2 storage helpers used by auth.deleteAccountHandler so we can
+// Mock the R2 storage helpers used by auth.deleteAccountDataHandler so we can
 // assert deletions without standing up an actual R2 client.
 mock.module("../../storage/r2", r2MockModuleFactory);
 
@@ -41,7 +41,7 @@ let ensureCardCreationAllowed: any;
 let getCurrentUserHandler: any;
 let getAuthUserHandler: any;
 let getCardCreationStatusHandler: any;
-let deleteAccountHandler: any;
+let deleteAccountDataHandler: any;
 let authComponent: any;
 let createAuth: any;
 let polar: any;
@@ -58,7 +58,7 @@ describe("auth", () => {
     getCurrentUserHandler = authModule.getCurrentUserHandler;
     getAuthUserHandler = authModule.getAuthUserHandler;
     getCardCreationStatusHandler = authModule.getCardCreationStatusHandler;
-    deleteAccountHandler = authModule.deleteAccountHandler;
+    deleteAccountDataHandler = authModule.deleteAccountDataHandler;
     authComponent = authModule.authComponent;
     createAuth = authModule.createAuth;
 
@@ -467,23 +467,11 @@ describe("auth", () => {
     });
   });
 
-  describe("deleteAccount", () => {
-    it("throws if not authenticated", () => {
-      const ctx = {
-        auth: { getUserIdentity: mock().mockResolvedValue(null) },
-      } as any;
-      expect(deleteAccountHandler(ctx)).rejects.toThrow(
-        "User must be authenticated"
-      );
-    });
-
+  describe("deleteAccountData", () => {
     it("deletes cards and files", async () => {
       r2Mocks.deleteObject.mockClear();
 
       const ctx = {
-        auth: {
-          getUserIdentity: mock().mockResolvedValue({ subject: "u1" }),
-        },
         db: {
           query: () => ({
             withIndex: (_name: any, cb: any) => {
@@ -506,7 +494,7 @@ describe("auth", () => {
         },
       } as any;
 
-      const result = await deleteAccountHandler(ctx);
+      const result = await deleteAccountDataHandler(ctx, "u1");
 
       expect(result.deletedCards).toBe(2);
       expect(result.deletedStorageObjectCount).toBe(2);
@@ -517,7 +505,7 @@ describe("auth", () => {
   });
 
   describe("createAuth", () => {
-    it("returns betterAuth instance and covers callbacks", () => {
+    it("returns betterAuth instance and covers callbacks", async () => {
       const originalSiteUrl = process.env.SITE_URL;
       const originalGoogleClientId = process.env.GOOGLE_CLIENT_ID;
       const originalGoogleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
@@ -550,6 +538,10 @@ describe("auth", () => {
         const options = auth.options;
         expect(options.emailAndPassword?.sendResetPassword).toBeFunction();
         expect(options.emailVerification?.sendVerificationEmail).toBeFunction();
+        await options.user.deleteUser.beforeDelete({ id: "u1" });
+        expect(ctx.runMutation).toHaveBeenCalledWith(expect.anything(), {
+          userId: "u1",
+        });
       } finally {
         process.env.SITE_URL = originalSiteUrl;
         process.env.GOOGLE_CLIENT_ID = originalGoogleClientId;

--- a/packages/convex/__tests__/auth.test.ts
+++ b/packages/convex/__tests__/auth.test.ts
@@ -30,9 +30,9 @@ describe("auth.ts", () => {
     expect(module.getCurrentUser).toBeDefined();
   });
 
-  test("exports deleteAccount", async () => {
+  test("exports canonical account data deletion", async () => {
     const module = await import("../auth");
-    expect(module.deleteAccount).toBeDefined();
+    expect(module.deleteAccountData).toBeDefined();
   });
 
   test("exports ensureCardCreationAllowed", async () => {
@@ -75,9 +75,9 @@ describe("auth.ts", () => {
     expect(module.getCurrentUser).toBeDefined();
   });
 
-  test("deleteAccount is a mutation function", async () => {
+  test("account data deletion is an internal mutation", async () => {
     const module = await import("../auth");
-    expect(module.deleteAccount).toBeDefined();
+    expect(module.deleteAccountData).toBeDefined();
   });
 
   test("createAuth returns auth configuration", async () => {

--- a/packages/convex/__tests__/e2eCleanup.test.ts
+++ b/packages/convex/__tests__/e2eCleanup.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  deleteE2ECleanupCandidates,
+  e2eCleanupPlugin,
+  isE2EEmail,
+  isWithinCleanupAge,
+  normalizeE2EEmailDomain,
+  resolveExactE2ECleanupCandidates,
+  resolveOrphanE2ECleanupCandidates,
+} from "../e2eCleanup";
+
+describe("production E2E cleanup safety", () => {
+  test("normalizes only valid configured domains", () => {
+    expect(normalizeE2EEmailDomain(" Tests.Example.COM ")).toBe(
+      "tests.example.com"
+    );
+    for (const domain of ["", "localhost", "@example.com", "-bad.example"]) {
+      expect(() => normalizeE2EEmailDomain(domain)).toThrow();
+    }
+  });
+
+  test("accepts only the configured E2E namespace", () => {
+    const domain = "tests.example.com";
+    expect(isE2EEmail("e2e-primary-123-abc@tests.example.com", domain)).toBe(
+      true
+    );
+    expect(isE2EEmail("person@tests.example.com", domain)).toBe(false);
+    expect(isE2EEmail("e2e-primary-123-abc@example.com", domain)).toBe(false);
+    expect(isE2EEmail("e2e-../../unsafe@tests.example.com", domain)).toBe(
+      false
+    );
+  });
+
+  test("enforces lower and upper account-age bounds", () => {
+    const now = Date.UTC(2026, 6, 10);
+    expect(
+      isWithinCleanupAge({
+        createdAt: now - 60_000,
+        maxAgeMs: 120_000,
+        minAgeMs: 30_000,
+        now,
+      })
+    ).toBe(true);
+    expect(
+      isWithinCleanupAge({
+        createdAt: now - 10_000,
+        maxAgeMs: 120_000,
+        minAgeMs: 30_000,
+        now,
+      })
+    ).toBe(false);
+    expect(
+      isWithinCleanupAge({
+        createdAt: now - 10 * 60_000,
+        maxAgeMs: 120_000,
+        minAgeMs: 30_000,
+        now,
+      })
+    ).toBe(false);
+  });
+
+  test("registers one schema-free protected cleanup endpoint", () => {
+    const plugin = e2eCleanupPlugin({} as never);
+    expect(plugin.id).toBe("teak-e2e-cleanup");
+    expect(plugin.schema).toBeUndefined();
+    expect(plugin.endpoints?.cleanupE2EAccounts).toBeDefined();
+  });
+
+  test("exact cleanup separates missing, eligible, and unsafe accounts", async () => {
+    const now = Date.UTC(2026, 6, 10);
+    const findUserByEmail = mock((email: string) => {
+      if (email.startsWith("e2e-missing")) {
+        return Promise.resolve(null);
+      }
+      return Promise.resolve({
+        accounts: [],
+        user: {
+          createdAt: new Date(
+            now - (email.startsWith("e2e-old") ? 48 : 1) * 60 * 60 * 1000
+          ),
+          email,
+          id: email,
+        },
+      });
+    });
+    const result = await resolveExactE2ECleanupCandidates({
+      authCtx: { internalAdapter: { findUserByEmail } } as never,
+      domain: "tests.example.com",
+      emails: [
+        "e2e-live@tests.example.com",
+        "e2e-missing@tests.example.com",
+        "e2e-old@tests.example.com",
+      ],
+      now,
+    });
+
+    expect(result.candidates.map((candidate) => candidate.email)).toEqual([
+      "e2e-live@tests.example.com",
+    ]);
+    expect(result.alreadyDeleted).toEqual(["e2e-missing@tests.example.com"]);
+    expect(result.ignoredOutOfRange).toEqual(["e2e-old@tests.example.com"]);
+    expect(findUserByEmail).toHaveBeenCalledTimes(3);
+    expect(
+      resolveExactE2ECleanupCandidates({
+        authCtx: { internalAdapter: { findUserByEmail } } as never,
+        domain: "tests.example.com",
+        emails: ["person@example.com"],
+        now,
+      })
+    ).rejects.toThrow("Invalid E2E email");
+  });
+
+  test("orphan cleanup is server-filtered, bounded, and reports overflow", async () => {
+    const now = Date.UTC(2026, 6, 10);
+    const users = Array.from({ length: 201 }, (_, index) => ({
+      createdAt: new Date(now - 60 * 60 * 1000),
+      email: `e2e-orphan-${index}@tests.example.com`,
+      id: `user-${index}`,
+    }));
+    const listUsers = mock(async () => users);
+    const result = await resolveOrphanE2ECleanupCandidates({
+      authCtx: { internalAdapter: { listUsers } } as never,
+      domain: "tests.example.com",
+      now,
+    });
+
+    expect(result.candidates).toHaveLength(200);
+    expect(result.remainingEligible).toBe(true);
+    expect(listUsers).toHaveBeenCalledTimes(1);
+    const [limit, offset, sortBy, where] = listUsers.mock.calls[0];
+    expect(limit).toBe(201);
+    expect(offset).toBe(0);
+    expect(sortBy).toEqual({ direction: "asc", field: "createdAt" });
+    expect(where).toContainEqual({
+      field: "email",
+      operator: "ends_with",
+      value: "@tests.example.com",
+    });
+  });
+
+  test("deletion removes Teak data before auth and surfaces failures", async () => {
+    const runMutation = mock((_reference: unknown, { userId }: any) => {
+      if (userId === "user-2") {
+        return Promise.reject(new Error("mutation failed"));
+      }
+      return Promise.resolve();
+    });
+    const deleteUser = mock(() => Promise.resolve());
+    const originalConsoleError = console.error;
+    console.error = mock();
+    try {
+      const result = await deleteE2ECleanupCandidates({
+        appCtx: { runMutation } as never,
+        authCtx: { internalAdapter: { deleteUser } } as never,
+        candidates: [
+          {
+            createdAt: new Date(),
+            email: "e2e-one@tests.example.com",
+            id: "user-1",
+          },
+          {
+            createdAt: new Date(),
+            email: "e2e-two@tests.example.com",
+            id: "user-2",
+          },
+        ],
+      });
+
+      expect(result.deleted).toEqual(["e2e-one@tests.example.com"]);
+      expect(result.failures).toEqual([
+        {
+          email: "e2e-two@tests.example.com",
+          reason: "account cleanup failed",
+        },
+      ]);
+      expect(runMutation).toHaveBeenCalledTimes(2);
+      expect(deleteUser).toHaveBeenCalledTimes(1);
+      expect(deleteUser).toHaveBeenCalledWith("user-1");
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+});

--- a/packages/convex/auth.ts
+++ b/packages/convex/auth.ts
@@ -9,18 +9,19 @@ import { requireActionCtx } from "@convex-dev/better-auth/utils";
 import { Resend } from "@convex-dev/resend";
 import { type BetterAuthOptions, betterAuth } from "better-auth/minimal";
 import { mcp } from "better-auth/plugins";
-import { ConvexError } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { components, internal } from "./_generated/api";
 import type { DataModel } from "./_generated/dataModel";
 import {
   internalAction,
+  internalMutation,
   type MutationCtx,
-  mutation,
   query,
 } from "./_generated/server";
 import authConfig from "./auth.config";
 import { polar } from "./billing";
 import { isLocalDevelopmentUrl, resolveTeakDevAppUrl } from "./devUrls";
+import { e2eCleanupPlugin } from "./e2eCleanup";
 import { scheduleBusinessEvent } from "./sentry";
 import {
   CARD_ERROR_CODES,
@@ -241,10 +242,19 @@ export const createAuth = (ctx: GenericCtx<DataModel>) => {
     user: {
       deleteUser: {
         enabled: true,
+        beforeDelete: async (user) => {
+          await requireActionCtx(ctx).runMutation(
+            internal.auth.deleteAccountData,
+            {
+              userId: user.id,
+            }
+          );
+        },
       },
     },
     plugins: [
       expo(),
+      e2eCleanupPlugin(ctx),
       convex({
         authConfig,
         jwksRotateOnTokenGenerationError: true,
@@ -495,13 +505,10 @@ export async function ensureCardCreationAllowed(
   }
 }
 
-export const deleteAccountHandler = async (ctx: any) => {
-  const identity = await ctx.auth.getUserIdentity();
-  if (!identity) {
-    throw new Error("User must be authenticated");
-  }
-
-  const userId = identity.subject;
+export const deleteAccountDataHandler = async (
+  ctx: MutationCtx,
+  userId: string
+) => {
   let deletedStorageObjectCount = 0;
 
   // Use by_user_deleted index with partial match (just userId)
@@ -559,9 +566,13 @@ export const deleteAccountHandler = async (ctx: any) => {
   return { deletedCards: cards.length, deletedStorageObjectCount };
 };
 
-export const deleteAccount = mutation({
-  args: {},
-  handler: deleteAccountHandler,
+export const deleteAccountData = internalMutation({
+  args: { userId: v.string() },
+  returns: v.object({
+    deletedCards: v.number(),
+    deletedStorageObjectCount: v.number(),
+  }),
+  handler: async (ctx, { userId }) => deleteAccountDataHandler(ctx, userId),
 });
 
 export const getLatestJwks = internalAction({

--- a/packages/convex/e2eCleanup.ts
+++ b/packages/convex/e2eCleanup.ts
@@ -1,0 +1,284 @@
+import type { AuthContext } from "@better-auth/core";
+import type { GenericCtx } from "@convex-dev/better-auth";
+import { requireActionCtx } from "@convex-dev/better-auth/utils";
+import type { BetterAuthPlugin } from "better-auth";
+import { APIError, createAuthEndpoint } from "better-auth/api";
+import { z } from "zod";
+import { internal } from "./_generated/api";
+import type { DataModel } from "./_generated/dataModel";
+import type { ActionCtx } from "./_generated/server";
+
+const CLEANUP_CONCURRENCY = 3;
+const EXACT_EMAIL_LIMIT = 20;
+const MAX_CANDIDATES_PER_RUN = 200;
+const ORPHAN_MIN_AGE_MS = 30 * 60 * 1000;
+const ORPHAN_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000;
+const EXACT_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const CLOCK_SKEW_MS = 5 * 60 * 1000;
+
+interface CleanupCandidate {
+  createdAt: Date | number;
+  email: string;
+  id: string;
+}
+
+interface CleanupFailure {
+  email: string;
+  reason: string;
+}
+
+type CleanupAuthContext = Pick<AuthContext, "internalAdapter">;
+
+export interface E2ECleanupResult {
+  alreadyDeleted: string[];
+  deleted: string[];
+  failures: CleanupFailure[];
+  ignoredOutOfRange: string[];
+  remainingEligible: boolean;
+}
+
+const requestSchema = z.object({
+  emails: z
+    .array(z.string().email().max(254))
+    .min(1)
+    .max(EXACT_EMAIL_LIMIT)
+    .optional(),
+});
+
+export const normalizeE2EEmailDomain = (value: string): string => {
+  const domain = value.trim().toLowerCase();
+  const isValid =
+    domain.length <= 253 &&
+    domain.includes(".") &&
+    !domain.includes("@") &&
+    domain
+      .split(".")
+      .every((label) => /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label));
+  if (!isValid) {
+    throw new Error("E2E_EMAIL_DOMAIN is invalid");
+  }
+  return domain;
+};
+
+export const isE2EEmail = (email: string, domain: string): boolean => {
+  const normalized = email.trim().toLowerCase();
+  const suffix = `@${domain}`;
+  if (!normalized.endsWith(suffix)) {
+    return false;
+  }
+  const localPart = normalized.slice(0, -suffix.length);
+  return /^e2e-[a-z0-9][a-z0-9-]{0,100}$/.test(localPart);
+};
+
+export const isWithinCleanupAge = ({
+  createdAt,
+  maxAgeMs,
+  minAgeMs,
+  now,
+}: {
+  createdAt: Date | number;
+  maxAgeMs: number;
+  minAgeMs: number;
+  now: number;
+}): boolean => {
+  const createdAtMs =
+    createdAt instanceof Date ? createdAt.getTime() : createdAt;
+  const ageMs = now - createdAtMs;
+  return ageMs >= minAgeMs && ageMs <= maxAgeMs + CLOCK_SKEW_MS;
+};
+
+const runWithConcurrency = async <T>(
+  values: T[],
+  operation: (value: T) => Promise<void>
+): Promise<PromiseSettledResult<void>[]> => {
+  const results: PromiseSettledResult<void>[] = [];
+  for (let index = 0; index < values.length; index += CLEANUP_CONCURRENCY) {
+    const batch = values.slice(index, index + CLEANUP_CONCURRENCY);
+    results.push(...(await Promise.allSettled(batch.map(operation))));
+  }
+  return results;
+};
+
+export const deleteE2ECleanupCandidates = async ({
+  appCtx,
+  authCtx,
+  candidates,
+}: {
+  appCtx: ActionCtx;
+  authCtx: CleanupAuthContext;
+  candidates: CleanupCandidate[];
+}) => {
+  const results = await runWithConcurrency(candidates, async (candidate) => {
+    await appCtx.runMutation(internal.auth.deleteAccountData, {
+      userId: candidate.id,
+    });
+    await authCtx.internalAdapter.deleteUser(candidate.id);
+  });
+
+  const deleted: string[] = [];
+  const failures: CleanupFailure[] = [];
+  for (const [index, result] of results.entries()) {
+    const candidate = candidates[index];
+    if (result.status === "fulfilled") {
+      deleted.push(candidate.email);
+    } else {
+      console.error(`E2E cleanup failed for ${candidate.email}`, result.reason);
+      failures.push({
+        email: candidate.email,
+        reason: "account cleanup failed",
+      });
+    }
+  }
+  return { deleted, failures };
+};
+
+export const resolveExactE2ECleanupCandidates = async ({
+  authCtx,
+  domain,
+  emails,
+  now,
+}: {
+  authCtx: CleanupAuthContext;
+  domain: string;
+  emails: string[];
+  now: number;
+}) => {
+  const uniqueEmails = [...new Set(emails.map((email) => email.toLowerCase()))];
+  if (uniqueEmails.some((email) => !isE2EEmail(email, domain))) {
+    throw new APIError("BAD_REQUEST", { message: "Invalid E2E email" });
+  }
+
+  const records = await Promise.all(
+    uniqueEmails.map(async (email) => ({
+      email,
+      result: await authCtx.internalAdapter.findUserByEmail(email),
+    }))
+  );
+  const alreadyDeleted: string[] = [];
+  const candidates: CleanupCandidate[] = [];
+  const ignoredOutOfRange: string[] = [];
+  for (const record of records) {
+    if (!record.result) {
+      alreadyDeleted.push(record.email);
+      continue;
+    }
+    const candidate = record.result.user;
+    if (
+      !isWithinCleanupAge({
+        createdAt: candidate.createdAt,
+        maxAgeMs: EXACT_MAX_AGE_MS,
+        minAgeMs: -CLOCK_SKEW_MS,
+        now,
+      })
+    ) {
+      ignoredOutOfRange.push(record.email);
+      continue;
+    }
+    candidates.push(candidate);
+  }
+  return { alreadyDeleted, candidates, ignoredOutOfRange };
+};
+
+export const resolveOrphanE2ECleanupCandidates = async ({
+  authCtx,
+  domain,
+  now,
+}: {
+  authCtx: CleanupAuthContext;
+  domain: string;
+  now: number;
+}) => {
+  const users = await authCtx.internalAdapter.listUsers(
+    MAX_CANDIDATES_PER_RUN + 1,
+    0,
+    { direction: "asc", field: "createdAt" },
+    [
+      { field: "email", operator: "starts_with", value: "e2e-" },
+      { field: "email", operator: "ends_with", value: `@${domain}` },
+      {
+        field: "createdAt",
+        operator: "gte",
+        value: new Date(now - ORPHAN_MAX_AGE_MS),
+      },
+      {
+        field: "createdAt",
+        operator: "lte",
+        value: new Date(now - ORPHAN_MIN_AGE_MS),
+      },
+    ]
+  );
+  const eligible = users.filter(
+    (user) =>
+      isE2EEmail(user.email, domain) &&
+      isWithinCleanupAge({
+        createdAt: user.createdAt,
+        maxAgeMs: ORPHAN_MAX_AGE_MS,
+        minAgeMs: ORPHAN_MIN_AGE_MS,
+        now,
+      })
+  );
+  return {
+    candidates: eligible.slice(0, MAX_CANDIDATES_PER_RUN),
+    remainingEligible: eligible.length > MAX_CANDIDATES_PER_RUN,
+  };
+};
+
+export const e2eCleanupPlugin = (
+  appCtx: GenericCtx<DataModel>
+): BetterAuthPlugin => ({
+  id: "teak-e2e-cleanup",
+  endpoints: {
+    cleanupE2EAccounts: createAuthEndpoint(
+      "/internal/e2e/cleanup",
+      { method: "POST", body: requestSchema },
+      async (ctx) => {
+        const expectedToken = process.env.E2E_CLEANUP_TOKEN;
+        const emailDomain = process.env.E2E_EMAIL_DOMAIN;
+        if (!(expectedToken && emailDomain)) {
+          throw new APIError("SERVICE_UNAVAILABLE", {
+            message: "E2E cleanup is not configured",
+          });
+        }
+        if (ctx.headers?.get("authorization") !== `Bearer ${expectedToken}`) {
+          throw new APIError("UNAUTHORIZED", { message: "Unauthorized" });
+        }
+
+        const domain = normalizeE2EEmailDomain(emailDomain);
+        const now = Date.now();
+        const exact = ctx.body.emails
+          ? await resolveExactE2ECleanupCandidates({
+              authCtx: ctx.context,
+              domain,
+              emails: ctx.body.emails,
+              now,
+            })
+          : null;
+        const orphan = exact
+          ? null
+          : await resolveOrphanE2ECleanupCandidates({
+              authCtx: ctx.context,
+              domain,
+              now,
+            });
+        const candidates = exact?.candidates ?? orphan?.candidates ?? [];
+        const deleted = await deleteE2ECleanupCandidates({
+          appCtx: requireActionCtx(appCtx),
+          authCtx: ctx.context,
+          candidates,
+        });
+        const result: E2ECleanupResult = {
+          alreadyDeleted: exact?.alreadyDeleted ?? [],
+          deleted: deleted.deleted,
+          failures: deleted.failures,
+          ignoredOutOfRange: exact?.ignoredOutOfRange ?? [],
+          remainingEligible: orphan?.remainingEligible ?? false,
+        };
+        const ineffective =
+          result.failures.length > 0 ||
+          result.ignoredOutOfRange.length > 0 ||
+          result.remainingEligible;
+        return ctx.json(result, { status: ineffective ? 500 : 200 });
+      }
+    ),
+  },
+});

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -15,6 +15,7 @@ bun run --cwd packages/tests teardown
 Required secret:
 
 - `PROD_E2E_PASSWORD`: strong password used only for throwaway `e2e-*` production accounts. The password is never written to `.state`.
+- `E2E_CLEANUP_TOKEN`: bearer token shared only by GitHub Actions and the production backend. It authorizes the server-side E2E account cleanup endpoint.
 - `MAILPIT_URL`: private Mailpit HTTP origin used for verification and reset email polling.
 - `E2E_EMAIL_DOMAIN`: private MX-routed domain used for throwaway account inboxes.
 
@@ -25,6 +26,8 @@ Useful variables:
 - `PROD_API_URL` defaults to `https://teakvault.com/api`
 - `PROD_MCP_URL` defaults to `https://teakvault.com/mcp`
 - `VITE_PUBLIC_CONVEX_URL` and `VITE_PUBLIC_CONVEX_SITE_URL` are required for the extension build. You can use matching `NEXT_PUBLIC_CONVEX_URL` and `NEXT_PUBLIC_CONVEX_SITE_URL` values locally.
+
+Cleanup is browserless. Exact accounts created by a test are removed during teardown, while the scheduled sweep discovers orphan accounts directly from the production auth database. The backend accepts only the configured `e2e-*` email namespace, enforces account-age bounds, caps each sweep, and reuses the same Teak data-deletion path as user-initiated account deletion. Mailpit messages are deleted separately by exact message ID.
 
 For local parity with GitHub Actions, put the required values in `.env.production-e2e.local` at the repo root and run `bun run --cwd packages/tests e2e:prod:local`. The local runner installs Playwright browsers, executes preflight, docs, journey, browser matrix, extension, and teardown steps, then preserves separate reports under `packages/tests/playwright-report`.
 

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "e2e:prod:journey": "playwright test --project=journey-setup --project=journey --project=journey-delete --project=journey-post-delete",
+    "e2e:prod:journey": "playwright test --project=journey-setup --project=journey-web --project=journey-services --project=journey-a11y --project=journey-security --project=journey-account --project=journey-delete --project=journey-post-delete",
     "e2e:prod:docs": "playwright test --project=docs",
     "e2e:prod:matrix": "playwright test --project=matrix-chromium --project=matrix-firefox --project=matrix-webkit",
     "e2e:prod:extension": "playwright test --project=extension",
@@ -12,6 +12,7 @@
     "preflight": "tsx src/scripts/preflight.ts",
     "teardown": "tsx src/scripts/teardown.ts",
     "sweep": "tsx src/scripts/sweep.ts",
+    "test": "bun test",
     "lint": "biome check .",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/tests/playwright.config.test.ts
+++ b/packages/tests/playwright.config.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import config from "./playwright.config";
+
+describe("production E2E project graph", () => {
+  test("keeps stateful web flows serial and parallelizes independent coverage", () => {
+    const projects = new Map(
+      config.projects?.map((project) => [project.name, project])
+    );
+    expect(projects.get("journey-web")?.workers).toBe(1);
+    expect(projects.get("journey-services")?.fullyParallel).toBe(true);
+    expect(projects.get("journey-services")?.workers).toBe(3);
+    expect(projects.get("journey-a11y")?.fullyParallel).toBe(true);
+    expect(projects.get("journey-account")?.dependencies).toEqual([
+      "journey-web",
+      "journey-services",
+      "journey-a11y",
+      "journey-security",
+    ]);
+    expect(projects.get("journey-delete")?.dependencies).toEqual([
+      "journey-account",
+    ]);
+  });
+
+  test("allows all three browser-matrix projects to run concurrently", () => {
+    const matrix = config.projects?.filter((project) =>
+      project.name.startsWith("matrix-")
+    );
+    expect(matrix?.map((project) => project.name).sort()).toEqual([
+      "matrix-chromium",
+      "matrix-firefox",
+      "matrix-webkit",
+    ]);
+    expect(matrix?.every((project) => project.fullyParallel)).toBe(true);
+    expect(config.workers).toBe(4);
+  });
+});

--- a/packages/tests/playwright.config.ts
+++ b/packages/tests/playwright.config.ts
@@ -1,13 +1,13 @@
 import { defineConfig, devices } from "@playwright/test";
 import { env } from "./src/helpers/env";
 
-const journey = "src/journey/**/*.e2e.ts";
 const deleteAccount = "journey/99-delete-account.e2e.ts";
 const postDelete = "journey/100-post-delete.e2e.ts";
 
 export default defineConfig({
   testDir: "./src",
   timeout: 120_000,
+  workers: 4,
   expect: { timeout: 15_000 },
   reporter: process.env.CI
     ? [["list"], ["html", { open: "never" }]]
@@ -25,10 +25,12 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
     {
-      name: "journey",
+      name: "journey-web",
       dependencies: ["journey-setup"],
-      testIgnore: ["journey/01-signup.setup.ts", deleteAccount, postDelete],
-      testMatch: journey,
+      testMatch: [
+        "journey/02-web-journey.e2e.ts",
+        "journey/09-web-product-surfaces.e2e.ts",
+      ],
       workers: 1,
       use: {
         ...devices["Desktop Chrome"],
@@ -42,8 +44,56 @@ export default defineConfig({
       },
     },
     {
+      name: "journey-services",
+      dependencies: ["journey-setup"],
+      fullyParallel: true,
+      testMatch: [
+        "journey/03-api.e2e.ts",
+        "journey/04-cli.e2e.ts",
+        "journey/05-mcp.e2e.ts",
+      ],
+      workers: 3,
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: ".state/user.json",
+      },
+    },
+    {
+      name: "journey-a11y",
+      dependencies: ["journey-setup"],
+      fullyParallel: true,
+      testMatch: "journey/08-a11y.e2e.ts",
+      workers: 4,
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: ".state/user.json",
+      },
+    },
+    {
+      name: "journey-security",
+      dependencies: ["journey-web"],
+      testMatch: "journey/06-security.e2e.ts",
+      workers: 1,
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: ".state/user.json",
+      },
+    },
+    {
+      name: "journey-account",
+      dependencies: [
+        "journey-web",
+        "journey-services",
+        "journey-a11y",
+        "journey-security",
+      ],
+      testMatch: "journey/07-account-flows.e2e.ts",
+      workers: 1,
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
       name: "journey-delete",
-      dependencies: ["journey"],
+      dependencies: ["journey-account"],
       testMatch: deleteAccount,
       workers: 1,
       use: { ...devices["Desktop Chrome"], storageState: ".state/user.json" },
@@ -57,24 +107,29 @@ export default defineConfig({
     },
     {
       name: "docs",
+      fullyParallel: true,
       testMatch: "docs/**/*.e2e.ts",
       retries: 1,
+      workers: 4,
       use: { ...devices["Desktop Chrome"], baseURL: env.siteUrl },
     },
     {
       name: "matrix-chromium",
+      fullyParallel: true,
       testMatch: "matrix/journey-lite.e2e.ts",
       workers: 1,
       use: { ...devices["Desktop Chrome"] },
     },
     {
       name: "matrix-firefox",
+      fullyParallel: true,
       testMatch: "matrix/journey-lite.e2e.ts",
       workers: 1,
       use: { ...devices["Desktop Firefox"] },
     },
     {
       name: "matrix-webkit",
+      fullyParallel: true,
       testMatch: "matrix/journey-lite.e2e.ts",
       workers: 1,
       use: { ...devices["Desktop Safari"] },

--- a/packages/tests/src/docs/extra-prod-surfaces.e2e.ts
+++ b/packages/tests/src/docs/extra-prod-surfaces.e2e.ts
@@ -145,38 +145,35 @@ const contentType = {
 for (const [index, probe] of probes.entries()) {
   const prefix = `extra-${String(index + 1).padStart(3, "0")} ${probe.name}`;
 
-  test(`${prefix} status is successful`, async () => {
-    expect((await fetch(probe.url)).status).toBeLessThan(400);
-  });
+  test(`${prefix} production response contract`, async () => {
+    const response = await test.step("fetch once", () => fetch(probe.url));
+    const body = await response.text();
 
-  test(`${prefix} content type is stable`, async () => {
-    const response = await fetch(probe.url);
-    expect(response.headers.get("content-type") ?? "").toMatch(
-      contentType[probe.kind]
-    );
-  });
-
-  test(`${prefix} security headers are present`, async () => {
-    const response = await fetch(probe.url);
-    expect(response.headers.get("strict-transport-security") ?? "").toContain(
-      "max-age"
-    );
-    if (probe.nosniff !== false) {
-      expect(response.headers.get("x-content-type-options") ?? "").toBe(
-        "nosniff"
+    await test.step("status is successful", () => {
+      expect(response.status).toBeLessThan(400);
+    });
+    await test.step("content type is stable", () => {
+      expect(response.headers.get("content-type") ?? "").toMatch(
+        contentType[probe.kind]
       );
-    }
-  });
-
-  test(`${prefix} body contains expected product marker`, async () => {
-    const body = await fetch(probe.url).then((response) => response.text());
-    expect(body).toMatch(probe.body);
-  });
-
-  test(`${prefix} body has no obvious server error leak`, async () => {
-    const body = await fetch(probe.url).then((response) => response.text());
-    expect(body).not.toMatch(
-      /Unhandled Runtime Error|Internal Server Error|stack trace/i
-    );
+    });
+    await test.step("security headers are present", () => {
+      expect(response.headers.get("strict-transport-security") ?? "").toContain(
+        "max-age"
+      );
+      if (probe.nosniff !== false) {
+        expect(response.headers.get("x-content-type-options") ?? "").toBe(
+          "nosniff"
+        );
+      }
+    });
+    await test.step("body contains expected product marker", () => {
+      expect(body).toMatch(probe.body);
+    });
+    await test.step("body has no obvious server error leak", () => {
+      expect(body).not.toMatch(
+        /Unhandled Runtime Error|Internal Server Error|stack trace/i
+      );
+    });
   });
 }

--- a/packages/tests/src/extension/save-page.e2e.ts
+++ b/packages/tests/src/extension/save-page.e2e.ts
@@ -1,7 +1,9 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { chromium, expect, test } from "@playwright/test";
-import { clientFor, createAccount, deleteAccountViaUi } from "../helpers/prod";
+import { cleanupE2EAccounts } from "../helpers/e2e-cleanup";
+import { deleteMessagesFor } from "../helpers/mailpit";
+import { clientFor, createAccount } from "../helpers/prod";
 
 test("extension build loads and account can save the active page", async ({
   browserName,
@@ -17,7 +19,7 @@ test("extension build loads and account can save the active page", async ({
     ],
   });
   const page = await context.newPage();
-  const account = await createAccount(page, "extension");
+  const account = await createAccount(page, "extension", { remember: false });
   try {
     const serviceWorker =
       context.serviceWorkers()[0] ??
@@ -34,7 +36,8 @@ test("extension build loads and account can save the active page", async ({
     });
     expect(created.cardId).toBeTruthy();
   } finally {
-    await deleteAccountViaUi(page, account);
+    await cleanupE2EAccounts([account.email]);
+    await deleteMessagesFor(account.email);
     await context.close();
   }
 });

--- a/packages/tests/src/helpers/cleanup.test.ts
+++ b/packages/tests/src/helpers/cleanup.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  cleanupE2EAccounts,
+  isConfiguredE2EEmail,
+  isE2ECleanupResult,
+  summarizeE2ECleanup,
+} from "./e2e-cleanup";
+import { env } from "./env";
+import {
+  deleteMailpitMessages,
+  type MailpitMessage,
+  messageIdsForRecipients,
+} from "./mailpit";
+
+const originalFetch = globalThis.fetch;
+const originalCleanupToken = env.cleanupToken;
+const originalConvexSiteUrl = env.convexSiteUrl;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  env.cleanupToken = originalCleanupToken;
+  env.convexSiteUrl = originalConvexSiteUrl;
+});
+
+describe("production E2E cleanup helpers", () => {
+  test("filters exact configured recipients and message IDs", () => {
+    const messages: MailpitMessage[] = [
+      {
+        ID: "one",
+        Subject: "verify",
+        To: [{ Address: "e2e-one@tests.example.com" }],
+      },
+      {
+        ID: "two",
+        Subject: "verify",
+        To: [{ Address: "person@example.com" }],
+      },
+    ];
+    expect(
+      messageIdsForRecipients(messages, ["e2e-one@tests.example.com"])
+    ).toEqual(["one"]);
+    expect(
+      isConfiguredE2EEmail("e2e-one@tests.example.com", "tests.example.com")
+    ).toBe(true);
+    expect(
+      isConfiguredE2EEmail("person@tests.example.com", "tests.example.com")
+    ).toBe(false);
+  });
+
+  test("bulk deletes known message IDs once", async () => {
+    const fetchMock = mock(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(null, { status: 200 })
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    expect(await deleteMailpitMessages(["one", "one", "two"])).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toEndWith("/api/v1/messages");
+    expect(init?.method).toBe("DELETE");
+    expect(JSON.parse(String(init?.body))).toEqual({ IDs: ["one", "two"] });
+  });
+
+  test("summarizes ineffective cleanup states", () => {
+    const result = {
+      alreadyDeleted: ["one"],
+      deleted: ["two"],
+      failures: [{ email: "three", reason: "failed" }],
+      ignoredOutOfRange: ["four"],
+      remainingEligible: true,
+    };
+    expect(isE2ECleanupResult(result)).toBe(true);
+    expect(isE2ECleanupResult({ ...result, deleted: "two" })).toBe(false);
+    expect(summarizeE2ECleanup(result)).toBe(
+      "deleted=1 alreadyDeleted=1 failed=1 outOfRange=1 remaining=true"
+    );
+  });
+
+  test("rejects malformed server responses without hiding status", async () => {
+    env.cleanupToken = "test-token";
+    env.convexSiteUrl = "https://example.convex.site";
+    globalThis.fetch = mock(async () =>
+      Response.json(
+        { code: "UNAUTHORIZED", message: "Unauthorized" },
+        { status: 401 }
+      )
+    ) as unknown as typeof fetch;
+
+    await expect(cleanupE2EAccounts()).rejects.toThrow(
+      "invalid response (401)"
+    );
+  });
+});

--- a/packages/tests/src/helpers/e2e-cleanup.ts
+++ b/packages/tests/src/helpers/e2e-cleanup.ts
@@ -1,0 +1,97 @@
+import { env, requireE2ECleanup } from "./env";
+
+export interface E2ECleanupResult {
+  alreadyDeleted: string[];
+  deleted: string[];
+  failures: Array<{ email: string; reason: string }>;
+  ignoredOutOfRange: string[];
+  remainingEligible: boolean;
+}
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === "string");
+
+export const isE2ECleanupResult = (
+  value: unknown
+): value is E2ECleanupResult => {
+  if (!(value && typeof value === "object")) {
+    return false;
+  }
+  const candidate = value as Partial<E2ECleanupResult>;
+  return (
+    isStringArray(candidate.alreadyDeleted) &&
+    isStringArray(candidate.deleted) &&
+    Array.isArray(candidate.failures) &&
+    candidate.failures.every(
+      (failure) =>
+        failure &&
+        typeof failure.email === "string" &&
+        typeof failure.reason === "string"
+    ) &&
+    isStringArray(candidate.ignoredOutOfRange) &&
+    typeof candidate.remainingEligible === "boolean"
+  );
+};
+
+export const summarizeE2ECleanup = (result: E2ECleanupResult): string =>
+  [
+    `deleted=${result.deleted.length}`,
+    `alreadyDeleted=${result.alreadyDeleted.length}`,
+    `failed=${result.failures.length}`,
+    `outOfRange=${result.ignoredOutOfRange.length}`,
+    `remaining=${result.remainingEligible}`,
+  ].join(" ");
+
+export const isConfiguredE2EEmail = (
+  email: string,
+  domain = env.emailDomain
+): boolean => {
+  const normalized = email.toLowerCase();
+  const suffix = `@${domain.toLowerCase()}`;
+  if (!normalized.endsWith(suffix)) {
+    return false;
+  }
+  return /^e2e-[a-z0-9][a-z0-9-]{0,100}$/.test(
+    normalized.slice(0, -suffix.length)
+  );
+};
+
+export const cleanupE2EAccounts = async (
+  emails?: string[]
+): Promise<E2ECleanupResult> => {
+  requireE2ECleanup();
+  const response = await fetch(
+    `${env.convexSiteUrl}/api/auth/internal/e2e/cleanup`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.cleanupToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(emails ? { emails } : {}),
+    }
+  );
+  const payload: unknown = await response.json().catch(() => null);
+  if (!isE2ECleanupResult(payload)) {
+    throw new Error(
+      `Production E2E cleanup returned an invalid response (${response.status})`
+    );
+  }
+  const result = payload;
+  if (!response.ok) {
+    throw new Error(
+      `Production E2E cleanup failed (${response.status}): ${summarizeE2ECleanup(result)}`
+    );
+  }
+  return result;
+};
+
+export const assertE2ECleanupReady = async (): Promise<void> => {
+  const email = `e2e-preflight-${Date.now()}-probe@${env.emailDomain}`;
+  const result = await cleanupE2EAccounts([email]);
+  if (!result.alreadyDeleted.includes(email)) {
+    throw new Error(
+      "Production E2E cleanup preflight was not side-effect free"
+    );
+  }
+};

--- a/packages/tests/src/helpers/env.ts
+++ b/packages/tests/src/helpers/env.ts
@@ -6,6 +6,12 @@ export const env = {
   siteUrl: trim(process.env.PROD_SITE_URL, "https://teakvault.com"),
   apiUrl: trim(process.env.PROD_API_URL, "https://teakvault.com/api"),
   mcpUrl: trim(process.env.PROD_MCP_URL, "https://teakvault.com/mcp"),
+  convexSiteUrl: trim(
+    process.env.VITE_PUBLIC_CONVEX_SITE_URL ??
+      process.env.NEXT_PUBLIC_CONVEX_SITE_URL,
+    ""
+  ),
+  cleanupToken: process.env.E2E_CLEANUP_TOKEN ?? "",
   mailpitUrl: trim(process.env.MAILPIT_URL, ""),
   emailDomain: process.env.E2E_EMAIL_DOMAIN?.trim() || "",
   password: process.env.PROD_E2E_PASSWORD || "",
@@ -21,6 +27,14 @@ export const requirePassword = () => {
 export const requireMailpit = () => {
   if (!(env.mailpitUrl && env.emailDomain)) {
     throw new Error("MAILPIT_URL and E2E_EMAIL_DOMAIN secrets are required");
+  }
+};
+
+export const requireE2ECleanup = () => {
+  if (!(env.cleanupToken && env.convexSiteUrl)) {
+    throw new Error(
+      "E2E_CLEANUP_TOKEN and VITE_PUBLIC_CONVEX_SITE_URL are required"
+    );
   }
 };
 

--- a/packages/tests/src/helpers/mailpit.ts
+++ b/packages/tests/src/helpers/mailpit.ts
@@ -1,6 +1,6 @@
 import { env, requireMailpit } from "./env";
 
-interface MailpitMessage {
+export interface MailpitMessage {
   ID: string;
   Subject: string;
   To?: Array<{ Address: string }> | null;
@@ -64,24 +64,53 @@ export const waitForEmail = async (to: string, subject: string) => {
   throw new Error(`Timed out waiting for ${subject} email to ${to}`);
 };
 
+export const deleteMailpitMessages = async (messageIds: string[]) => {
+  const uniqueMessageIds = [...new Set(messageIds)];
+  if (uniqueMessageIds.length === 0) {
+    return 0;
+  }
+  const response = await mailpitFetch("/messages", {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ IDs: uniqueMessageIds }),
+  });
+  if (!response.ok) {
+    throw new Error(`Mailpit message deletion failed: ${response.status}`);
+  }
+  return uniqueMessageIds.length;
+};
+
+export const messageIdsForRecipients = (
+  messages: MailpitMessage[],
+  emails: string[]
+) => {
+  const recipients = new Set(emails.map((email) => email.toLowerCase()));
+  return messages
+    .filter((message) =>
+      (message.To ?? []).some((recipient) =>
+        recipients.has(recipient.Address?.toLowerCase())
+      )
+    )
+    .map((message) => message.ID);
+};
+
 export const deleteMessagesFor = async (email: string) => {
   try {
-    const response = await mailpitFetch("/messages?limit=100");
+    const query = encodeURIComponent(`to:"${email.toLowerCase()}"`);
+    const response = await mailpitFetch(`/search?query=${query}&limit=200`);
     if (!response.ok) {
-      return;
+      throw new Error(`Mailpit recipient search failed: ${response.status}`);
     }
     const data = (await response.json()) as { messages?: MailpitMessage[] };
-    for (const message of data.messages ?? []) {
-      if (hasRecipient(message, email.toLowerCase())) {
-        await mailpitFetch(`/message/${message.ID}`, { method: "DELETE" });
-      }
-    }
+    return await deleteMailpitMessages(
+      messageIdsForRecipients(data.messages ?? [], [email])
+    );
   } catch (error) {
-    console.warn(`Mailpit cleanup skipped for ${email}: ${error}`);
+    throw new Error(`Mailpit cleanup failed for ${email}: ${error}`);
   }
 };
 
-export const listMailpitMessages = async (limit = 200) => {
+export const listMailpitMessages = async (limit = 500) => {
   const response = await mailpitFetch(`/messages?limit=${limit}`);
   if (!response.ok) {
     throw new Error(`Mailpit sweep list failed: ${response.status}`);

--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -123,11 +123,17 @@ export const generateApiKey = async (page: Page) => {
   return input.inputValue();
 };
 
-export const createAccount = async (page: Page, label = "acct") => {
+export const createAccount = async (
+  page: Page,
+  label = "acct",
+  options: { remember?: boolean } = {}
+) => {
   const email = await signUp(page, uniqueEmail(label));
   const apiKey = await generateApiKey(page);
   const account = { email, apiKey };
-  rememberAccount(account);
+  if (options.remember !== false) {
+    rememberAccount(account);
+  }
   return account;
 };
 

--- a/packages/tests/src/journey/03-api.e2e.ts
+++ b/packages/tests/src/journey/03-api.e2e.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { apiFetch, loadOpenApi } from "../helpers/api";
-import { readState, updateState } from "../helpers/run-state";
+import { readState } from "../helpers/run-state";
 
 test("REST API happy paths and OpenAPI contracts", async () => {
   const { primary } = readState();
@@ -33,7 +33,6 @@ test("REST API happy paths and OpenAPI contracts", async () => {
   });
   const payload = await created.json();
   openapi.validate("/v1/cards", "POST", created.status, payload);
-  updateState((s) => s.createdCardIds.push(payload.cardId));
   const cardPath = `/v1/cards/${payload.cardId}`;
   expect((await apiFetch(cardPath, primary.apiKey)).status).toBe(200);
   expect(
@@ -87,7 +86,6 @@ test("saving a URL as content creates a link card, not a text card", async () =>
   });
   expect(created.status).toBe(200);
   const payload = await created.json();
-  updateState((s) => s.createdCardIds.push(payload.cardId));
 
   // The create response should already reflect the link classification.
   expect(payload.card?.type).toBe("link");
@@ -120,7 +118,6 @@ test("saving a color as content creates a palette card, not a text card", async 
   });
   expect(created.status).toBe(200);
   const payload = await created.json();
-  updateState((s) => s.createdCardIds.push(payload.cardId));
 
   await expect
     .poll(

--- a/packages/tests/src/journey/04-cli.e2e.ts
+++ b/packages/tests/src/journey/04-cli.e2e.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { runCli } from "../helpers/cli";
-import { readState, updateState } from "../helpers/run-state";
+import { readState } from "../helpers/run-state";
 
 for (const kind of ["repo", "npm"] as const) {
   test(`${kind} CLI covers auth, cards, tags, and aliases`, async () => {
@@ -20,7 +20,6 @@ for (const kind of ["repo", "npm"] as const) {
         primary.apiKey
       )
     );
-    updateState((s) => s.createdCardIds.push(created.cardId));
     for (const args of [
       ["--json", "cards", "list", "--limit", "5"],
       ["--json", "cards", "search", "cli"],

--- a/packages/tests/src/journey/05-mcp.e2e.ts
+++ b/packages/tests/src/journey/05-mcp.e2e.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { env } from "../helpers/env";
 import { connectMcp } from "../helpers/mcp";
-import { readState, updateState } from "../helpers/run-state";
+import { readState } from "../helpers/run-state";
 
 test("MCP lists and calls every public tool", async () => {
   const { primary } = readState();
@@ -36,7 +36,6 @@ test("MCP lists and calls every public tool", async () => {
     arguments: { content: `mcp-${Date.now()}` },
   });
   const cardId = created.structuredContent.cardId;
-  updateState((s) => s.createdCardIds.push(cardId));
   const calls = [
     ["teak_v1_list_cards", { limit: 5 }],
     ["teak_v1_get_card", { cardId }],
@@ -63,16 +62,6 @@ test("MCP lists and calls every public tool", async () => {
       result.isError,
       `${name} failed: ${JSON.stringify(result.content ?? result.structuredContent)}`
     ).not.toBe(true);
-    if (name === "teak_v1_bulk_cards") {
-      const bulk = result.structuredContent as
-        | { results?: Array<{ cardId?: string }> }
-        | undefined;
-      for (const item of bulk?.results ?? []) {
-        if (item.cardId) {
-          updateState((s) => s.createdCardIds.push(item.cardId as string));
-        }
-      }
-    }
     if (name === "fetch") {
       expect(result.structuredContent ?? result.content).toBeTruthy();
     }

--- a/packages/tests/src/journey/06-security.e2e.ts
+++ b/packages/tests/src/journey/06-security.e2e.ts
@@ -1,11 +1,8 @@
 import { expect, test } from "@playwright/test";
 import { apiFetch } from "../helpers/api";
-import {
-  clientFor,
-  createAccount,
-  deleteAccountViaUi,
-  newAnonymousContext,
-} from "../helpers/prod";
+import { cleanupE2EAccounts } from "../helpers/e2e-cleanup";
+import { deleteMessagesFor } from "../helpers/mailpit";
+import { clientFor, createAccount, newAnonymousContext } from "../helpers/prod";
 import { readState } from "../helpers/run-state";
 
 test("cross-tenant, revoked-key, hostile input, headers, and cookie security", async ({
@@ -19,7 +16,9 @@ test("cross-tenant, revoked-key, hostile input, headers, and cookie security", a
   }
   const secondContext = await newAnonymousContext(browser);
   const secondPage = await secondContext.newPage();
-  const second = await createAccount(secondPage, "tenant-b");
+  const second = await createAccount(secondPage, "tenant-b", {
+    remember: false,
+  });
   try {
     const targetCard = state.createdCardIds[0];
     if (targetCard) {
@@ -61,7 +60,8 @@ test("cross-tenant, revoked-key, hostile input, headers, and cookie security", a
       )
     ).toBe(true);
   } finally {
-    await deleteAccountViaUi(secondPage, second);
+    await cleanupE2EAccounts([second.email]);
+    await deleteMessagesFor(second.email);
     await secondContext.close();
   }
 });

--- a/packages/tests/src/matrix/journey-lite.e2e.ts
+++ b/packages/tests/src/matrix/journey-lite.e2e.ts
@@ -1,26 +1,37 @@
 import { expect, test } from "@playwright/test";
+import { cleanupE2EAccounts } from "../helpers/e2e-cleanup";
+import { deleteMessagesFor } from "../helpers/mailpit";
 import { clickVisibleControl, createAccount } from "../helpers/prod";
 
 test.setTimeout(180_000);
 
 test("signup, create, and search", async ({ page }) => {
-  await createAccount(page, `matrix-${test.info().project.name}`);
-  const marker = `matrix-${Date.now()}`;
-  await page.goto("/");
-  await page.getByPlaceholder(/Write a note/i).fill(marker);
-  await clickVisibleControl(
-    page.getByRole("button", { exact: true, name: "Save" })
+  const account = await createAccount(
+    page,
+    `matrix-${test.info().project.name}`,
+    { remember: false }
   );
-  const savedCard = page
-    .getByRole("main")
-    .getByRole("paragraph")
-    .filter({ hasText: marker })
-    .first();
-  await expect(savedCard).toBeVisible();
-  const search = page.getByPlaceholder("Search for anything...");
-  await search.fill(`${marker}-missing`);
-  await expect(savedCard).not.toBeVisible();
-  await expect(page.getByText(/nothing found/i)).toBeVisible();
-  await search.fill(marker);
-  await expect(savedCard).toBeVisible();
+  try {
+    const marker = `matrix-${Date.now()}`;
+    await page.goto("/");
+    await page.getByPlaceholder(/Write a note/i).fill(marker);
+    await clickVisibleControl(
+      page.getByRole("button", { exact: true, name: "Save" })
+    );
+    const savedCard = page
+      .getByRole("main")
+      .getByRole("paragraph")
+      .filter({ hasText: marker })
+      .first();
+    await expect(savedCard).toBeVisible();
+    const search = page.getByPlaceholder("Search for anything...");
+    await search.fill(`${marker}-missing`);
+    await expect(savedCard).not.toBeVisible();
+    await expect(page.getByText(/nothing found/i)).toBeVisible();
+    await search.fill(marker);
+    await expect(savedCard).toBeVisible();
+  } finally {
+    await cleanupE2EAccounts([account.email]);
+    await deleteMessagesFor(account.email);
+  }
 });

--- a/packages/tests/src/scripts/preflight.ts
+++ b/packages/tests/src/scripts/preflight.ts
@@ -1,6 +1,12 @@
 import { resolveMx } from "node:dns/promises";
 import { Socket } from "node:net";
-import { env, requireMailpit, requirePassword } from "../helpers/env";
+import { assertE2ECleanupReady } from "../helpers/e2e-cleanup";
+import {
+  env,
+  requireE2ECleanup,
+  requireMailpit,
+  requirePassword,
+} from "../helpers/env";
 import { assertMailpitReady } from "../helpers/mailpit";
 
 const checkPort = (host: string, port: number) =>
@@ -22,7 +28,9 @@ const checkPort = (host: string, port: number) =>
 const main = async () => {
   requirePassword();
   requireMailpit();
+  requireE2ECleanup();
   await assertMailpitReady();
+  await assertE2ECleanupReady();
 
   const mx = await resolveMx(env.emailDomain).catch(() => []);
   if (!mx.length) {

--- a/packages/tests/src/scripts/run-prod-suite.ts
+++ b/packages/tests/src/scripts/run-prod-suite.ts
@@ -58,6 +58,7 @@ if (
 
 const required = [
   "PROD_E2E_PASSWORD",
+  "E2E_CLEANUP_TOKEN",
   "MAILPIT_URL",
   "E2E_EMAIL_DOMAIN",
   "VITE_PUBLIC_CONVEX_URL",
@@ -116,8 +117,9 @@ mkdirSync(runnerTemp, { recursive: true });
 mkdirSync(resultsRoot, { recursive: true });
 
 const results = [
-  run("preflight", "bun", ["run", "--cwd", "packages/tests", "preflight"]),
+  run("preflight", "bun", ["packages/tests/src/scripts/preflight.ts"]),
   run("smoke urls", "bash", ["scripts/smoke-urls.sh"]),
+  run("orphan sweep", "bun", ["packages/tests/src/scripts/sweep.ts"]),
   run("install playwright browsers", "bunx", [
     "playwright",
     "install",
@@ -135,7 +137,11 @@ const results = [
   ]),
   playwright("journey", [
     "journey-setup",
-    "journey",
+    "journey-web",
+    "journey-services",
+    "journey-a11y",
+    "journey-security",
+    "journey-account",
     "journey-delete",
     "journey-post-delete",
   ]),
@@ -148,22 +154,8 @@ const results = [
     }
   ),
   playwright("matrix", ["matrix-chromium", "matrix-firefox", "matrix-webkit"]),
-  run(
-    "matrix teardown",
-    "bun",
-    ["run", "--cwd", "packages/tests", "teardown"],
-    {
-      optional: true,
-    }
-  ),
   run("build extension", "bun", ["run", "--cwd", "apps/extension", "build"]),
   playwright("extension", ["extension"]),
-  run(
-    "extension teardown",
-    "bun",
-    ["run", "--cwd", "packages/tests", "teardown"],
-    { optional: true }
-  ),
 ];
 
 const failed = results.filter(

--- a/packages/tests/src/scripts/sweep.ts
+++ b/packages/tests/src/scripts/sweep.ts
@@ -1,30 +1,28 @@
-import { chromium } from "@playwright/test";
-import { deleteMessagesFor, listMailpitMessages } from "../helpers/mailpit";
-import { deleteAccountViaUi } from "../helpers/prod";
+import {
+  cleanupE2EAccounts,
+  isConfiguredE2EEmail,
+  summarizeE2ECleanup,
+} from "../helpers/e2e-cleanup";
+import {
+  deleteMailpitMessages,
+  listMailpitMessages,
+  messageIdsForRecipients,
+} from "../helpers/mailpit";
 
-const emails = [
+const cleanup = await cleanupE2EAccounts();
+const messages = await listMailpitMessages();
+const recipients = [
   ...new Set(
-    (await listMailpitMessages())
+    messages
       .flatMap((message) => message.To ?? [])
-      .map((to) => to.Address.toLowerCase())
-      .filter((email) => email.startsWith("e2e-"))
+      .map((recipient) => recipient.Address.toLowerCase())
+      .filter((email) => isConfiguredE2EEmail(email))
   ),
-].slice(0, 20);
+];
+const deletedMessages = await deleteMailpitMessages(
+  messageIdsForRecipients(messages, recipients)
+);
 
-const browser = await chromium.launch();
-try {
-  for (const email of emails) {
-    const page = await browser.newPage();
-    try {
-      await deleteAccountViaUi(page, { email });
-    } catch (error) {
-      console.warn(`sweep skipped ${email}: ${error}`);
-    } finally {
-      await deleteMessagesFor(email);
-      await page.close();
-      await new Promise((resolve) => setTimeout(resolve, 15_000));
-    }
-  }
-} finally {
-  await browser.close();
-}
+console.log(
+  `Production E2E sweep complete: ${summarizeE2ECleanup(cleanup)} mailpitDeleted=${deletedMessages}`
+);

--- a/packages/tests/src/scripts/teardown.ts
+++ b/packages/tests/src/scripts/teardown.ts
@@ -1,21 +1,50 @@
-import { chromium } from "@playwright/test";
-import { deleteMessagesFor } from "../helpers/mailpit";
-import { deleteAccountViaUi } from "../helpers/prod";
-import { readState } from "../helpers/run-state";
+import {
+  cleanupE2EAccounts,
+  summarizeE2ECleanup,
+} from "../helpers/e2e-cleanup";
+import {
+  deleteMailpitMessages,
+  listMailpitMessages,
+  messageIdsForRecipients,
+} from "../helpers/mailpit";
+import { readState, updateState } from "../helpers/run-state";
 
-const browser = await chromium.launch();
-try {
-  for (const account of readState().accounts.filter((item) => !item.deleted)) {
-    const page = await browser.newPage();
-    try {
-      await deleteAccountViaUi(page, account);
-    } catch (error) {
-      console.warn(`teardown skipped ${account.email}: ${error}`);
-    } finally {
-      await deleteMessagesFor(account.email);
-      await page.close();
+const accounts = readState().accounts;
+const pendingEmails = accounts
+  .filter((account) => !account.deleted)
+  .map((account) => account.email);
+const cleanup = pendingEmails.length
+  ? await cleanupE2EAccounts(pendingEmails)
+  : {
+      alreadyDeleted: [],
+      deleted: [],
+      failures: [],
+      ignoredOutOfRange: [],
+      remainingEligible: false,
+    };
+
+const removedAccounts = new Set([
+  ...cleanup.deleted,
+  ...cleanup.alreadyDeleted,
+]);
+updateState((state) => {
+  for (const account of state.accounts) {
+    if (removedAccounts.has(account.email)) {
+      account.deleted = true;
     }
   }
-} finally {
-  await browser.close();
-}
+  if (state.primary && removedAccounts.has(state.primary.email)) {
+    state.primary.deleted = true;
+  }
+});
+
+const messages = await listMailpitMessages();
+const deletedMessages = await deleteMailpitMessages(
+  messageIdsForRecipients(
+    messages,
+    accounts.map((account) => account.email)
+  )
+);
+console.log(
+  `Production E2E teardown complete: ${summarizeE2ECleanup(cleanup)} mailpitDeleted=${deletedMessages}`
+);


### PR DESCRIPTION
## Summary

- replace Mailpit-derived account discovery with a token-protected, server-side E2E cleanup endpoint that reuses the canonical account-deletion implementation and cannot target non-E2E users
- remove arbitrary sweep sleeps and browser setup, make cleanup failure-visible, delete exact known Mailpit message IDs, and run cleanup alongside the main journey
- safely parallelize independent journey, browser-matrix, accessibility, and docs coverage while preserving stateful ordering, traces, screenshots, and proof artifacts
- run preflight and teardown directly with Bun and collapse repeated docs probes into one request per URL

## Baseline

Latest successful scheduled run: https://github.com/praveenjuge/teak/actions/runs/29074069648

- workflow wall time: 16m11s (971s)
- summed job runner time: 20m42s (1,242s)
- critical path: gate 31s -> journey 5m32s -> sweep 9m47s -> notify 5s
- sweep spent 9m47s while skipping all 20 candidates because it serialized Mailpit-derived candidates and slept 15 seconds after each

## Validation

- official actionlint: pass
- bun run typecheck: pass (10/10 workspaces)
- bun run lint: pass
- bun run test: pass, including 1,250 Convex tests and the new production-E2E helper/config tests
- bun run pre-commit: pass (15/15 affected typecheck/lint/build tasks)
- focused auth/cleanup tests: 42 pass
- production docs E2E: 28/28 pass in 26.1s
- git diff --check: pass

The cleanup endpoint is schema-free, so there is no migration or backfill. This is internal workflow maintenance, so no public changelog entry is included. Final production timing will be measured from a real Production E2E workflow run after merge and deployment.