### PR TITLE
Fix production E2E Convex secret wiring

### DIFF
--- a/.github/workflows/prod-e2e.yml
+++ b/.github/workflows/prod-e2e.yml
@@ -28,6 +28,7 @@ env:
   E2E_CLEANUP_TOKEN: ${{ secrets.E2E_CLEANUP_TOKEN }}
   MAILPIT_URL: ${{ secrets.MAILPIT_URL }}
   E2E_EMAIL_DOMAIN: ${{ secrets.E2E_EMAIL_DOMAIN }}
+  VITE_PUBLIC_CONVEX_URL: ${{ secrets.VITE_PUBLIC_CONVEX_URL }}
   VITE_PUBLIC_CONVEX_SITE_URL: ${{ secrets.VITE_PUBLIC_CONVEX_SITE_URL }}
 
 jobs:
@@ -107,9 +108,6 @@ jobs:
     if: always() && needs.gate.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    env:
-      VITE_PUBLIC_CONVEX_URL: ${{ secrets.VITE_PUBLIC_CONVEX_URL }}
-      VITE_PUBLIC_CONVEX_SITE_URL: ${{ secrets.VITE_PUBLIC_CONVEX_SITE_URL }}
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/prod-e2e.yml
+++ b/.github/workflows/prod-e2e.yml
@@ -28,7 +28,7 @@ env:
   E2E_CLEANUP_TOKEN: ${{ secrets.E2E_CLEANUP_TOKEN }}
   MAILPIT_URL: ${{ secrets.MAILPIT_URL }}
   E2E_EMAIL_DOMAIN: ${{ secrets.E2E_EMAIL_DOMAIN }}
-  VITE_PUBLIC_CONVEX_SITE_URL: ${{ vars.VITE_PUBLIC_CONVEX_SITE_URL }}
+  VITE_PUBLIC_CONVEX_SITE_URL: ${{ secrets.VITE_PUBLIC_CONVEX_SITE_URL }}
 
 jobs:
   gate:
@@ -108,8 +108,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
-      VITE_PUBLIC_CONVEX_URL: ${{ vars.VITE_PUBLIC_CONVEX_URL }}
-      VITE_PUBLIC_CONVEX_SITE_URL: ${{ vars.VITE_PUBLIC_CONVEX_SITE_URL }}
+      VITE_PUBLIC_CONVEX_URL: ${{ secrets.VITE_PUBLIC_CONVEX_URL }}
+      VITE_PUBLIC_CONVEX_SITE_URL: ${{ secrets.VITE_PUBLIC_CONVEX_SITE_URL }}
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

- read the existing production Convex URL values from GitHub Secrets, where this repository already stores them
- restore the new fail-fast cleanup preflight and extension build without duplicating the values as repository variables

## Production evidence

Production E2E dispatch https://github.com/praveenjuge/teak/actions/runs/29104645057 correctly failed at the gate in 7 seconds because `VITE_PUBLIC_CONVEX_SITE_URL` was empty. GitHub has the value as the existing `VITE_PUBLIC_CONVEX_SITE_URL` secret, not a repository variable.

## Validation

- official actionlint: pass
- git diff --check: pass
- repository pre-commit hook: pass (15/15 affected typecheck/lint/build tasks)
- full local production E2E suite before this wiring-only follow-up: pass, including 22-test journey in 3.9m, 3-browser matrix in 25.4s, docs 28/28, extension, canonical sweep, and teardown