### PR TITLE
fix: stabilize WebKit production composer journey

### DIFF
--- a/packages/tests/src/matrix/journey-lite.e2e.ts
+++ b/packages/tests/src/matrix/journey-lite.e2e.ts
@@ -14,7 +14,9 @@ test("signup, create, and search", async ({ page }) => {
   try {
     const marker = `matrix-${Date.now()}`;
     await page.goto("/");
-    await page.getByPlaceholder(/Write a note/i).fill(marker);
+    const note = page.getByPlaceholder(/Write a note/i);
+    await note.pressSequentially(marker);
+    await expect(note).toHaveValue(marker);
     await clickVisibleControl(
       page.getByRole("button", { exact: true, name: "Save" })
     );


### PR DESCRIPTION
## Summary
- type notes through real sequential keyboard events in the production browser matrix
- assert the controlled composer value before waiting for the Save action
- eliminate the WebKit state-update race observed in the production E2E artifact

## Validation
- `bun run --cwd packages/tests typecheck`
- `bunx ultracite check packages/tests/src/matrix/journey-lite.e2e.ts`
- `bun run pre-commit`

No user-facing behavior changes; no changelog entry.