### PR TITLE
Verify extension file metadata in production E2E

### DIFF
--- a/packages/tests/src/extension/save-page.e2e.ts
+++ b/packages/tests/src/extension/save-page.e2e.ts
@@ -80,14 +80,17 @@ test("extension saves a selected file and safe page asset with private URL fallb
       mimeType: "text/mdx",
       name: `${marker}.mdx`,
     });
+    await expect(uploadPopup.getByText("File saved!")).toBeVisible({
+      timeout: 45_000,
+    });
 
     const client = clientFor(account.apiKey!);
     await expect
       .poll(
         async () =>
-          (await client.cards.list({ limit: 100 })).items.some(
-            (card) => card.fileName === `${marker}.mdx`
-          ),
+          (
+            await client.cards.list({ include: "metadata", limit: 100 })
+          ).items.some((card) => card.fileName === `${marker}.mdx`),
         { timeout: 45_000 }
       )
       .toBe(true);
@@ -111,9 +114,9 @@ test("extension saves a selected file and safe page asset with private URL fallb
     await expect
       .poll(
         async () =>
-          (await client.cards.list({ limit: 100 })).items.some(
-            (card) => card.fileName === "icon.svg"
-          ),
+          (
+            await client.cards.list({ include: "metadata", limit: 100 })
+          ).items.some((card) => card.fileName === "icon.svg"),
         { timeout: 45_000 }
       )
       .toBe(true);
@@ -132,7 +135,7 @@ test("extension saves a selected file and safe page asset with private URL fallb
       status: "error",
     });
     expect(
-      (await client.cards.list({ limit: 100 })).items.some(
+      (await client.cards.list({ include: "metadata", limit: 100 })).items.some(
         (card) => card.fileName === "private.png"
       )
     ).toBe(false);


### PR DESCRIPTION
## Summary
- assert the extension popup reaches its visible File saved state before checking API persistence
- request the API metadata include group when validating uploaded file names
- preserve the private-asset negative assertion with the same metadata contract

## Evidence
Production E2E run 29116531212 showed the extension upload completed, but its compact default list response intentionally omitted fileName. Tests workspace typecheck/lint and the canonical pre-commit gate pass.

After merge I will rerun the full Production E2E workflow.