### PR TITLE
fix: bound AI analysis and tiny images

### DIFF
--- a/.github/workflows/prod-e2e.yml
+++ b/.github/workflows/prod-e2e.yml
@@ -84,7 +84,7 @@ jobs:
           retention-days: 7
 
   matrix:
-    needs: gate
+    needs: [gate, journey]
     if: always() && needs.gate.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/packages/convex/__tests__/workflows/aiMetadata/generators.test.ts
+++ b/packages/convex/__tests__/workflows/aiMetadata/generators.test.ts
@@ -14,6 +14,9 @@ mock.module("ai", () => aiMocks);
 let generateTextMetadata: any;
 let generateImageMetadata: any;
 let generateLinkMetadata: any;
+let boundAiMetadataInput: any;
+let maxInputChars: number;
+let maxOutputTokens: number;
 
 const mockResponse = {
   output: {
@@ -29,6 +32,9 @@ describe("aiMetadata generators", () => {
     generateTextMetadata = mod.generateTextMetadata;
     generateImageMetadata = mod.generateImageMetadata;
     generateLinkMetadata = mod.generateLinkMetadata;
+    boundAiMetadataInput = mod.boundAiMetadataInput;
+    maxInputChars = mod.MAX_AI_METADATA_INPUT_CHARS;
+    maxOutputTokens = mod.MAX_AI_METADATA_OUTPUT_TOKENS;
   });
 
   beforeEach(() => {
@@ -49,6 +55,7 @@ describe("aiMetadata generators", () => {
           recordOutputs: false,
         }),
         prompt: expect.stringContaining("some content"),
+        maxOutputTokens,
       })
     );
   });
@@ -63,6 +70,7 @@ describe("aiMetadata generators", () => {
           functionId: "teak.ai.metadata.image",
         }),
         messages: expect.arrayContaining([expect.any(Object)]),
+        maxOutputTokens,
       })
     );
   });
@@ -77,8 +85,26 @@ describe("aiMetadata generators", () => {
           functionId: "teak.ai.metadata.link",
         }),
         prompt: expect.stringContaining("page content"),
+        maxOutputTokens,
       })
     );
