### PR TITLE
Wait for production accessibility surfaces

### DIFF
--- a/packages/tests/src/journey/08-a11y.e2e.ts
+++ b/packages/tests/src/journey/08-a11y.e2e.ts
@@ -1,8 +1,24 @@
 import { AxeBuilder } from "@axe-core/playwright";
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { appPath, newAnonymousContext } from "../helpers/prod";
 
 const authPaths = new Set(["/login", "/register"]);
+
+const waitForReadySurface = async (path: string, page: Page) => {
+  if (path === "/") {
+    const composer = page.locator("#content");
+    await expect(composer).toBeVisible();
+    await expect(composer).toBeEnabled();
+    return;
+  }
+  if (path === "/settings") {
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Settings" })
+    ).toBeVisible();
+    return;
+  }
+  await expect(page.locator("form")).toBeVisible();
+};
 
 for (const path of ["/login", "/register", "/", "/settings"]) {
   test(`axe serious/critical scan ${path}`, async ({ browser, page }) => {
@@ -13,6 +29,7 @@ for (const path of ["/login", "/register", "/", "/settings"]) {
     try {
       await scanPage.goto(appPath(path));
       await scanPage.waitForLoadState("domcontentloaded");
+      await waitForReadySurface(path, scanPage);
       const results = await new AxeBuilder({ page: scanPage })
         .withTags(["wcag2a", "wcag2aa"])
         .analyze();

--- a/packages/tests/src/journey/08-a11y.e2e.ts
+++ b/packages/tests/src/journey/08-a11y.e2e.ts
@@ -6,7 +6,9 @@ const authPaths = new Set(["/login", "/register"]);
 
 const waitForReadySurface = async (path: string, page: Page) => {
   if (path === "/") {
-    const composer = page.locator("#content");
+    const composer = page.locator(
+      'form[data-card-creation-status="ready"] #content'
+    );
     await expect(composer).toBeVisible();
     await expect(composer).toBeEnabled();
     return;

--- a/packages/ui/src/components/forms/AddCardForm.tsx
+++ b/packages/ui/src/components/forms/AddCardForm.tsx
@@ -286,6 +286,9 @@ export function AddCardForm({
         <CardContent className="h-full p-0">
           <form
             className="flex h-full flex-1 flex-col"
+            data-card-creation-status={
+              cardCreationStatus === undefined ? "loading" : "ready"
+            }
             onSubmit={handleTextSubmit}
           >
             <Textarea

--- a/packages/ui/src/components/forms/__tests__/AddCardForm.test.tsx
+++ b/packages/ui/src/components/forms/__tests__/AddCardForm.test.tsx
@@ -1,6 +1,9 @@
 // @ts-nocheck
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+let cardCreationStatusResult: { canCreateCard: boolean } | undefined;
 
 mock.module("@teak/ui/components/ui/button", () => ({
   Button: ({ children, type, onClick, disabled, variant, size }: any) =>
@@ -56,7 +59,7 @@ mock.module("convex/react", () => ({
 }));
 
 mock.module("convex-helpers/react/cache/hooks", () => ({
-  useQuery: () => null,
+  useQuery: () => cardCreationStatusResult,
 }));
 
 mock.module("@teak/convex/shared/hooks/useFileUpload", () => ({
@@ -133,6 +136,7 @@ import { AddCardForm } from "../AddCardForm";
 
 describe("AddCardForm", () => {
   beforeEach(() => {
+    cardCreationStatusResult = undefined;
     global.crypto = {
       ...global.crypto,
       randomUUID: mock(() => "mock-uuid"),
@@ -162,6 +166,17 @@ describe("AddCardForm", () => {
     expect(() => {
       React.createElement(AddCardForm, { canCreateCard: false });
     }).not.toThrow();
+  });
+
+  test("exposes loading and ready card-creation states", () => {
+    expect(renderToStaticMarkup(<AddCardForm />)).toContain(
+      'data-card-creation-status="loading"'
+    );
+
+    cardCreationStatusResult = { canCreateCard: true };
+    expect(renderToStaticMarkup(<AddCardForm />)).toContain(
+      'data-card-creation-status="ready"'
+    );
   });
 
   test("renders with custom upgrade link component", () => {


### PR DESCRIPTION
## Summary

- wait for each real production surface before running Axe instead of scanning immediately after `domcontentloaded`
- require the authenticated home composer to be visible and enabled, the settings heading to be visible, and auth forms to be visible
- keep the full WCAG A/AA serious/critical assertion unchanged

## Production evidence

Production run https://github.com/praveenjuge/teak/actions/runs/29110323448 passed the bounded REST/CLI/MCP lane and every auxiliary job, but the home Axe scan caught the composer during its transient disabled/loading state and reported the faded placeholder. Direct inspection after the composer became ready showed the settled production token has no Axe violations.

## Validation

- production setup: pass
- four production accessibility surfaces repeated three times each: 12/12 pass in 7.7s
- canonical teardown: pass, deleted=1 failed=0
- package typecheck/lint: pass
- repository pre-commit hook: pass (15/15 affected typecheck/lint/build tasks)
- git diff --check: pass