### PR TITLE
fix: finish deleted card workflows cleanly

### DIFF
--- a/packages/convex/__tests__/shared/metrics.test.ts
+++ b/packages/convex/__tests__/shared/metrics.test.ts
@@ -57,6 +57,49 @@ describe("trackAiStage", () => {
       },
     ]);
   });
+
+  test("counts skipped workflow stages without reporting a failure", () => {
+    const counts: Array<{
+      attributes: MetricAttributes;
+      name: string;
+      value: number;
+    }> = [];
+
+    configureMetrics({
+      app: "convex",
+      env: "production",
+      recorder: {
+        count(name, value, attributes) {
+          counts.push({ attributes, name, value });
+        },
+        distribution() {
+          // The duration distribution is covered above.
+        },
+        gauge() {
+          // Not used by workflow stage metrics.
+        },
+      },
+    });
+
+    trackAiStage({
+      durationMs: 0,
+      outcome: "skipped",
+      stage: "classification",
+    });
+
+    expect(counts).toEqual([
+      {
+        attributes: {
+          "card.type": null,
+          environment: "production",
+          stage: "classification",
+          surface: "backend",
+        },
+        name: TELEMETRY_METRICS.workflowSkip,
+        value: 1,
+      },
+    ]);
+  });
 });
 
 describe("trackUpload", () => {

--- a/packages/convex/__tests__/workflows/cardProcessing.test.ts
+++ b/packages/convex/__tests__/workflows/cardProcessing.test.ts
@@ -15,6 +15,16 @@ describe("workflows/cardProcessing", () => {
       );
     });
 
+    test("finishes a deleted-card workflow as skipped instead of failed", async () => {
+      const module = await import("../../workflows/cardProcessing");
+
+      expect(module.createMissingCardWorkflowResult()).toEqual({
+        success: true,
+        mode: "skipped",
+        reason: "card_missing",
+      });
+    });
+
     test("clamps completion duration to a non-negative value", async () => {
       const module = await import("../../workflows/cardProcessing");
       expect(module.resolveCardProcessingDurationMs(500, 1000)).toBe(500);

--- a/packages/convex/__tests__/workflows/steps/classification.test.ts
+++ b/packages/convex/__tests__/workflows/steps/classification.test.ts
@@ -28,18 +28,22 @@ describe("classification step", () => {
   });
 
   describe("classification error handling", () => {
-    test("throws error when card not found", async () => {
+    test("skips when card was deleted before classification", async () => {
       mockRunQuery.mockResolvedValue(null);
 
-      await expect(classify(mockCtx, { cardId: "c1" })).rejects.toThrow(
-        "Card c1 not found for classification"
-      );
+      await expect(classify(mockCtx, { cardId: "c1" })).resolves.toEqual({
+        mode: "skipped",
+      });
+      expect(mockRunMutation).not.toHaveBeenCalled();
     });
 
-    test("handles missing card gracefully", async () => {
+    test("treats an undefined card as the same deletion race", async () => {
       mockRunQuery.mockResolvedValue(undefined);
 
-      await expect(classify(mockCtx, { cardId: "c2" })).rejects.toThrow();
+      await expect(classify(mockCtx, { cardId: "c2" })).resolves.toEqual({
+        mode: "skipped",
+      });
+      expect(mockRunMutation).not.toHaveBeenCalled();
     });
   });
 
@@ -55,6 +59,7 @@ describe("classification step", () => {
 
       const result = await classify(mockCtx, { cardId: "c1" });
 
+      expect(result.mode).toBe("completed");
       expect(result.type).toBe("quote");
       expect(result.confidence).toBe(0.95);
       expect(result.shouldCategorize).toBe(false);

--- a/packages/convex/shared/metrics.ts
+++ b/packages/convex/shared/metrics.ts
@@ -314,6 +314,12 @@ export function trackAiStage(params: {
       "error.class": params.errorClass ?? null,
     });
   }
+  if (params.outcome === "skipped") {
+    counter(TELEMETRY_METRICS.workflowSkip, 1, {
+      stage: params.stage,
+      "card.type": params.cardType ?? null,
+    });
+  }
 }
 
 export function trackUpload(params: {

--- a/packages/convex/workflows/cardProcessing.ts
+++ b/packages/convex/workflows/cardProcessing.ts
@@ -43,6 +43,12 @@ export const resolveCardProcessingDurationMs = (
 ): number | undefined =>
   creationTime === undefined ? undefined : Math.max(0, now - creationTime);
 
+export const createMissingCardWorkflowResult = () => ({
+  success: true as const,
+  mode: "skipped" as const,
+  reason: "card_missing" as const,
+});
+
 async function timeStage<T>(
   stage: AiPipelineStage,
   cardType: string | undefined,
@@ -87,29 +93,37 @@ export const cardProcessingWorkflow: any = workflow.define({
   args: {
     cardId: v.id("cards"),
   },
-  returns: v.object({
-    success: v.boolean(),
-    classification: v.object({
-      type: v.string(),
-      confidence: v.number(),
-    }),
-    categorization: v.optional(
-      v.object({
-        category: v.string(),
+  returns: v.union(
+    v.object({
+      success: v.boolean(),
+      mode: v.literal("completed"),
+      classification: v.object({
+        type: v.string(),
         confidence: v.number(),
-      })
-    ),
-    metadata: v.object({
-      aiTagsCount: v.number(),
-      hasSummary: v.boolean(),
-      hasTranscript: v.boolean(),
+      }),
+      categorization: v.optional(
+        v.object({
+          category: v.string(),
+          confidence: v.number(),
+        })
+      ),
+      metadata: v.object({
+        aiTagsCount: v.number(),
+        hasSummary: v.boolean(),
+        hasTranscript: v.boolean(),
+      }),
+      renderables: v.optional(
+        v.object({
+          thumbnailGenerated: v.boolean(),
+        })
+      ),
     }),
-    renderables: v.optional(
-      v.object({
-        thumbnailGenerated: v.boolean(),
-      })
-    ),
-  }),
+    v.object({
+      success: v.boolean(),
+      mode: v.literal("skipped"),
+      reason: v.literal("card_missing"),
+    })
+  ),
   handler: async (step, { cardId }) => {
     console.info(`${PIPELINE_LOG_PREFIX} Starting`, { cardId });
 
@@ -118,12 +132,22 @@ export const cardProcessingWorkflow: any = workflow.define({
       { cardId }
     );
 
+    if (!initialCard) {
+      trackAiStage({
+        stage: "classification",
+        durationMs: 0,
+        outcome: "skipped",
+      });
+      return createMissingCardWorkflowResult();
+    }
+
     // Step 1: Classification
     // If already classified (client-provided type), reuse it; otherwise run classifier
     const existingClassifyStatus = initialCard?.processingStatus?.classify;
     const classification =
       existingClassifyStatus?.status === "completed" && initialCard
         ? {
+            mode: "completed" as const,
             type: initialCard.type,
             confidence: existingClassifyStatus.confidence ?? 1,
             needsLinkMetadata:
@@ -141,6 +165,10 @@ export const cardProcessingWorkflow: any = workflow.define({
               { cardId }
             )
           );
+
+    if (classification.mode === "skipped") {
+      return createMissingCardWorkflowResult();
+    }
 
     // Ensure link metadata is ready before proceeding with downstream AI steps.
     if (classification.type === "link") {
@@ -304,6 +332,7 @@ export const cardProcessingWorkflow: any = workflow.define({
 
     const result = {
       success: true,
+      mode: "completed" as const,
       classification: {
         type: classification.type,
         confidence: classification.confidence,

--- a/packages/convex/workflows/steps/classification.ts
+++ b/packages/convex/workflows/steps/classification.ts
@@ -29,14 +29,23 @@ const MEDIUM_CONFIDENCE = 0.9;
 const PALETTE_CONFIDENCE = 0.88;
 const DEFAULT_CONFIDENCE = 0.7;
 
-interface ClassificationWorkflowResult {
+interface CompletedClassificationWorkflowResult {
   confidence: number;
+  mode: "completed";
   needsLinkMetadata: boolean;
   shouldCategorize: boolean;
   shouldGenerateMetadata: boolean;
   shouldGenerateRenderables: boolean;
   type: CardType;
 }
+
+interface SkippedClassificationWorkflowResult {
+  mode: "skipped";
+}
+
+type ClassificationWorkflowResult =
+  | CompletedClassificationWorkflowResult
+  | SkippedClassificationWorkflowResult;
 
 interface DbColor {
   hex: string;
@@ -286,14 +295,20 @@ export const classify = internalAction({
   args: {
     cardId: v.id("cards"),
   },
-  returns: v.object({
-    type: v.string(),
-    confidence: v.number(),
-    needsLinkMetadata: v.boolean(),
-    shouldCategorize: v.boolean(),
-    shouldGenerateMetadata: v.boolean(),
-    shouldGenerateRenderables: v.boolean(),
-  }),
+  returns: v.union(
+    v.object({
+      mode: v.literal("completed"),
+      type: v.string(),
+      confidence: v.number(),
+      needsLinkMetadata: v.boolean(),
+      shouldCategorize: v.boolean(),
+      shouldGenerateMetadata: v.boolean(),
+      shouldGenerateRenderables: v.boolean(),
+    }),
+    v.object({
+      mode: v.literal("skipped"),
+    })
+  ),
   handler: async (ctx, { cardId }): Promise<ClassificationWorkflowResult> =>
     withBackendSpan(
       {
@@ -309,7 +324,7 @@ export const classify = internalAction({
         });
 
         if (!card) {
-          throw new Error(`Card ${cardId} not found for classification`);
+          return { mode: "skipped" };
         }
 
         // If previously classified as quote and no conflicting signals, keep it sticky
@@ -317,6 +332,7 @@ export const classify = internalAction({
           const confidence =
             card.processingStatus?.classify?.confidence ?? 0.95;
           const stickyResult: ClassificationWorkflowResult = {
+            mode: "completed",
             type: "quote",
             confidence,
             needsLinkMetadata: false,
@@ -344,6 +360,7 @@ export const classify = internalAction({
           );
 
           const heuristicResult: ClassificationWorkflowResult = {
+            mode: "completed",
             type: "quote",
             confidence: 0.95,
             needsLinkMetadata: false,
@@ -407,6 +424,7 @@ export const classify = internalAction({
         ].includes(normalizedType);
 
         const result: ClassificationWorkflowResult = {
+          mode: "completed",
           type: normalizedType,
           confidence: normalizedConfidence,
           needsLinkMetadata,

--- a/packages/tests/src/helpers/run-state.ts
+++ b/packages/tests/src/helpers/run-state.ts
@@ -13,7 +13,10 @@ export interface RunState {
   createdCardIds: string[];
   primary?: AccountState;
   revokedKey?: string;
+  serviceAccounts?: Partial<Record<ServiceAccountSurface, AccountState>>;
 }
+
+export type ServiceAccountSurface = "api" | "cli" | "mcp";
 
 const file = new URL("../../.state/run-state.json", import.meta.url);
 export const storageStateFile = ".state/user.json";
@@ -36,6 +39,16 @@ export const updateState = (fn: (state: RunState) => void) => {
   fn(state);
   writeState(state);
   return state;
+};
+
+export const requireServiceApiKey = (
+  surface: ServiceAccountSurface
+): string => {
+  const apiKey = readState().serviceAccounts?.[surface]?.apiKey;
+  if (!apiKey) {
+    throw new Error(`Missing ${surface} service account API key`);
+  }
+  return apiKey;
 };
 
 export const rememberAccount = (account: AccountState, primary = false) =>

--- a/packages/tests/src/journey/01-signup.setup.ts
+++ b/packages/tests/src/journey/01-signup.setup.ts
@@ -5,11 +5,30 @@ import { storageStateFile, updateState } from "../helpers/run-state";
 
 test.setTimeout(240_000);
 
-test("create verified production account and API key", async ({ page }) => {
+test("create isolated verified production accounts and API keys", async ({
+  browser,
+  page,
+}) => {
   await assertMailpitReady();
   const account = await createAccount(page, "primary");
   updateState((state) => {
     state.primary = account;
   });
   await page.context().storageState({ path: storageStateFile });
+
+  for (const surface of ["api", "cli", "mcp"] as const) {
+    const context = await browser.newContext();
+    try {
+      const serviceAccount = await createAccount(
+        await context.newPage(),
+        `service-${surface}`
+      );
+      updateState((state) => {
+        state.serviceAccounts ??= {};
+        state.serviceAccounts[surface] = serviceAccount;
+      });
+    } finally {
+      await context.close();
+    }
+  }
 });

--- a/packages/tests/src/journey/03-api.e2e.ts
+++ b/packages/tests/src/journey/03-api.e2e.ts
@@ -1,13 +1,10 @@
 import { expect, test } from "@playwright/test";
 import { apiFetch, loadOpenApi } from "../helpers/api";
 import { expandedFileFixtures } from "../helpers/file-formats";
-import { readState, updateState } from "../helpers/run-state";
+import { requireServiceApiKey, updateState } from "../helpers/run-state";
 
 test("REST API happy paths and OpenAPI contracts", async () => {
-  const { primary } = readState();
-  if (!primary?.apiKey) {
-    throw new Error("Missing primary API key");
-  }
+  const apiKey = requireServiceApiKey("api");
   const openapi = await loadOpenApi();
   for (const path of [
     "/v1/cards",
@@ -15,7 +12,7 @@ test("REST API happy paths and OpenAPI contracts", async () => {
     "/v1/cards/favorites",
     "/v1/tags",
   ]) {
-    const response = await apiFetch(path, primary.apiKey);
+    const response = await apiFetch(path, apiKey);
     expect(response.ok).toBe(true);
     openapi.validate(
       path,
@@ -24,7 +21,7 @@ test("REST API happy paths and OpenAPI contracts", async () => {
       await response.clone().json()
     );
   }
-  const created = await apiFetch("/v1/cards", primary.apiKey, {
+  const created = await apiFetch("/v1/cards", apiKey, {
     method: "POST",
     body: JSON.stringify({
       content: `api-prod-e2e-${Date.now()}`,
@@ -35,10 +32,10 @@ test("REST API happy paths and OpenAPI contracts", async () => {
   const payload = await created.json();
   openapi.validate("/v1/cards", "POST", created.status, payload);
   const cardPath = `/v1/cards/${payload.cardId}`;
-  expect((await apiFetch(cardPath, primary.apiKey)).status).toBe(200);
+  expect((await apiFetch(cardPath, apiKey)).status).toBe(200);
   expect(
     (
-      await apiFetch(`${cardPath}/favorite`, primary.apiKey, {
+      await apiFetch(`${cardPath}/favorite`, apiKey, {
         method: "PATCH",
         body: JSON.stringify({ isFavorited: true }),
       })
@@ -46,7 +43,7 @@ test("REST API happy paths and OpenAPI contracts", async () => {
   ).toBe(200);
   expect(
     (
-      await apiFetch(cardPath, primary.apiKey, {
+      await apiFetch(cardPath, apiKey, {
         method: "PATCH",
         body: JSON.stringify({ notes: "updated by prod e2e" }),
       })
@@ -54,7 +51,7 @@ test("REST API happy paths and OpenAPI contracts", async () => {
   ).toBe(200);
   expect(
     (
-      await apiFetch("/v1/cards/bulk", primary.apiKey, {
+      await apiFetch("/v1/cards/bulk", apiKey, {
         method: "POST",
         body: JSON.stringify({
           operation: "create",
@@ -63,21 +60,16 @@ test("REST API happy paths and OpenAPI contracts", async () => {
       })
     ).status
   ).toBe(200);
-  expect((await apiFetch("/v1/cards/not-a-card", primary.apiKey)).status).toBe(
-    404
-  );
+  expect((await apiFetch("/v1/cards/not-a-card", apiKey)).status).toBe(404);
 });
 
 test("saving a URL as content creates a link card, not a text card", async () => {
   // Regression: a bare URL (e.g. a Goodreads book link) submitted as card
   // content was stored as a "text" card instead of being recognized as a link.
-  const { primary } = readState();
-  if (!primary?.apiKey) {
-    throw new Error("Missing primary API key");
-  }
+  const apiKey = requireServiceApiKey("api");
   const bookUrl =
     "https://www.goodreads.com/book/show/2767052-the-hunger-games";
-  const created = await apiFetch("/v1/cards", primary.apiKey, {
+  const created = await apiFetch("/v1/cards", apiKey, {
     method: "POST",
     body: JSON.stringify({
       content: bookUrl,
@@ -93,7 +85,7 @@ test("saving a URL as content creates a link card, not a text card", async () =>
   expect(payload.card?.url).toBe(bookUrl);
 
   // And it should persist as a link when fetched back.
-  const fetched = await apiFetch(`/v1/cards/${payload.cardId}`, primary.apiKey);
+  const fetched = await apiFetch(`/v1/cards/${payload.cardId}`, apiKey);
   expect(fetched.status).toBe(200);
   const fetchedPayload = await fetched.json();
   expect(fetchedPayload.type).toBe("link");
@@ -104,11 +96,7 @@ test("saving a color as content creates a palette card, not a text card", async 
   // Regression: saving a color (single hex, or a list of colors/names) as card
   // content stopped becoming a "palette" card and stuck as "text". Palette
   // classification runs asynchronously after creation, so poll until it lands.
-  const { primary } = readState();
-  if (!primary?.apiKey) {
-    throw new Error("Missing primary API key");
-  }
-  const apiKey = primary.apiKey;
+  const apiKey = requireServiceApiKey("api");
   const created = await apiFetch("/v1/cards", apiKey, {
     method: "POST",
     body: JSON.stringify({
@@ -135,15 +123,12 @@ test("saving a color as content creates a palette card, not a text card", async 
 });
 
 test("REST API uploads and infers the expanded file-format matrix", async () => {
-  const { primary } = readState();
-  if (!primary?.apiKey) {
-    throw new Error("Missing primary API key");
-  }
+  const apiKey = requireServiceApiKey("api");
   const marker = `api-file-${Date.now()}`;
   const fixtures = expandedFileFixtures(marker);
 
   for (const [index, fixture] of fixtures.entries()) {
-    const prepared = await apiFetch("/v1/uploads", primary.apiKey, {
+    const prepared = await apiFetch("/v1/uploads", apiKey, {
       method: "POST",
       body: JSON.stringify({
         fileName: fixture.fileName,
@@ -171,7 +156,7 @@ test("REST API uploads and infers the expanded file-format matrix", async () => 
         ? "image"
         : "document";
     }
-    const created = await apiFetch("/v1/cards", primary.apiKey, {
+    const created = await apiFetch("/v1/cards", apiKey, {
       method: "POST",
       body: JSON.stringify({
         ...(explicitCardType ? { cardType: explicitCardType } : {}),
@@ -187,7 +172,7 @@ test("REST API uploads and infers the expanded file-format matrix", async () => 
     const card = await created.json();
     updateState((state) => state.createdCardIds.push(card.cardId));
 
-    const fetched = await apiFetch(`/v1/cards/${card.cardId}`, primary.apiKey);
+    const fetched = await apiFetch(`/v1/cards/${card.cardId}`, apiKey);
     expect(fetched.status).toBe(200);
     const fetchedCard = await fetched.json();
     expect(fetchedCard.fileName).toBe(fixture.fileName);
@@ -199,7 +184,7 @@ test("REST API uploads and infers the expanded file-format matrix", async () => 
     }
   }
 
-  const unsupported = await apiFetch("/v1/uploads", primary.apiKey, {
+  const unsupported = await apiFetch("/v1/uploads", apiKey, {
     method: "POST",
     body: JSON.stringify({
       fileName: `${marker}.riv`,

--- a/packages/tests/src/journey/04-cli.e2e.ts
+++ b/packages/tests/src/journey/04-cli.e2e.ts
@@ -1,24 +1,20 @@
 import { expect, test } from "@playwright/test";
 import { runCli } from "../helpers/cli";
 import { cliFileFixtures, materializeFixtures } from "../helpers/file-formats";
-import { readState, updateState } from "../helpers/run-state";
+import { requireServiceApiKey, updateState } from "../helpers/run-state";
 
 for (const kind of ["repo", "npm"] as const) {
   test(`${kind} CLI covers auth, cards, tags, and aliases`, async () => {
-    const { primary } = readState();
-    if (!primary?.apiKey) {
-      throw new Error("Missing primary API key");
-    }
+    const apiKey = requireServiceApiKey("cli");
     expect(
-      JSON.parse(
-        await runCli(kind, ["--json", "auth", "status"], primary.apiKey)
-      ).status
+      JSON.parse(await runCli(kind, ["--json", "auth", "status"], apiKey))
+        .status
     ).toBe("ok");
     const created = JSON.parse(
       await runCli(
         kind,
         ["--json", "cards", "create", `cli-${kind}-${Date.now()}`],
-        primary.apiKey
+        apiKey
       )
     );
     for (const args of [
@@ -30,16 +26,13 @@ for (const kind of ["repo", "npm"] as const) {
       ["--json", "ls", "--limit", "1"],
       ["--json", "search", "cli"],
     ]) {
-      expect(await runCli(kind, args, primary.apiKey)).toBeTruthy();
+      expect(await runCli(kind, args, apiKey)).toBeTruthy();
     }
   });
 }
 
 test("repo CLI uploads source, Markdown, ZIP, SVG, GIF, and Figma files", async () => {
-  const { primary } = readState();
-  if (!primary?.apiKey) {
-    throw new Error("Missing primary API key");
-  }
+  const apiKey = requireServiceApiKey("cli");
   const marker = `cli-file-${Date.now()}`;
   const paths = materializeFixtures(cliFileFixtures(marker));
 
@@ -55,7 +48,7 @@ test("repo CLI uploads source, Markdown, ZIP, SVG, GIF, and Figma files", async 
           "--tags",
           "prod-e2e,file-formats",
         ],
-        primary.apiKey
+        apiKey
       )
     );
     expect(created.cardId, filePath).toBeTruthy();

--- a/packages/tests/src/journey/05-mcp.e2e.ts
+++ b/packages/tests/src/journey/05-mcp.e2e.ts
@@ -2,17 +2,14 @@ import { expect, test } from "@playwright/test";
 import { env } from "../helpers/env";
 import { cliFileFixtures } from "../helpers/file-formats";
 import { connectMcp } from "../helpers/mcp";
-import { readState, updateState } from "../helpers/run-state";
+import { requireServiceApiKey, updateState } from "../helpers/run-state";
 
 test("MCP lists and calls every public tool", async () => {
-  const { primary } = readState();
-  if (!primary?.apiKey) {
-    throw new Error("Missing primary API key");
-  }
+  const apiKey = requireServiceApiKey("mcp");
   const unauth = await fetch(env.mcpUrl);
   expect(unauth.status).toBe(401);
   expect(unauth.headers.get("www-authenticate")).toContain("resource_metadata");
-  const client = await connectMcp(primary.apiKey);
+  const client = await connectMcp(apiKey);
   const tools = await client.listTools();
   expect(tools.tools.map((tool) => tool.name).sort()).toEqual(
     [
@@ -74,12 +71,9 @@ test("MCP lists and calls every public tool", async () => {
 });
 
 test("MCP uploads, creates, fetches, and searches expanded file cards", async () => {
-  const { primary } = readState();
-  if (!primary?.apiKey) {
-    throw new Error("Missing primary API key");
-  }
+  const apiKey = requireServiceApiKey("mcp");
   const marker = `mcp-file-${Date.now()}`;
-  const client = await connectMcp(primary.apiKey);
+  const client = await connectMcp(apiKey);
   try {
     for (const fixture of cliFileFixtures(marker)) {
       const prepared: any = await client.callTool({


### PR DESCRIPTION
## Summary
- finish classification as a successful skipped workflow when a card is deleted before or during the step
- record canonical workflow-skip metrics instead of raising post-delete Sentry errors
- isolate REST, CLI, and MCP production E2E accounts so independent surfaces do not contend for one card-creation rate-limit bucket

## Production evidence
- fixes Sentry TEAK-BACKEND-PROD-7 / issue 7606231625 on release teak-backend@f6339f4a4cfa6dad36224d5194339f2deb7a932d
- addresses the remaining GIF upload 500 in Production E2E run 29179447252; the other five substantive jobs were already green

## Validation
- bun run test — 10/10 workspaces passed, including 1,364 Convex tests
- bun run typecheck — 10/10 workspaces passed
- bun run pre-commit — 19/19 affected lint, typecheck, and build tasks passed
- changed-file Ultracite check passed
