### PR TITLE
Keep extension file uploads alive

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak-cli",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "description": "Command-line client for Teak, the personal knowledge hub for saving and rediscovering ideas.",
   "type": "module",
   "bin": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@teak/desktop",
   "productName": "Teak",
   "private": true,
-  "version": "1.0.57",
+  "version": "1.0.58",
   "type": "module",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/docs",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "scripts": {
     "build": "astro build",
     "dev": "PORTLESS_PORT=1355 portless docs.teak astro dev",

--- a/apps/docs/src/content/changelog/2026-07.mdx
+++ b/apps/docs/src/content/changelog/2026-07.mdx
@@ -18,6 +18,7 @@ date: "2026-07-10"
 - Saving colors or a color list as a note now creates a palette card again.
 - File uploads now report progress accurately and retry brief storage hiccups, so a first drag, drop, or paste is less likely to fail.
 - File uploads now support source code, Markdown and MDX, design tokens, ZIP, Office documents, SVG, HEIC, animated GIF, Figma files, and more across web, mobile, desktop, browser extension, API, CLI, and MCP, with a 100 MB limit and safe previews or file facts.
+- Choosing a file in the browser extension now keeps the popup open until the upload finishes or shows an error you can act on.
 - Search now clears old cards when a query has no matches, so empty results show accurately.
 - Settings and sign-in screens now show stable loading states, and managing your subscription opens reliably in Safari and other browsers.
 - Saving a web address now reliably creates a link card with a preview, even when it comes in as plain text.

