### PR TITLE
fix: balance AI metadata token budget

### DIFF
--- a/packages/convex/__tests__/workflows/aiMetadata/generators.test.ts
+++ b/packages/convex/__tests__/workflows/aiMetadata/generators.test.ts
@@ -56,6 +56,9 @@ describe("aiMetadata generators", () => {
         }),
         prompt: expect.stringContaining("some content"),
         maxOutputTokens,
+        providerOptions: {
+          groq: { reasoningEffort: "low", structuredOutputs: false },
+        },
       })
     );
   });
@@ -71,6 +74,7 @@ describe("aiMetadata generators", () => {
         }),
         messages: expect.arrayContaining([expect.any(Object)]),
         maxOutputTokens,
+        providerOptions: { groq: { structuredOutputs: false } },
       })
     );
   });
@@ -86,11 +90,15 @@ describe("aiMetadata generators", () => {
         }),
         prompt: expect.stringContaining("page content"),
         maxOutputTokens,
+        providerOptions: {
+          groq: { reasoningEffort: "low", structuredOutputs: false },
+        },
       })
     );
   });
 
   test("keeps short metadata input unchanged", () => {
+    expect(maxOutputTokens).toBe(768);
     expect(boundAiMetadataInput("short content")).toBe("short content");
   });
 

--- a/packages/convex/workflows/aiMetadata/generators.ts
+++ b/packages/convex/workflows/aiMetadata/generators.ts
@@ -32,8 +32,12 @@ const GROQ_JSON_OBJECT_OPTIONS = {
   groq: { structuredOutputs: false },
 } as const;
 
+const GROQ_LOW_REASONING_JSON_OBJECT_OPTIONS = {
+  groq: { reasoningEffort: "low", structuredOutputs: false },
+} as const;
+
 export const MAX_AI_METADATA_INPUT_CHARS = 6000;
-export const MAX_AI_METADATA_OUTPUT_TOKENS = 384;
+export const MAX_AI_METADATA_OUTPUT_TOKENS = 768;
 
 export const boundAiMetadataInput = (content: string): string => {
   if (content.length <= MAX_AI_METADATA_INPUT_CHARS) {
@@ -90,7 +94,7 @@ export const generateTextMetadata = async (content: string, title?: string) => {
         // strict server-side validator rejects with a 400. In json_object mode
         // the SDK validates client-side against the Zod schema (unknown keys are
         // stripped), so leaked schema fields no longer fail the request.
-        providerOptions: GROQ_JSON_OBJECT_OPTIONS,
+        providerOptions: GROQ_LOW_REASONING_JSON_OBJECT_OPTIONS,
       })
   );
 
@@ -200,7 +204,7 @@ Generate tags and summary that will help the user rediscover and understand the 
         output: Output.object({
           schema: aiMetadataSchema,
         }),
-        providerOptions: GROQ_JSON_OBJECT_OPTIONS,
+        providerOptions: GROQ_LOW_REASONING_JSON_OBJECT_OPTIONS,
       })
   );
 


### PR DESCRIPTION
## Summary
- raise the bounded AI metadata output budget from 384 to 768 tokens so reasoning models can return complete JSON
- use Groq low reasoning effort for text and link metadata while keeping the vision model on its compatible provider options
- retain the existing 6,000-character complete-prompt bound and validate the production token contract in tests

## Live production evidence
- exact release `teak-backend@376f23c601dcd3d0d440ee8ea1dd9a3b072c4246` produced a provider JSON validation failure at 384 tokens
- Sentry trace `e172e0e133114701b28050963bf110cf` identifies `teak.ai.metadata.text` on `openai/gpt-oss-20b`

## Validation
- `bun run test` (10/10 workspaces; 1,371 Convex tests)
- `bun run typecheck` (10/10 workspaces)
- `bun run pre-commit` (19/19 affected tasks)
- focused generator tests assert 768 tokens and model-specific provider options