### PR TITLE
fix: expose TypeScript to Convex deploy

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -59,7 +59,6 @@ jobs:
           test -f node_modules/typescript/bin/tsc
           bunx convex deploy \
             --typecheck enable \
-            --typecheck-components \
             --message "Sentry release teak-backend@$GITHUB_SHA"
       - name: Finalize Sentry release
         run: |

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -52,8 +52,11 @@ jobs:
       - name: Deploy Convex production
         working-directory: packages/convex
         run: |
-          export PATH="$GITHUB_WORKSPACE/node_modules/.bin:$PATH"
-          test -x "$GITHUB_WORKSPACE/node_modules/.bin/tsc"
+          mkdir -p node_modules
+          if [ ! -e node_modules/typescript ]; then
+            ln -s "$GITHUB_WORKSPACE/node_modules/typescript" node_modules/typescript
+          fi
+          test -f node_modules/typescript/bin/tsc
           bunx convex deploy \
             --typecheck enable \
             --typecheck-components \

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Deploy Convex production
         working-directory: packages/convex
         run: |
+          export PATH="$GITHUB_WORKSPACE/node_modules/.bin:$PATH"
+          test -x "$GITHUB_WORKSPACE/node_modules/.bin/tsc"
           bunx convex deploy \
             --typecheck enable \
             --typecheck-components \

--- a/packages/convex/__tests__/telemetry/node-runtime.test.ts
+++ b/packages/convex/__tests__/telemetry/node-runtime.test.ts
@@ -64,18 +64,16 @@ describe("backend telemetry Node runtime", () => {
     expect(invalidPaths).toEqual([]);
   });
 
-  test("exposes the hoisted TypeScript binary to Convex deploy", () => {
+  test("links hoisted TypeScript where Convex deploy resolves it", () => {
     const workflow = readFileSync(
       resolve(repositoryRoot, ".github/workflows/backend-deploy.yml"),
       "utf8"
     );
 
     expect(workflow).toContain(
-      'export PATH="$GITHUB_WORKSPACE/node_modules/.bin:$PATH"'
+      'ln -s "$GITHUB_WORKSPACE/node_modules/typescript" node_modules/typescript'
     );
-    expect(workflow).toContain(
-      'test -x "$GITHUB_WORKSPACE/node_modules/.bin/tsc"'
-    );
+    expect(workflow).toContain("test -f node_modules/typescript/bin/tsc");
     expect(workflow).toContain("--typecheck enable");
     expect(workflow).toContain("--typecheck-components");
   });

--- a/packages/convex/__tests__/telemetry/node-runtime.test.ts
+++ b/packages/convex/__tests__/telemetry/node-runtime.test.ts
@@ -77,5 +77,6 @@ describe("backend telemetry Node runtime", () => {
       'test -x "$GITHUB_WORKSPACE/node_modules/.bin/tsc"'
     );
     expect(workflow).toContain("--typecheck enable");
+    expect(workflow).toContain("--typecheck-components");
   });
 });

--- a/packages/convex/__tests__/telemetry/node-runtime.test.ts
+++ b/packages/convex/__tests__/telemetry/node-runtime.test.ts
@@ -3,6 +3,7 @@ import { readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 const convexRoot = resolve(import.meta.dirname, "../..");
+const repositoryRoot = resolve(convexRoot, "../..");
 const readConvexSource = (relativePath: string) =>
   readFileSync(resolve(convexRoot, relativePath), "utf8");
 
@@ -61,5 +62,20 @@ describe("backend telemetry Node runtime", () => {
     );
 
     expect(invalidPaths).toEqual([]);
+  });
+
+  test("exposes the hoisted TypeScript binary to Convex deploy", () => {
+    const workflow = readFileSync(
+      resolve(repositoryRoot, ".github/workflows/backend-deploy.yml"),
+      "utf8"
+    );
+
+    expect(workflow).toContain(
+      'export PATH="$GITHUB_WORKSPACE/node_modules/.bin:$PATH"'
+    );
+    expect(workflow).toContain(
+      'test -x "$GITHUB_WORKSPACE/node_modules/.bin/tsc"'
+    );
+    expect(workflow).toContain("--typecheck enable");
   });
 });

--- a/packages/convex/__tests__/telemetry/node-runtime.test.ts
+++ b/packages/convex/__tests__/telemetry/node-runtime.test.ts
@@ -75,6 +75,6 @@ describe("backend telemetry Node runtime", () => {
     );
     expect(workflow).toContain("test -f node_modules/typescript/bin/tsc");
     expect(workflow).toContain("--typecheck enable");
-    expect(workflow).toContain("--typecheck-components");
+    expect(workflow).not.toContain("--typecheck-components");
   });
 });


### PR DESCRIPTION
## Summary
- link Bun's hoisted TypeScript package where Convex CLI resolves it
- verify the compiler exists before production deployment
- keep root Convex typechecking enabled
- avoid component typechecking for installed components that do not ship tsconfig files
- add a regression contract for the deploy workflow

## Production failures fixed
Backend Deploy runs first could not find the hoisted compiler, then root typechecking passed but installed @convex-dev components failed because they do not ship tsconfig files. Convex documents component typechecking as opt-in and defaults it off.

## Validation
- focused backend workflow contract: 4 tests passed
- bun run pre-commit: 16 affected typecheck, lint, and build tasks passed
- Convex root typecheck passed