### PR TITLE
Bound production E2E service load

### DIFF
--- a/packages/tests/playwright.config.test.ts
+++ b/packages/tests/playwright.config.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, test } from "bun:test";
 import config from "./playwright.config";
 
 describe("production E2E project graph", () => {
-  test("keeps stateful web flows serial and parallelizes independent coverage", () => {
+  test("bounds shared-key load while parallelizing independent projects", () => {
     const projects = new Map(
       config.projects?.map((project) => [project.name, project])
     );
     expect(projects.get("journey-web")?.workers).toBe(1);
-    expect(projects.get("journey-services")?.fullyParallel).toBe(true);
-    expect(projects.get("journey-services")?.workers).toBe(3);
+    expect(projects.get("journey-services")?.fullyParallel).not.toBe(true);
+    expect(projects.get("journey-services")?.workers).toBe(1);
     expect(projects.get("journey-a11y")?.fullyParallel).toBe(true);
     expect(projects.get("journey-account")?.dependencies).toEqual([
       "journey-web",

--- a/packages/tests/playwright.config.ts
+++ b/packages/tests/playwright.config.ts
@@ -46,13 +46,15 @@ export default defineConfig({
     {
       name: "journey-services",
       dependencies: ["journey-setup"],
-      fullyParallel: true,
       testMatch: [
         "journey/03-api.e2e.ts",
         "journey/04-cli.e2e.ts",
         "journey/05-mcp.e2e.ts",
       ],
-      workers: 3,
+      // These surfaces share one production API key. Keep their requests
+      // serial to avoid rate-limiter contention while this project still runs
+      // concurrently with the longer web and accessibility projects.
+      workers: 1,
       use: {
         ...devices["Desktop Chrome"],
         storageState: ".state/user.json",


### PR DESCRIPTION
## Summary

- serialize REST, repo CLI, npm CLI, and MCP tests within their shared-key service project to avoid production rate-limiter contention
- keep that bounded service lane running concurrently with the longer web and accessibility projects, preserving critical-path speed and all 22 journey tests
- lock the load-bound invariant into the deterministic Playwright project-graph test

## Production evidence

Production run https://github.com/praveenjuge/teak/actions/runs/29106361846 completed the optimized graph in under five minutes but failed one repo CLI assertion with `RATE_LIMITED: Too many requests` while REST, both CLIs, and MCP shared one API key concurrently. Every auxiliary job passed, including the canonical sweep in 11s.

## Validation

- project-graph tests: 2/2 pass
- package typecheck/lint: pass
- Playwright discovery: all 22 journey tests remain present
- Actions-parity service lane: setup + REST + repo CLI + npm CLI + MCP, 7/7 pass in 1.5m with one worker
- canonical teardown: pass, deleted=1 failed=0
- repository pre-commit hook: pass (15/15 affected typecheck/lint/build tasks)
- git diff --check: pass