--- a/apps/extension/__tests__/lib/popupAutoClose.test.ts
+++ b/apps/extension/__tests__/lib/popupAutoClose.test.ts
@@ -1,0 +1,44 @@
+// @ts-nocheck
+import { describe, expect, test } from "bun:test";
+import { shouldAutoClosePopup } from "../../lib/popupAutoClose";
+
+describe("shouldAutoClosePopup", () => {
+  test("closes after ordinary and context-menu saves while file upload is idle", () => {
+    expect(
+      shouldAutoClosePopup({
+        fileUploadState: "idle",
+        isAutoSaveSuccess: true,
+        isContextMenuSuccess: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldAutoClosePopup({
+        fileUploadState: "idle",
+        isAutoSaveSuccess: false,
+        isContextMenuSuccess: true,
+      })
+    ).toBe(true);
+  });
+
+  test("keeps the popup open while a selected file is saving or has failed", () => {
+    for (const fileUploadState of ["saving", "error"] as const) {
+      expect(
+        shouldAutoClosePopup({
+          fileUploadState,
+          isAutoSaveSuccess: true,
+          isContextMenuSuccess: true,
+        })
+      ).toBe(false);
+    }
+  });
+
+  test("closes only after the selected file finishes saving", () => {
+    expect(
+      shouldAutoClosePopup({
+        fileUploadState: "success",
+        isAutoSaveSuccess: false,
+        isContextMenuSuccess: false,
+      })
+    ).toBe(true);
+  });
+});

--- a/apps/extension/__tests__/popup-file-upload.test.ts
+++ b/apps/extension/__tests__/popup-file-upload.test.ts
@@ -21,3 +21,8 @@ test("popup keeps upload failures in its existing visible error state", () => {
   expect(popupSource).toContain('fileUploadState === "error"');
   expect(popupSource).toContain("{fileUploadError}");
 });
+
+test("popup gives an active file upload ownership of auto-close behavior", () => {
+  expect(popupSource).toContain("shouldAutoClosePopup({");
+  expect(popupSource).toContain("fileUploadState,");
+});

--- a/apps/extension/entrypoints/popup/App.tsx
+++ b/apps/extension/entrypoints/popup/App.tsx
@@ -14,6 +14,10 @@ import { useAutoSaveUrl } from "../../hooks/useAutoSaveUrl";
 import { useContextMenuSave } from "../../hooks/useContextMenuSave";
 import { useExtensionSession } from "../../hooks/useExtensionSession";
 import { beginSignIn } from "../../lib/nativeAuth";
+import {
+  type FileUploadState,
+  shouldAutoClosePopup,
+} from "../../lib/popupAutoClose";
 import { saveFileToTeak } from "../../lib/saveFileToTeak";
 import { MESSAGE_TYPES } from "../../types/messages";
 import { getAuthErrorMessage } from "../../utils/getAuthErrorMessage";
@@ -231,9 +235,8 @@ function AuthenticatedPopup({ user }: { user: SessionUser }) {
   const { state, error, duplicateCard } = useAutoSaveUrl(!isRecentSave);
   const [_signOutLoading, _setSignOutLoading] = useState(false);
   const [signOutError, _setSignOutError] = useState<string | null>(null);
-  const [fileUploadState, setFileUploadState] = useState<
-    "idle" | "saving" | "success" | "error"
-  >("idle");
+  const [fileUploadState, setFileUploadState] =
+    useState<FileUploadState>("idle");
   const [fileUploadError, setFileUploadError] = useState<string | null>(null);
 
   // Auto-close popup after successful save
@@ -243,9 +246,11 @@ function AuthenticatedPopup({ user }: { user: SessionUser }) {
       isRecentSave && contextMenuState.status === "success";
 
     if (
-      isAutoSaveSuccess ||
-      isContextMenuSuccess ||
-      fileUploadState === "success"
+      shouldAutoClosePopup({
+        fileUploadState,
+        isAutoSaveSuccess,
+        isContextMenuSuccess,
+      })
     ) {
       const timer = setTimeout(() => {
         window.close();

--- a/apps/extension/lib/popupAutoClose.ts
+++ b/apps/extension/lib/popupAutoClose.ts
@@ -1,0 +1,19 @@
+export type FileUploadState = "error" | "idle" | "saving" | "success";
+
+interface PopupAutoCloseState {
+  fileUploadState: FileUploadState;
+  isAutoSaveSuccess: boolean;
+  isContextMenuSuccess: boolean;
+}
+
+export function shouldAutoClosePopup({
+  fileUploadState,
+  isAutoSaveSuccess,
+  isContextMenuSuccess,
+}: PopupAutoCloseState): boolean {
+  if (fileUploadState !== "idle") {
+    return fileUploadState === "success";
+  }
+
+  return isAutoSaveSuccess || isContextMenuSuccess;
+}

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teak/extension",
   "description": "Teak - Your Personal Knowledge Hub. Save, organize, and rediscover web content, text selections, and ideas effortlessly.",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "author": "Praveen Juge (hi@praveenjuge.com)",
   "homepage": "https://teakvault.com",
   "type": "module",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/mobile",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "main": "expo-router/entry",
   "scripts": {
     "build": "expo export --platform web --clear",

--- a/apps/raycast/package.json
+++ b/apps/raycast/package.json
@@ -1,7 +1,7 @@
 {
   "name": "teak-raycast",
   "title": "Teak",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "private": true,
   "license": "MIT",
   "description": "Save ideas fast, search your Teak cards, and access favorites directly from Raycast.",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/web",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/cli": {
       "name": "teak-cli",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "bin": {
         "teak": "./dist/index.js",
       },
@@ -30,7 +30,7 @@
     },
     "apps/desktop": {
       "name": "@teak/desktop",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "dependencies": {
         "@tailwindcss/vite": "^4.3.0",
         "@teak/convex": "workspace:*",
@@ -62,7 +62,7 @@
     },
     "apps/docs": {
       "name": "@teak/docs",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "dependencies": {
         "@astrojs/check": "^0.9.9",
         "@astrojs/sitemap": "^3.7.3",
@@ -81,7 +81,7 @@
     },
     "apps/extension": {
       "name": "@teak/extension",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "dependencies": {
         "@convex-dev/better-auth": "0.12.5",
         "@tailwindcss/vite": "^4.3.0",
@@ -104,7 +104,7 @@
     },
     "apps/mobile": {
       "name": "@teak/mobile",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "dependencies": {
         "@better-auth/expo": "1.6.23",
         "@convex-dev/better-auth": "0.12.5",
@@ -157,7 +157,7 @@
     },
     "apps/raycast": {
       "name": "teak-raycast",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "dependencies": {
         "@raycast/api": "^1.104.19",
         "@raycast/utils": "^2.2.7",
@@ -171,7 +171,7 @@
     },
     "apps/web": {
       "name": "@teak/web",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "dependencies": {
         "@convex-dev/better-auth": "^0.12.5",
         "@polar-sh/checkout": "^0.2.1",
@@ -208,7 +208,7 @@
     },
     "packages/convex": {
       "name": "@teak/convex",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "dependencies": {
         "@ai-sdk/groq": "^3.0.39",
         "@aws-sdk/client-s3": "3.1069.0",
@@ -249,7 +249,7 @@
     },
     "packages/tests": {
       "name": "@teak/tests",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "dependencies": {
         "@axe-core/playwright": "^4.12.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -268,7 +268,7 @@
     },
     "packages/ui": {
       "name": "@teak/ui",
-      "version": "1.0.57",
+      "version": "1.0.58",
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "private": true,
   "packageManager": "bun@1.3.5",
   "workspaces": [

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/convex",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "type": "module",
   "exports": {
     ".": "./index.ts",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/tests",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { truncateSync, writeFileSync } from "node:fs";
 import { expect, type Page, test } from "@playwright/test";
 import { MAX_FILE_SIZE } from "@teak/convex/shared";
 import { apiFetch } from "../helpers/api";
@@ -76,7 +77,10 @@ const clearFilters = async (page: Page) => {
     .click();
 };
 
-const uploadFiles = async (page: Page, files: FilePayload | FilePayload[]) => {
+const uploadFiles = async (
+  page: Page,
+  files: FilePayload | FilePayload[] | string | string[]
+) => {
   const [chooser] = await Promise.all([
     page.waitForEvent("filechooser"),
     page.getByRole("button", { name: "Upload files" }).click(),
@@ -207,7 +211,9 @@ test("web editor, deep links, and link metadata stay usable", async ({
   );
 });
 
-test("web uploads and paste-created files complete", async ({ page }) => {
+test("web uploads and paste-created files complete", async ({
+  page,
+}, testInfo) => {
   const { apiKey } = primaryContext();
   const marker = markerFor("uploads");
   await waitForHomeUploadSurface(page);
@@ -228,11 +234,10 @@ test("web uploads and paste-created files complete", async ({ page }) => {
     timeout: 90_000,
   });
 
-  await uploadFiles(page, {
-    buffer: Buffer.alloc(MAX_FILE_SIZE + 1),
-    mimeType: "application/octet-stream",
-    name: `${marker}-too-large.bin`,
-  });
+  const oversizedPath = testInfo.outputPath(`${marker}-too-large.bin`);
+  writeFileSync(oversizedPath, "");
+  truncateSync(oversizedPath, MAX_FILE_SIZE + 1);
+  await uploadFiles(page, oversizedPath);
   await expect(page.getByText(/Maximum file size is 100MB/i)).toBeVisible();
 
   await waitForHomeUploadSurface(page);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/ui",
-  "version": "1.0.57",
+  "version": "1.0.58",
   "private": true,
   "exports": {
     "./logo": "./src/logo.tsx",


### PR DESCRIPTION
## Summary
- prevent URL/context-save auto-close timers from interrupting an active user-selected file upload
- keep upload errors visible and add direct popup auto-close regression coverage
- use a sparse on-disk oversized fixture so production Playwright reaches Teak's 100 MB validation instead of exceeding Playwright's 50 MB in-memory transport cap
- release the production hotfix as 1.0.58 and document the user-visible behavior

## Evidence
- production E2E run 29115413424 exposed both failures
- extension tests: 328 passed
- extension typecheck and production build passed
- tests workspace typecheck/lint passed
- docs tests passed
- canonical pre-commit: 22/22 tasks passed

## Production plan
After review and merge, verify the 1.0.58 release chain, deployment aliases, and rerun the full Production E2E workflow with cleanup.