### PR TITLE
release: prepare mobile 1.0.58

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Teak",
     "slug": "teak",
-    "version": "1.0.45",
+    "version": "1.0.58",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/apps/mobile/store.config.json
+++ b/apps/mobile/store.config.json
@@ -1,7 +1,7 @@
 {
   "configVersion": 0,
   "apple": {
-    "version": "1.0.45",
+    "version": "1.0.58",
     "copyright": "Praveen Juge. All rights reserved.",
     "release": {
       "automaticRelease": true
@@ -18,7 +18,7 @@
           "creative",
           "save"
         ],
-        "releaseNotes": "FIXED: When your iPhone is offline, Teak now shows a clear connection screen with a retry action instead of sending you to sign in.",
+        "releaseNotes": "NEW: Save source files, Markdown, archives, SVGs, GIFs, HEIC images, presentations, and design files from the picker or share sheet.\nIMPROVED: File cards now show safe previews or clear file details when a format cannot be previewed.",
         "marketingUrl": "https://teakvault.com",
         "promoText": "Capture, organize, and access your creative inspiration anywhere.",
         "supportUrl": "https://teakvault.com/docs",


### PR DESCRIPTION
## Summary
- align the iOS app version with Teak 1.0.58
- publish user-facing expanded file support release notes

## App Store delivery
- metadata pushed to App Store Connect
- signed iOS build 63 uploaded successfully
- review submission 45df8731-c7fc-488d-93ae-a595ec74759f submitted

## Validation
- mobile typecheck and lint
- 157 mobile tests
- mobile production export
- signed local IPA archive/export
- App Store Connect upload and review submission