### PR TITLE
fix: make upload finalization retry-safe

### DIFF
--- a/packages/convex/__tests__/card/uploadCard.test.ts
+++ b/packages/convex/__tests__/card/uploadCard.test.ts
@@ -244,6 +244,63 @@ describe("card uploads", () => {
     });
   });
 
+  test("retries incomplete storage metadata before finalizing", async () => {
+    const wait = mock().mockResolvedValue(undefined);
+    const send = mock()
+      .mockResolvedValueOnce({ ContentLength: 10 })
+      .mockResolvedValueOnce({
+        ContentLength: 10,
+        ContentType: "image/png",
+        ETag: '"etag"',
+      });
+
+    await expect(
+      inspectUploadedCardSource(
+        "u1",
+        {
+          cardType: "image",
+          fileKey: VALID_FILE_KEY,
+          fileName: "image.png",
+          fileSize: 10,
+          fileType: "image/png",
+        },
+        { bucket: "test", client: { send }, wait }
+      )
+    ).resolves.toMatchObject({
+      cardType: "image",
+      storedFileSize: 10,
+      storedMimeType: "image/png",
+    });
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledWith(75);
+  });
+
+  test("keeps a stable error after incomplete storage metadata retries", async () => {
+    const send = mock().mockResolvedValue({ ContentLength: 10 });
+    const wait = mock().mockResolvedValue(undefined);
+
+    await expect(
+      inspectUploadedCardSource(
+        "u1",
+        {
+          cardType: "image",
+          fileKey: VALID_FILE_KEY,
+          fileName: "image.png",
+          fileSize: 10,
+          fileType: "image/png",
+        },
+        { bucket: "test", client: { send }, wait }
+      )
+    ).rejects.toMatchObject({
+      data: {
+        code: "INVALID_INPUT",
+        message: "Uploaded file metadata is unavailable",
+      },
+    });
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(wait).toHaveBeenCalledTimes(2);
+  });
+
   test("rejects oversized and invalid UTF-8 Markdown objects without reading partial text", async () => {
     const oversizedSend = mock(async () => ({
       ContentLength: 512 * 1024 + 1,

--- a/packages/convex/card/uploadCardAction.ts
+++ b/packages/convex/card/uploadCardAction.ts
@@ -66,8 +66,60 @@ interface FinalizeArgs {
   tags?: string[];
 }
 
+interface UploadStorage {
+  bucket: string;
+  client: Pick<S3Client, "send">;
+  wait?: (delayMs: number) => Promise<void>;
+}
+
+type CompleteHeadMetadata = HeadObjectCommandOutput & {
+  ContentLength: number;
+  ETag: string;
+};
+
+const HEAD_RETRY_DELAYS_MS = [75, 225] as const;
+
 const convexUploadError = (code: string, message: string): never => {
   throw new ConvexError({ code, message });
+};
+
+const waitFor = (delayMs: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, delayMs));
+
+const headUploadedObject = async (
+  storage: UploadStorage,
+  key: string
+): Promise<CompleteHeadMetadata> => {
+  let sawIncompleteMetadata = false;
+  for (let attempt = 0; attempt <= HEAD_RETRY_DELAYS_MS.length; attempt += 1) {
+    try {
+      const head = await storage.client.send(
+        new HeadObjectCommand({ Bucket: storage.bucket, Key: key })
+      );
+      if (
+        typeof head.ContentLength === "number" &&
+        Number.isFinite(head.ContentLength) &&
+        head.ETag
+      ) {
+        return head as CompleteHeadMetadata;
+      }
+      sawIncompleteMetadata = true;
+    } catch {
+      // A just-uploaded object may not be readable on the first HEAD attempt.
+    }
+
+    const delayMs = HEAD_RETRY_DELAYS_MS[attempt];
+    if (delayMs !== undefined) {
+      await (storage.wait ?? waitFor)(delayMs);
+    }
+  }
+
+  return convexUploadError(
+    "INVALID_INPUT",
+    sawIncompleteMetadata
+      ? "Uploaded file metadata is unavailable"
+      : "Uploaded file was not found"
+  );
 };
 
 const normalizeMimeType = (value?: string): string | undefined => {
@@ -95,7 +147,7 @@ const createClient = () => {
 export async function inspectUploadedCardSource(
   userId: string,
   args: FinalizeArgs,
-  storage = createClient()
+  storage: UploadStorage = createClient()
 ): Promise<{
   cardType: FinalizeArgs["cardType"];
   content?: string;
@@ -120,27 +172,10 @@ export async function inspectUploadedCardSource(
   }
 
   const { bucket, client } = storage;
-  let head: HeadObjectCommandOutput;
-  try {
-    head = await client.send(
-      new HeadObjectCommand({ Bucket: bucket, Key: args.fileKey })
-    );
-  } catch {
-    return convexUploadError("INVALID_INPUT", "Uploaded file was not found");
-  }
+  const head = await headUploadedObject(storage, args.fileKey);
 
   const storedFileSize = head.ContentLength;
   const sourceEtag = head.ETag;
-  if (
-    typeof storedFileSize !== "number" ||
-    !Number.isFinite(storedFileSize) ||
-    !sourceEtag
-  ) {
-    return convexUploadError(
-      "INVALID_INPUT",
-      "Uploaded file metadata is unavailable"
-    );
-  }
   if (args.fileSize !== undefined && args.fileSize !== storedFileSize) {
     return convexUploadError(
       "INVALID_INPUT",

--- a/packages/tests/src/docs/pages.e2e.ts
+++ b/packages/tests/src/docs/pages.e2e.ts
@@ -28,7 +28,7 @@ test("changelog renders release notes with Typeset", async ({ page }) => {
   await expect(releaseNotes.locator("ul")).toHaveCSS("list-style-type", "disc");
 });
 
-test("public docs describe expanded file support and inferred uploads", async ({
+test("public docs describe expanded file support and optional card types", async ({
   page,
 }) => {
   await page.goto("/docs/api/");
@@ -39,7 +39,12 @@ test("public docs describe expanded file support and inferred uploads", async ({
   await expect(page.locator("body")).toContainText(/Markdown and MDX/i);
 
   await page.goto("/docs/mcp/");
-  await expect(page.locator("body")).toContainText(/cardType.*inferred/i);
+  await expect(page.locator("body")).toContainText(
+    /cardType.*text.*stores raw Markdown exactly/i
+  );
+  await expect(page.locator("body")).toContainText(
+    /automatic URL, quote, and palette detection remains when the type is omitted/i
+  );
 
   await page.goto("/docs/extension/");
   await expect(page.locator("body")).toContainText("Save Asset to Teak");

--- a/packages/tests/src/journey/03-api.e2e.ts
+++ b/packages/tests/src/journey/03-api.e2e.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { expect, test } from "@playwright/test";
 import { apiFetch, loadOpenApi } from "../helpers/api";
 import { expandedFileFixtures } from "../helpers/file-formats";
@@ -254,7 +255,7 @@ test("REST API uploads and infers the expanded file-format matrix", async () => 
     expect(fetchedCard.mimeType).toBe(fixture.mimeType);
     if (fixture.fileName.toLowerCase().endsWith(".md")) {
       expect(fetchedCard).toMatchObject({
-        content: new TextDecoder().decode(fixture.bytes),
+        content: Buffer.from(fixture.bytes).toString("utf8"),
         type: "text",
       });
       expect(fetchedCard.fileUrl).toMatch(/^https?:\/\//);

--- a/packages/tests/src/journey/05-mcp.e2e.ts
+++ b/packages/tests/src/journey/05-mcp.e2e.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { expect, test } from "@playwright/test";
 import { env } from "../helpers/env";
 import { cliFileFixtures } from "../helpers/file-formats";
@@ -122,7 +123,7 @@ test("MCP uploads, creates, fetches, and searches expanded file cards", async ()
       expect(fetched.isError).not.toBe(true);
       if (fixture.fileName.toLowerCase().endsWith(".md")) {
         expect(fetched.structuredContent).toMatchObject({
-          content: new TextDecoder().decode(fixture.bytes),
+          content: Buffer.from(fixture.bytes).toString("utf8"),
           fileName: fixture.fileName,
           type: "text",
         });

--- a/packages/tests/src/matrix/journey-lite.e2e.ts
+++ b/packages/tests/src/matrix/journey-lite.e2e.ts
@@ -15,7 +15,7 @@ test("signup, create, and search", async ({ page }) => {
     const marker = `matrix-${Date.now()}`;
     await page.goto("/");
     const note = page.getByPlaceholder(/Write a note/i);
-    await note.pressSequentially(marker);
+    await note.fill(marker);
     await expect(note).toHaveValue(marker);
     await clickVisibleControl(
       page.getByRole("button", { exact: true, name: "Save" })


### PR DESCRIPTION
## Summary
- retry incomplete storage metadata reads during canonical upload finalization
- preserve BOMs in production REST and MCP contract assertions
- make docs and browser-matrix production checks deterministic

## Validation
- bun run test
- bun run typecheck
- bun run lint
- bun run pre-commit
- bunx convex deploy --dry-run --typecheck enable --yes
- git diff --check

## Production evidence
Production E2E run 30187466668 reproduced incomplete metadata on a newly uploaded extension asset. Journey teardown and the final cleanup sweep both completed successfully.