### PR TITLE
fix: preserve Electron Sentry runtime boundary

### DIFF
--- a/apps/desktop/src/__tests__/sentryObservability.test.ts
+++ b/apps/desktop/src/__tests__/sentryObservability.test.ts
@@ -138,4 +138,15 @@ describe("desktop Sentry observability", () => {
     expect(workflow).toContain("debug-files upload");
     expect(workflow).toContain("find .vite -name '*.map'");
   });
+
+  test("keeps main-process Sentry instrumentation outside the ESM bundle", () => {
+    const mainConfig = readFileSync(
+      resolve(desktopRoot, "vite.main.config.ts"),
+      "utf8"
+    );
+
+    expect(mainConfig).toContain('"@sentry/electron/main"');
+    expect(mainConfig).toContain("rollupOptions");
+    expect(mainConfig).toContain("external:");
+  });
 });

--- a/apps/desktop/vite.main.config.ts
+++ b/apps/desktop/vite.main.config.ts
@@ -29,6 +29,10 @@ export default defineConfig(({ command }) => ({
     },
     rollupOptions: {
       external: [
+        // Keep the Electron SDK in its native Node module boundary. Bundling
+        // its require-in-the-middle instrumentation into this ESM entry leaves
+        // CommonJS globals such as `require.cache` undefined at runtime.
+        "@sentry/electron/main",
         "electron",
         "electron-updater",
         "electron-store",


### PR DESCRIPTION
## Summary
- keep `@sentry/electron/main` external in the Electron main-process Vite build so Sentry's Node instrumentation remains an ESM module boundary
- add a regression contract covering the production bundling configuration
- preserve the existing renderer/preload source-map and release pipeline

## Production evidence
- before the fix, a real production-configured desktop launch crashed with `ReferenceError: require is not defined in ES module scope` (Sentry event `61e1927b86bb4d64aac0ff6af3e0d03c`, issue `7606587964`)
- after the fix, the same production-configured launch completed and emitted trace `766565d2e4281ae50dd86f3f896a9941` with successful `app.start`, `electron.ready`, `electron.web-contents.created`, and `dom-ready` spans
- the built Sentry chunk is now a small ESM import boundary instead of a bundled require-hook implementation

## Validation
- `bun test apps/desktop/src/__tests__/sentryObservability.test.ts`
- `bun run typecheck --filter=@teak/desktop`
- Ultracite checks for changed files
- `bun run build --filter=@teak/desktop`
- production-configured `bun run dev` desktop smoke
- `bun run pre-commit`
- `bun run test` (10/10 workspaces; Convex 1374/1374; desktop 39/39)

No public changelog entry: this corrects an internal runtime/build boundary without changing user-visible behavior.