+  });
+
+  test("keeps short metadata input unchanged", () => {
+    expect(boundAiMetadataInput("short content")).toBe("short content");
+  });
+
+  test("bounds long metadata input while retaining both ends", () => {
+    const content = `${"a".repeat(maxInputChars)}MIDDLE${"z".repeat(maxInputChars)}`;
+    const bounded = boundAiMetadataInput(content);
+
+    expect(bounded.length).toBe(maxInputChars);
+    expect(bounded.startsWith("aaaa")).toBe(true);
+    expect(bounded.endsWith("zzzz")).toBe(true);
+    expect(bounded).toContain(
+      `[Content truncated from ${content.length} characters]`
+    );
+    expect(bounded).not.toContain("MIDDLE");
   });
 
   test("handles errors in all generators", () => {

--- a/packages/convex/__tests__/workflows/aiMetadata/generators.test.ts
+++ b/packages/convex/__tests__/workflows/aiMetadata/generators.test.ts
@@ -107,6 +107,23 @@ describe("aiMetadata generators", () => {
     expect(bounded).not.toContain("MIDDLE");
   });
 
+  test("bounds complete text, image, and link prompts", async () => {
+    const oversized = "x".repeat(maxInputChars * 2);
+    mockGenerateText.mockResolvedValue(mockResponse);
+
+    await generateTextMetadata(oversized, oversized);
+    const textCall = mockGenerateText.mock.calls.at(-1)?.[0];
+    expect(textCall.prompt.length).toBe(maxInputChars);
+
+    await generateImageMetadata("https://img.com", oversized);
+    const imageCall = mockGenerateText.mock.calls.at(-1)?.[0];
+    expect(imageCall.messages[0].content[0].text.length).toBe(maxInputChars);
+
+    await generateLinkMetadata(oversized, `https://example.com/${oversized}`);
+    const linkCall = mockGenerateText.mock.calls.at(-1)?.[0];
+    expect(linkCall.prompt.length).toBe(maxInputChars);
+  });
+
   test("handles errors in all generators", () => {
     mockGenerateText.mockRejectedValue(new Error("AI error"));
     expect(generateTextMetadata("c")).rejects.toThrow("AI error");

--- a/packages/convex/__tests__/workflows/imageAnalysis.test.ts
+++ b/packages/convex/__tests__/workflows/imageAnalysis.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import {
+  hasKnownTinyImageDimensions,
+  hasMinimumImageAnalysisDimensions,
+  MIN_IMAGE_ANALYSIS_DIMENSION,
+} from "../../workflows/imageAnalysis";
+
+describe("image analysis dimensions", () => {
+  test("accepts images at or above the minimum dimensions", () => {
+    expect(
+      hasMinimumImageAnalysisDimensions({
+        height: MIN_IMAGE_ANALYSIS_DIMENSION,
+        width: MIN_IMAGE_ANALYSIS_DIMENSION,
+      })
+    ).toBe(true);
+  });
+
+  test("rejects known tiny images", () => {
+    expect(hasKnownTinyImageDimensions({ height: 1, width: 1 })).toBe(true);
+    expect(hasMinimumImageAnalysisDimensions({ height: 1, width: 1 })).toBe(
+      false
+    );
+  });
+
+  test("does not treat missing dimensions as a known tiny image", () => {
+    expect(hasKnownTinyImageDimensions()).toBe(false);
+    expect(hasMinimumImageAnalysisDimensions()).toBe(false);
+  });
+});

--- a/packages/convex/__tests__/workflows/steps/metadata.test.ts
+++ b/packages/convex/__tests__/workflows/steps/metadata.test.ts
@@ -115,6 +115,12 @@ describe("resolveImageAnalysisKey", () => {
         fileMetadata: { height: 6000, width: 6000 },
       })
     ).toBeUndefined();
+    expect(
+      resolveImageAnalysisKey({
+        fileKey: "tiny",
+        fileMetadata: { height: 1, width: 1 },
+      })
+    ).toBeUndefined();
   });
 });
 

--- a/packages/convex/__tests__/workflows/steps/metadata.test.ts
+++ b/packages/convex/__tests__/workflows/steps/metadata.test.ts
@@ -119,6 +119,7 @@ describe("resolveImageAnalysisKey", () => {
       resolveImageAnalysisKey({
         fileKey: "tiny",
         fileMetadata: { height: 1, width: 1 },
+        thumbnailKey: "tiny-thumbnail",
       })
     ).toBeUndefined();
   });
@@ -313,6 +314,24 @@ describe("metadata handler", () => {
         cardType: "image",
       });
       expect(result.mode).toBe("skipped");
