### PR TITLE
fix: survive Groq free-tier token resets

### DIFF
--- a/packages/convex/__tests__/workflows/aiMetadata/generators.test.ts
+++ b/packages/convex/__tests__/workflows/aiMetadata/generators.test.ts
@@ -17,6 +17,7 @@ let generateLinkMetadata: any;
 let boundAiMetadataInput: any;
 let maxInputChars: number;
 let maxOutputTokens: number;
+let maxRetries: number;
 
 const mockResponse = {
   output: {
@@ -35,6 +36,7 @@ describe("aiMetadata generators", () => {
     boundAiMetadataInput = mod.boundAiMetadataInput;
     maxInputChars = mod.MAX_AI_METADATA_INPUT_CHARS;
     maxOutputTokens = mod.MAX_AI_METADATA_OUTPUT_TOKENS;
+    maxRetries = mod.MAX_AI_METADATA_RETRIES;
   });
 
   beforeEach(() => {
@@ -55,6 +57,7 @@ describe("aiMetadata generators", () => {
           recordOutputs: false,
         }),
         prompt: expect.stringContaining("some content"),
+        maxRetries,
         maxOutputTokens,
         providerOptions: {
           groq: { reasoningEffort: "low", structuredOutputs: false },
@@ -73,6 +76,7 @@ describe("aiMetadata generators", () => {
           functionId: "teak.ai.metadata.image",
         }),
         messages: expect.arrayContaining([expect.any(Object)]),
+        maxRetries,
         maxOutputTokens,
         providerOptions: { groq: { structuredOutputs: false } },
       })
@@ -89,6 +93,7 @@ describe("aiMetadata generators", () => {
           functionId: "teak.ai.metadata.link",
         }),
         prompt: expect.stringContaining("page content"),
+        maxRetries,
         maxOutputTokens,
         providerOptions: {
           groq: { reasoningEffort: "low", structuredOutputs: false },
@@ -98,6 +103,7 @@ describe("aiMetadata generators", () => {
   });
 
   test("keeps short metadata input unchanged", () => {
+    expect(maxRetries).toBe(5);
     expect(maxOutputTokens).toBe(768);
     expect(boundAiMetadataInput("short content")).toBe("short content");
   });

--- a/packages/convex/workflows/aiMetadata/generators.ts
+++ b/packages/convex/workflows/aiMetadata/generators.ts
@@ -38,6 +38,7 @@ const GROQ_LOW_REASONING_JSON_OBJECT_OPTIONS = {
 
 export const MAX_AI_METADATA_INPUT_CHARS = 6000;
 export const MAX_AI_METADATA_OUTPUT_TOKENS = 768;
+export const MAX_AI_METADATA_RETRIES = 5;
 
 export const boundAiMetadataInput = (content: string): string => {
   if (content.length <= MAX_AI_METADATA_INPUT_CHARS) {
@@ -81,6 +82,9 @@ export const generateTextMetadata = async (content: string, title?: string) => {
           stage: "ai_metadata",
         }),
         model: TEXT_METADATA_MODEL,
+        // Groq's free tier has an 8K TPM window. Keep retrying provider 429s
+        // long enough to cross that reset instead of failing card enrichment.
+        maxRetries: MAX_AI_METADATA_RETRIES,
         maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
         // Static system prompt - will be cached across requests
         system: SYSTEM_PROMPTS.textAnalysis,
@@ -133,6 +137,7 @@ export const generateImageMetadata = async (
           stage: "ai_metadata",
         }),
         model: IMAGE_METADATA_MODEL,
+        maxRetries: MAX_AI_METADATA_RETRIES,
         maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
         // Static system prompt - structured for potential future caching support
         system: SYSTEM_PROMPTS.imageAnalysis,
@@ -196,6 +201,7 @@ Generate tags and summary that will help the user rediscover and understand the 
           stage: "ai_metadata",
         }),
         model: LINK_METADATA_MODEL,
+        maxRetries: MAX_AI_METADATA_RETRIES,
         maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
         // Static system prompt - will be cached across requests
         system: SYSTEM_PROMPTS.linkAnalysis,


### PR DESCRIPTION
## Summary
- raise AI metadata provider retries from the SDK default to five
- allow free-plan 8K TPM bursts to wait across Groq token-window resets
- cover text, image, and link generation with an explicit retry contract

## Production evidence
- Sentry event `27d7042d153d400db40c1c6788bc4a26` exhausted three attempts only 1.245s before Groq reset
- the card flow itself remained green, but link enrichment emitted a handled RateLimitError

## Validation
- focused generator tests: 7/7
- full `bun run test`: 10/10 workspaces, Convex 1371/1371
- Convex typecheck
- Ultracite on changed files
- full affected `bun run pre-commit`: 19/19

No paid Groq tier, Expo cloud build, user-facing behavior, or changelog change.