### PR TITLE
test: stabilize production file journeys

### DIFF
--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "e2e:prod:journey": "playwright test --project=journey-setup --project=journey-web --project=journey-services --project=journey-a11y --project=journey-security --project=journey-account --project=journey-delete --project=journey-post-delete",
     "e2e:prod:docs": "playwright test --project=docs",
-    "e2e:prod:matrix": "playwright test --project=matrix-chromium --project=matrix-firefox --project=matrix-webkit",
+    "e2e:prod:matrix": "playwright test --workers=1 --project=matrix-chromium --project=matrix-firefox --project=matrix-webkit",
     "e2e:prod:extension": "playwright test --project=extension",
     "e2e:prod:local": "tsx src/scripts/run-prod-suite.ts",
     "preflight": "tsx src/scripts/preflight.ts",

--- a/packages/tests/src/extension/save-page.e2e.ts
+++ b/packages/tests/src/extension/save-page.e2e.ts
@@ -74,6 +74,9 @@ test("extension saves a selected file and safe page asset with private URL fallb
 
     const marker = `extension-file-${Date.now()}`;
     const uploadPopup = await context.newPage();
+    await uploadPopup.addInitScript(() => {
+      window.close = () => undefined;
+    });
     await uploadPopup.goto(popupUrl);
     await uploadPopup.locator('input[type="file"]').setInputFiles({
       buffer: Buffer.from(`# ${marker}\n\nSaved from the extension.`),
@@ -95,7 +98,7 @@ test("extension saves a selected file and safe page asset with private URL fallb
       )
       .toBe(true);
 
-    const assetResult = await serviceWorker.evaluate(
+    const assetResult = await uploadPopup.evaluate(
       ({ assetUrl, messageType }) => {
         const extensionChrome = (
           globalThis as typeof globalThis & { chrome: ExtensionChrome }
@@ -121,7 +124,7 @@ test("extension saves a selected file and safe page asset with private URL fallb
       )
       .toBe(true);
 
-    const unsafeResult = await serviceWorker.evaluate((messageType) => {
+    const unsafeResult = await uploadPopup.evaluate((messageType) => {
       const extensionChrome = (
         globalThis as typeof globalThis & { chrome: ExtensionChrome }
       ).chrome;

--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { truncateSync, writeFileSync } from "node:fs";
+import { writeFileSync } from "node:fs";
 import { expect, type Page, test } from "@playwright/test";
 import { MAX_FILE_SIZE } from "@teak/convex/shared";
 import { apiFetch } from "../helpers/api";
@@ -235,8 +235,7 @@ test("web uploads and paste-created files complete", async ({
   });
 
   const oversizedPath = testInfo.outputPath(`${marker}-too-large.bin`);
-  writeFileSync(oversizedPath, "");
-  truncateSync(oversizedPath, MAX_FILE_SIZE + 1);
+  writeFileSync(oversizedPath, Buffer.alloc(MAX_FILE_SIZE + 1));
   await uploadFiles(page, oversizedPath);
   await expect(page.getByText(/Maximum file size is 100MB/i)).toBeVisible();
 


### PR DESCRIPTION
## Summary
- send extension asset-save test messages from an extension page so the background listener receives them
- use an allocated 100MB+ fixture so Playwright observes the exact file length
- run browser-matrix projects sequentially to avoid cross-browser signup contention

## Validation
- focused Ultracite check
- @teak/tests typecheck and lint
- extension project discovery
- full 22-task pre-commit gate