### PR TITLE
fix: isolate Convex Sentry Node runtime

### DIFF
--- a/packages/convex/__tests__/telemetry/node-runtime.test.ts
+++ b/packages/convex/__tests__/telemetry/node-runtime.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const convexRoot = resolve(import.meta.dirname, "../..");
+const readConvexSource = (relativePath: string) =>
+  readFileSync(resolve(convexRoot, relativePath), "utf8");
+
+describe("backend telemetry Node runtime", () => {
+  test("marks every Node-only AI telemetry helper", () => {
+    for (const relativePath of [
+      "ai/telemetry.ts",
+      "workflows/aiMetadata/generators.ts",
+      "workflows/aiMetadata/transcript.ts",
+    ]) {
+      expect(readConvexSource(relativePath).trimStart()).toStartWith(
+        '"use node";'
+      );
+    }
+  });
+
+  test("keeps Node-only helpers out of the default-runtime workflow barrel", () => {
+    const source = readConvexSource("workflows/aiMetadata/index.ts");
+
+    expect(source).not.toContain('from "./generators"');
+    expect(source).not.toContain('from "./transcript"');
+  });
+});

--- a/packages/convex/ai/telemetry.ts
+++ b/packages/convex/ai/telemetry.ts
@@ -1,3 +1,5 @@
+"use node";
+
 import { distribution, trackAiCall } from "../shared/metrics";
 import {
   normalizeErrorClass,

--- a/packages/convex/workflows/aiMetadata/generators.ts
+++ b/packages/convex/workflows/aiMetadata/generators.ts
@@ -1,3 +1,5 @@
+"use node";
+
 import { generateText, Output } from "ai";
 import {
   IMAGE_METADATA_MODEL,

--- a/packages/convex/workflows/aiMetadata/index.ts
+++ b/packages/convex/workflows/aiMetadata/index.ts
@@ -91,8 +91,6 @@ export const startAiMetadataWorkflow = internalMutation({
 });
 
 export * from "./actions";
-export * from "./generators";
 export * from "./mutations";
 export * from "./schemas";
-export * from "./transcript";
 export * from "./types";

--- a/packages/convex/workflows/aiMetadata/transcript.ts
+++ b/packages/convex/workflows/aiMetadata/transcript.ts
@@ -1,3 +1,5 @@
+"use node";
+
 import { experimental_transcribe as transcribe } from "ai";
 import { TRANSCRIPTION_MODEL, TRANSCRIPTION_MODEL_ID } from "../../ai/models";
 import { observeAiGeneration } from "../../ai/telemetry";


### PR DESCRIPTION
## Summary

- mark the Sentry-backed AI telemetry helper chain as Convex Node-runtime code
- stop the default-runtime AI workflow barrel from re-exporting Node-only helpers
- add a regression test that locks both runtime boundaries

## Production failure fixed

Backend Deploy run 29159806633 reached credential validation and Sentry release creation, then Convex bundling failed because the default runtime followed AI helper re-exports into @sentry/node and Node built-ins.

## Validation

- 23 focused backend telemetry and AI tests
- Convex typecheck
- targeted Biome check
- affected pre-commit typecheck, lint, and build pipeline

The post-merge Backend Deploy workflow is the authoritative bundle and production deployment check.