### PR TITLE
fix: retry invalid AI metadata JSON

### DIFF
--- a/packages/convex/__tests__/shared/metrics.test.ts
+++ b/packages/convex/__tests__/shared/metrics.test.ts
@@ -3,6 +3,7 @@ import {
   configureMetrics,
   type MetricAttributes,
   resetMetricsConfig,
+  trackAiRetry,
   trackAiStage,
   trackAuth,
   trackUpload,
@@ -96,6 +97,52 @@ describe("trackAiStage", () => {
           surface: "backend",
         },
         name: TELEMETRY_METRICS.workflowSkip,
+        value: 1,
+      },
+    ]);
+  });
+});
+
+describe("trackAiRetry", () => {
+  test("records a bounded validation retry", () => {
+    const counts: Array<{
+      attributes: MetricAttributes;
+      name: string;
+      value: number;
+    }> = [];
+
+    configureMetrics({
+      app: "convex",
+      env: "production",
+      recorder: {
+        count(name, value, attributes) {
+          counts.push({ attributes, name, value });
+        },
+        distribution() {
+          // Not used by retry metrics.
+        },
+        gauge() {
+          // Not used by retry metrics.
+        },
+      },
+    });
+
+    trackAiRetry({
+      model: "qwen/qwen3.6-27b",
+      provider: "groq",
+      reason: "validation",
+    });
+
+    expect(counts).toEqual([
+      {
+        attributes: {
+          environment: "production",
+          model: "qwen/qwen3.6-27b",
+          provider: "groq",
+          reason: "validation",
+          surface: "backend",
+        },
+        name: TELEMETRY_METRICS.aiRetries,
         value: 1,
       },
     ]);

--- a/packages/convex/__tests__/workflows/aiMetadata/generators.test.ts
+++ b/packages/convex/__tests__/workflows/aiMetadata/generators.test.ts
@@ -18,6 +18,7 @@ let boundAiMetadataInput: any;
 let maxInputChars: number;
 let maxOutputTokens: number;
 let maxRetries: number;
+let maxValidationRetries: number;
 
 const mockResponse = {
   output: {
@@ -37,6 +38,7 @@ describe("aiMetadata generators", () => {
     maxInputChars = mod.MAX_AI_METADATA_INPUT_CHARS;
     maxOutputTokens = mod.MAX_AI_METADATA_OUTPUT_TOKENS;
     maxRetries = mod.MAX_AI_METADATA_RETRIES;
+    maxValidationRetries = mod.MAX_AI_METADATA_VALIDATION_RETRIES;
   });
 
   beforeEach(() => {
@@ -104,6 +106,7 @@ describe("aiMetadata generators", () => {
 
   test("keeps short metadata input unchanged", () => {
     expect(maxRetries).toBe(5);
+    expect(maxValidationRetries).toBe(2);
     expect(maxOutputTokens).toBe(768);
     expect(boundAiMetadataInput("short content")).toBe("short content");
   });
@@ -143,5 +146,34 @@ describe("aiMetadata generators", () => {
     expect(generateTextMetadata("c")).rejects.toThrow("AI error");
     expect(generateImageMetadata("url")).rejects.toThrow("AI error");
     expect(generateLinkMetadata("url")).rejects.toThrow("AI error");
+  });
+
+  test("retries provider JSON validation failures with a corrective prompt", async () => {
+    mockGenerateText
+      .mockRejectedValueOnce(
+        new Error(
+          "Failed to validate JSON. See failed_generation for more details."
+        )
+      )
+      .mockResolvedValueOnce(mockResponse);
+
+    await generateImageMetadata("https://img.com/example.jpeg");
+
+    expect(mockGenerateText).toHaveBeenCalledTimes(2);
+    const retryCall = mockGenerateText.mock.calls[1]?.[0];
+    expect(retryCall.messages[0].content[0].text).toStartWith(
+      "JSON validation retry 1:"
+    );
+  });
+
+  test("stops after the bounded JSON validation retry budget", async () => {
+    mockGenerateText.mockRejectedValue(
+      new Error("Failed to validate JSON. See failed_generation.")
+    );
+
+    await expect(
+      generateImageMetadata("https://img.com/example.jpeg")
+    ).rejects.toThrow("Failed to validate JSON");
+    expect(mockGenerateText).toHaveBeenCalledTimes(maxValidationRetries + 1);
   });
 });

--- a/packages/convex/shared/metrics.ts
+++ b/packages/convex/shared/metrics.ts
@@ -474,6 +474,18 @@ export function trackAiCall(params: {
   }
 }
 
+export function trackAiRetry(params: {
+  model: string;
+  provider: string;
+  reason: "validation";
+}): void {
+  counter(TELEMETRY_METRICS.aiRetries, 1, {
+    model: params.model,
+    provider: params.provider,
+    reason: params.reason,
+  });
+}
+
 export function trackCron(params: {
   durationMs: number;
   monitor: string;

--- a/packages/convex/workflows/aiMetadata/generators.ts
+++ b/packages/convex/workflows/aiMetadata/generators.ts
@@ -14,6 +14,8 @@ import {
   createAiTelemetrySettings,
   observeAiGeneration,
 } from "../../ai/telemetry";
+import { trackAiRetry } from "../../shared/metrics";
+import { recordBackendLog } from "../../telemetry/sentry";
 import { aiMetadataSchema } from "./schemas";
 
 /**
@@ -39,6 +41,44 @@ const GROQ_LOW_REASONING_JSON_OBJECT_OPTIONS = {
 export const MAX_AI_METADATA_INPUT_CHARS = 6000;
 export const MAX_AI_METADATA_OUTPUT_TOKENS = 768;
 export const MAX_AI_METADATA_RETRIES = 5;
+export const MAX_AI_METADATA_VALIDATION_RETRIES = 2;
+
+const JSON_VALIDATION_ERROR = /failed to validate json|failed_generation/iu;
+
+const validationRetryPrompt = (prompt: string, attempt: number): string => {
+  if (attempt === 0) {
+    return prompt;
+  }
+  return boundAiMetadataInput(
+    `JSON validation retry ${attempt}: Return only the required JSON object with tags and summary. Do not include markdown, commentary, or any other keys.\n\n${prompt}`
+  );
+};
+
+const generateWithValidationRetries = async <T>(
+  model: string,
+  generate: (attempt: number) => Promise<T>
+): Promise<T> => {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await generate(attempt);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        attempt >= MAX_AI_METADATA_VALIDATION_RETRIES ||
+        !JSON_VALIDATION_ERROR.test(message)
+      ) {
+        throw error;
+      }
+      trackAiRetry({ model, provider: "groq", reason: "validation" });
+      recordBackendLog("warn", "ai.generation.validation_retry", {
+        attempt: attempt + 1,
+        model,
+        provider: "groq",
+        reason: "validation",
+      });
+    }
+  }
+};
 
 export const boundAiMetadataInput = (content: string): string => {
   if (content.length <= MAX_AI_METADATA_INPUT_CHARS) {
@@ -75,31 +115,33 @@ export const generateTextMetadata = async (content: string, title?: string) => {
       system: SYSTEM_PROMPTS.textAnalysis,
     },
     () =>
-      generateText({
-        experimental_telemetry: createAiTelemetrySettings({
-          functionId: "teak.ai.metadata.text",
-          model: TEXT_METADATA_MODEL_ID,
-          stage: "ai_metadata",
-        }),
-        model: TEXT_METADATA_MODEL,
-        // Groq's free tier has an 8K TPM window. Keep retrying provider 429s
-        // long enough to cross that reset instead of failing card enrichment.
-        maxRetries: MAX_AI_METADATA_RETRIES,
-        maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
-        // Static system prompt - will be cached across requests
-        system: SYSTEM_PROMPTS.textAnalysis,
-        // Dynamic content last for cache optimization
-        prompt,
-        output: Output.object({
-          schema: aiMetadataSchema,
-        }),
-        // Use Groq JSON object mode instead of strict json_schema. gpt-oss
-        // models intermittently echo the schema definition back, which the
-        // strict server-side validator rejects with a 400. In json_object mode
-        // the SDK validates client-side against the Zod schema (unknown keys are
-        // stripped), so leaked schema fields no longer fail the request.
-        providerOptions: GROQ_LOW_REASONING_JSON_OBJECT_OPTIONS,
-      })
+      generateWithValidationRetries(TEXT_METADATA_MODEL_ID, (attempt) =>
+        generateText({
+          experimental_telemetry: createAiTelemetrySettings({
+            functionId: "teak.ai.metadata.text",
+            model: TEXT_METADATA_MODEL_ID,
+            stage: "ai_metadata",
+          }),
+          model: TEXT_METADATA_MODEL,
+          // Groq's free tier has an 8K TPM window. Keep retrying provider 429s
+          // long enough to cross that reset instead of failing card enrichment.
+          maxRetries: MAX_AI_METADATA_RETRIES,
+          maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
+          // Static system prompt - will be cached across requests
+          system: SYSTEM_PROMPTS.textAnalysis,
+          // Dynamic content last for cache optimization
+          prompt: validationRetryPrompt(prompt, attempt),
+          output: Output.object({
+            schema: aiMetadataSchema,
+          }),
+          // Use Groq JSON object mode instead of strict json_schema. gpt-oss
+          // models intermittently echo the schema definition back, which the
+          // strict server-side validator rejects with a 400. In json_object mode
+          // the SDK validates client-side against the Zod schema (unknown keys are
+          // stripped), so leaked schema fields no longer fail the request.
+          providerOptions: GROQ_LOW_REASONING_JSON_OBJECT_OPTIONS,
+        })
+      )
   );
 
   return {
@@ -130,39 +172,41 @@ export const generateImageMetadata = async (
       system: SYSTEM_PROMPTS.imageAnalysis,
     },
     () =>
-      generateText({
-        experimental_telemetry: createAiTelemetrySettings({
-          functionId: "teak.ai.metadata.image",
-          model: IMAGE_METADATA_MODEL_ID,
-          stage: "ai_metadata",
-        }),
-        model: IMAGE_METADATA_MODEL,
-        maxRetries: MAX_AI_METADATA_RETRIES,
-        maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
-        // Static system prompt - structured for potential future caching support
-        system: SYSTEM_PROMPTS.imageAnalysis,
-        messages: [
-          {
-            role: "user",
-            content: [
-              {
-                type: "text",
-                // Dynamic text content
-                text: prompt,
-              },
-              {
-                type: "image",
-                // Dynamic image content
-                image: imageUrl,
-              },
-            ],
-          },
-        ],
-        output: Output.object({
-          schema: aiMetadataSchema,
-        }),
-        providerOptions: GROQ_JSON_OBJECT_OPTIONS,
-      })
+      generateWithValidationRetries(IMAGE_METADATA_MODEL_ID, (attempt) =>
+        generateText({
+          experimental_telemetry: createAiTelemetrySettings({
+            functionId: "teak.ai.metadata.image",
+            model: IMAGE_METADATA_MODEL_ID,
+            stage: "ai_metadata",
+          }),
+          model: IMAGE_METADATA_MODEL,
+          maxRetries: MAX_AI_METADATA_RETRIES,
+          maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
+          // Static system prompt - structured for potential future caching support
+          system: SYSTEM_PROMPTS.imageAnalysis,
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  // Dynamic text content
+                  text: validationRetryPrompt(prompt, attempt),
+                },
+                {
+                  type: "image",
+                  // Dynamic image content
+                  image: imageUrl,
+                },
+              ],
+            },
+          ],
+          output: Output.object({
+            schema: aiMetadataSchema,
+          }),
+          providerOptions: GROQ_JSON_OBJECT_OPTIONS,
+        })
+      )
   );
 
   return {
@@ -194,24 +238,26 @@ Generate tags and summary that will help the user rediscover and understand the 
       system: SYSTEM_PROMPTS.linkAnalysis,
     },
     () =>
-      generateText({
-        experimental_telemetry: createAiTelemetrySettings({
-          functionId: "teak.ai.metadata.link",
-          model: LINK_METADATA_MODEL_ID,
-          stage: "ai_metadata",
-        }),
-        model: LINK_METADATA_MODEL,
-        maxRetries: MAX_AI_METADATA_RETRIES,
-        maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
-        // Static system prompt - will be cached across requests
-        system: SYSTEM_PROMPTS.linkAnalysis,
-        // Dynamic content last for cache optimization
-        prompt,
-        output: Output.object({
-          schema: aiMetadataSchema,
-        }),
-        providerOptions: GROQ_LOW_REASONING_JSON_OBJECT_OPTIONS,
-      })
+      generateWithValidationRetries(LINK_METADATA_MODEL_ID, (attempt) =>
+        generateText({
+          experimental_telemetry: createAiTelemetrySettings({
+            functionId: "teak.ai.metadata.link",
+            model: LINK_METADATA_MODEL_ID,
+            stage: "ai_metadata",
+          }),
+          model: LINK_METADATA_MODEL,
+          maxRetries: MAX_AI_METADATA_RETRIES,
+          maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
+          // Static system prompt - will be cached across requests
+          system: SYSTEM_PROMPTS.linkAnalysis,
+          // Dynamic content last for cache optimization
+          prompt: validationRetryPrompt(prompt, attempt),
+          output: Output.object({
+            schema: aiMetadataSchema,
+          }),
+          providerOptions: GROQ_LOW_REASONING_JSON_OBJECT_OPTIONS,
+        })
+      )
   );
 
   return {


### PR DESCRIPTION
## Summary
- retry Groq JSON validation failures up to two additional times with a corrective JSON-only prompt
- emit bounded AI retry metrics and structured warning logs for validation retries
- cover recovery and bounded exhaustion in generator tests

## Validation
- `bun test packages/convex/__tests__/workflows/aiMetadata/generators.test.ts packages/convex/__tests__/shared/metrics.test.ts`
- `bun run typecheck` in `packages/convex`
- `bunx ultracite check` on changed files
- `bun run pre-commit`
- `bun run test`

## Production evidence
- Addresses the delayed `Failed to validate JSON` event in Sentry issue 7605733727 on `teak-backend@cda07da9f9c5a8cb55d016fbec9f2608310d5c05`.
- No user-visible behavior change; successful AI metadata generation remains unchanged.