+    });
+
+    test("skips a known tiny original even if a thumbnail key exists", async () => {
+      mockRunQuery.mockResolvedValue({
+        _id: "c1",
+        fileKey: "f1",
+        fileMetadata: { height: 1, width: 1 },
+        thumbnailKey: "t1",
+      });
+
+      const result = await generateHandler(ctx, {
+        cardId: "c1",
+        cardType: "image",
+      });
+
+      expect(result.mode).toBe("skipped");
+      expect(r2Mocks.resolveObjectUrl).not.toHaveBeenCalled();
+      expect(aiMocks.generateText).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/convex/workflows/aiMetadata/generators.ts
+++ b/packages/convex/workflows/aiMetadata/generators.ts
@@ -32,6 +32,22 @@ const GROQ_JSON_OBJECT_OPTIONS = {
   groq: { structuredOutputs: false },
 } as const;
 
+export const MAX_AI_METADATA_INPUT_CHARS = 6000;
+export const MAX_AI_METADATA_OUTPUT_TOKENS = 384;
+
+export const boundAiMetadataInput = (content: string): string => {
+  if (content.length <= MAX_AI_METADATA_INPUT_CHARS) {
+    return content;
+  }
+
+  const marker = `\n\n[Content truncated from ${content.length} characters]\n\n`;
+  const retainedLength = MAX_AI_METADATA_INPUT_CHARS - marker.length;
+  const prefixLength = Math.ceil(retainedLength / 2);
+  const suffixLength = Math.floor(retainedLength / 2);
+
+  return `${content.slice(0, prefixLength)}${marker}${content.slice(-suffixLength)}`;
+};
+
 /**
  * Generate AI metadata for text content
  * Uses prompt caching-enabled model (openai/gpt-oss-20b)
@@ -41,7 +57,7 @@ export const generateTextMetadata = async (content: string, title?: string) => {
   const fullContent = title
     ? `Title: ${title}\n\nContent: ${content}`
     : content;
-  const prompt = `Analyze this content and generate tags and summary:\n\n${fullContent}`;
+  const prompt = `Analyze this content and generate tags and summary:\n\n${boundAiMetadataInput(fullContent)}`;
 
   const result = await observeAiGeneration(
     {
@@ -59,6 +75,7 @@ export const generateTextMetadata = async (content: string, title?: string) => {
           stage: "ai_metadata",
         }),
         model: TEXT_METADATA_MODEL,
+        maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
         // Static system prompt - will be cached across requests
         system: SYSTEM_PROMPTS.textAnalysis,
         // Dynamic content last for cache optimization
@@ -108,6 +125,7 @@ export const generateImageMetadata = async (
           stage: "ai_metadata",
         }),
         model: IMAGE_METADATA_MODEL,
+        maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
         // Static system prompt - structured for potential future caching support
         system: SYSTEM_PROMPTS.imageAnalysis,
         messages: [
@@ -145,11 +163,12 @@ export const generateImageMetadata = async (
  * Uses prompt caching-enabled model (openai/gpt-oss-20b)
  */
 export const generateLinkMetadata = async (content: string, url?: string) => {
+  const boundedContent = boundAiMetadataInput(
+    `${content}${url ? `\n\nURL: ${url}` : ""}`
+  );
   const prompt = `Analyze this web page content and generate optimized tags and summary for knowledge management:
 
-${content}
-
-${url ? `\nURL: ${url}` : ""}
+${boundedContent}
 
 Generate tags and summary that will help the user rediscover and understand the value of this content.`;
   const result = await observeAiGeneration(
@@ -168,6 +187,7 @@ Generate tags and summary that will help the user rediscover and understand the 
           stage: "ai_metadata",
         }),
         model: LINK_METADATA_MODEL,
+        maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
         // Static system prompt - will be cached across requests
         system: SYSTEM_PROMPTS.linkAnalysis,
         // Dynamic content last for cache optimization

--- a/packages/convex/workflows/aiMetadata/generators.ts
+++ b/packages/convex/workflows/aiMetadata/generators.ts
@@ -57,7 +57,9 @@ export const generateTextMetadata = async (content: string, title?: string) => {
   const fullContent = title
     ? `Title: ${title}\n\nContent: ${content}`
     : content;
-  const prompt = `Analyze this content and generate tags and summary:\n\n${boundAiMetadataInput(fullContent)}`;
+  const prompt = boundAiMetadataInput(
+    `Analyze this content and generate tags and summary:\n\n${fullContent}`
+  );
 
   const result = await observeAiGeneration(
     {
@@ -106,9 +108,11 @@ export const generateImageMetadata = async (
   imageUrl: string,
   title?: string
 ) => {
-  const prompt = title
-    ? `Image title: ${title}\n\nAnalyze this image and generate tags and summary:`
-    : "Analyze this image and generate tags and summary:";
+  const prompt = boundAiMetadataInput(
+    title
+      ? `Image title: ${title}\n\nAnalyze this image and generate tags and summary:`
+      : "Analyze this image and generate tags and summary:"
+  );
   const result = await observeAiGeneration(
     {
       functionId: "teak.ai.metadata.image",
@@ -163,14 +167,15 @@ export const generateImageMetadata = async (
  * Uses prompt caching-enabled model (openai/gpt-oss-20b)
  */
 export const generateLinkMetadata = async (content: string, url?: string) => {
-  const boundedContent = boundAiMetadataInput(
-    `${content}${url ? `\n\nURL: ${url}` : ""}`
+  const prompt = boundAiMetadataInput(
+    `Analyze this web page content and generate optimized tags and summary for knowledge management:
+
+${content}
+
+${url ? `URL: ${url}` : ""}
+
+Generate tags and summary that will help the user rediscover and understand the value of this content.`
   );
-  const prompt = `Analyze this web page content and generate optimized tags and summary for knowledge management:
-
-${boundedContent}
-
-Generate tags and summary that will help the user rediscover and understand the value of this content.`;
   const result = await observeAiGeneration(
     {
       functionId: "teak.ai.metadata.link",

--- a/packages/convex/workflows/imageAnalysis.ts
+++ b/packages/convex/workflows/imageAnalysis.ts
@@ -1,0 +1,24 @@
+export const MIN_IMAGE_ANALYSIS_DIMENSION = 12;
+
+interface ImageDimensions {
+  height?: number;
+  width?: number;
+}
+
+const hasStoredDimensions = (
+  dimensions?: ImageDimensions
+): dimensions is Required<ImageDimensions> =>
+  typeof dimensions?.width === "number" &&
+  typeof dimensions.height === "number";
+
+export const hasMinimumImageAnalysisDimensions = (
+  dimensions?: ImageDimensions
+) =>
+  hasStoredDimensions(dimensions) &&
+  dimensions.width >= MIN_IMAGE_ANALYSIS_DIMENSION &&
+  dimensions.height >= MIN_IMAGE_ANALYSIS_DIMENSION;
+
+export const hasKnownTinyImageDimensions = (dimensions?: ImageDimensions) =>
+  hasStoredDimensions(dimensions) &&
+  (dimensions.width < MIN_IMAGE_ANALYSIS_DIMENSION ||
+    dimensions.height < MIN_IMAGE_ANALYSIS_DIMENSION);

--- a/packages/convex/workflows/steps/metadata.ts
+++ b/packages/convex/workflows/steps/metadata.ts
@@ -25,6 +25,7 @@ import {
 } from "../aiMetadata/generators";
 import { generateTranscript } from "../aiMetadata/transcript";
 import { extractFileTextForAi } from "../fileProcessing";
+import { hasMinimumImageAnalysisDimensions } from "../imageAnalysis";
 
 interface LinkPreviewMetadata {
   author?: string;
@@ -63,8 +64,7 @@ export const resolveImageAnalysisKey = (
     card.fileKey &&
     typeof width === "number" &&
     typeof height === "number" &&
-    width > 0 &&
-    height > 0 &&
+    hasMinimumImageAnalysisDimensions(card.fileMetadata) &&
     width * height <= MAX_ORIGINAL_AI_IMAGE_PIXELS
   ) {
     return card.fileKey;

--- a/packages/convex/workflows/steps/metadata.ts
+++ b/packages/convex/workflows/steps/metadata.ts
@@ -25,7 +25,10 @@ import {
 } from "../aiMetadata/generators";
 import { generateTranscript } from "../aiMetadata/transcript";
 import { extractFileTextForAi } from "../fileProcessing";
-import { hasMinimumImageAnalysisDimensions } from "../imageAnalysis";
+import {
+  hasKnownTinyImageDimensions,
+  hasMinimumImageAnalysisDimensions,
+} from "../imageAnalysis";
 
 interface LinkPreviewMetadata {
   author?: string;
@@ -55,6 +58,9 @@ const MAX_ORIGINAL_AI_IMAGE_PIXELS = 500 * 500;
 export const resolveImageAnalysisKey = (
   card: ImageAnalysisCard
 ): string | undefined => {
+  if (hasKnownTinyImageDimensions(card.fileMetadata)) {
+    return;
+  }
   if (card.thumbnailKey) {
     return card.thumbnailKey;
   }

--- a/packages/convex/workflows/steps/palette.ts
+++ b/packages/convex/workflows/steps/palette.ts
@@ -7,11 +7,11 @@ import { internalAction } from "../../_generated/server";
 import { TELEMETRY_OPERATIONS } from "../../shared/telemetry";
 import { resolveObjectUrl } from "../../storage/r2";
 import { withBackendSpan } from "../../telemetry/sentry";
+import { hasKnownTinyImageDimensions } from "../imageAnalysis";
 
 const MAX_COLORS = 5;
 const SAMPLE_TARGET = 4000;
 const CHANNEL_PRECISION = 16;
-const MIN_DIMENSION = 12;
 
 const quantizeChannel = (value: number): number => {
   const clamped = Math.max(0, Math.min(255, value));
@@ -106,6 +106,13 @@ export const extractPaletteFromImage = internalAction({
           width <= 500 &&
           height <= 500;
 
+        if (
+          !card.thumbnailKey &&
+          hasKnownTinyImageDimensions(card.fileMetadata)
+        ) {
+          return;
+        }
+
         // Prefer the bounded thumbnail for every image. Only decode the
         // original when thumbnailing intentionally skipped an already-small
         // raster image.
@@ -130,13 +137,18 @@ export const extractPaletteFromImage = internalAction({
         }
 
         const bytes = new Uint8Array(await response.arrayBuffer());
-        const image = PhotonImage.new_from_byteslice(bytes);
+        let image: PhotonImage;
+        try {
+          image = PhotonImage.new_from_byteslice(bytes);
+        } catch {
+          return;
+        }
 
         try {
           const width = image.get_width();
           const height = image.get_height();
 
-          if (width < MIN_DIMENSION || height < MIN_DIMENSION) {
+          if (hasKnownTinyImageDimensions({ height, width })) {
             return;
           }
 

--- a/packages/convex/workflows/steps/palette.ts
+++ b/packages/convex/workflows/steps/palette.ts
@@ -106,10 +106,7 @@ export const extractPaletteFromImage = internalAction({
           width <= 500 &&
           height <= 500;
 
-        if (
-          !card.thumbnailKey &&
-          hasKnownTinyImageDimensions(card.fileMetadata)
-        ) {
+        if (hasKnownTinyImageDimensions(card.fileMetadata)) {
           return;
         }
 

--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -86,23 +86,6 @@ export const signUp = async (page: Page, email = uniqueEmail()) => {
   await page
     .getByRole("button", { name: /create an account|sign up/i })
     .click();
-  const verificationMessages = page.getByText(
-    `Verification email sent to ${email}`
-  );
-  await expect
-    .poll(
-      async () => {
-        const count = await verificationMessages.count();
-        for (let index = 0; index < count; index += 1) {
-          if (await verificationMessages.nth(index).isVisible()) {
-            return true;
-          }
-        }
-        return false;
-      },
-      { timeout: 15_000 }
-    )
-    .toBe(true);
   await page.goto(await waitForEmail(email, "Verify your email address"));
   await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
   return email;


### PR DESCRIPTION
## Summary
- reject known sub-12px originals before vision or palette analysis and treat unsupported Photon decodes as an optional skipped palette
- bound AI metadata inputs to 6,000 characters, retain the prefix and suffix, and cap structured output requests at 384 tokens
- make production signup verification wait on the actual email and serialize the browser matrix after the main journey to avoid free-tier provider bursts

## Validation
- `bun run test` (10/10 workspaces; 1,369 Convex tests)
- `bun run typecheck` (10/10 workspaces)
- `bun run pre-commit` (19/19 affected tasks)
- focused AI/image analysis tests and changed-file Ultracite checks

## Production evidence addressed
- tiny valid PNG fixture no longer reaches Groq vision or Photon decode
- oversized security fixture is bounded before model ingestion
- WebKit signup no longer depends on transient confirmation copy
- no Expo/iOS artifact workflow is added or used