### PR TITLE
Fix exact preservation for implicit text cards

### DIFF
--- a/packages/convex/__tests__/card/createCard.test.ts
+++ b/packages/convex/__tests__/card/createCard.test.ts
@@ -257,7 +257,7 @@ describe("card/createCard.ts", () => {
     );
   });
 
-  test("keeps text card when content has no URL", async () => {
+  test("keeps implicit text source exact when content has no URL", async () => {
     const ctx = {
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -274,16 +274,16 @@ describe("card/createCard.ts", () => {
     } as any;
 
     const handler = (createCard as any).handler ?? createCard;
+    const content = "\uFEFF  # regular note\r\n\rBody  ";
     await handler(ctx, {
-      content: "just a regular note without any links",
-      type: "text",
+      content,
     });
 
     expect(ctx.db.insert).toHaveBeenCalledWith(
       "cards",
       expect.objectContaining({
         type: "text",
-        content: "just a regular note without any links",
+        content,
       })
     );
   });

--- a/packages/convex/card/createCard.ts
+++ b/packages/convex/card/createCard.ts
@@ -127,8 +127,10 @@ export const createCardForUserHandler = async (
 
   if (!(explicitText || finalUrl) && args.content?.trim()) {
     const urlExtraction = extractUrlFromContent(args.content);
-    finalUrl = urlExtraction.url ?? finalUrl;
-    finalContent = urlExtraction.cleanedContent;
+    if (urlExtraction.url) {
+      finalUrl = urlExtraction.url;
+      finalContent = urlExtraction.cleanedContent;
+    }
   }
 
   // When the client does not specify a type, let the backend decide: a resolved

--- a/packages/tests/src/extension/save-page.e2e.ts
+++ b/packages/tests/src/extension/save-page.e2e.ts
@@ -47,10 +47,7 @@ test("extension saves a selected file and safe page asset with private URL fallb
     await expect(signIn).toBeVisible();
     const nextPage = context.waitForEvent("page");
     await signIn.click();
-    const authPage = await nextPage;
-    await authPage.waitForURL(/\/native\/auth\/complete/, {
-      timeout: 30_000,
-    });
+    await nextPage;
 
     await expect
       .poll(

--- a/packages/tests/src/journey/02-web-journey.e2e.ts
+++ b/packages/tests/src/journey/02-web-journey.e2e.ts
@@ -11,7 +11,9 @@ test("web journey covers cards, search, settings, upload, and revoked key", asyn
   if (!state.primary?.apiKey) {
     throw new Error("Missing primary API key");
   }
+  const api = clientFor(state.primary.apiKey);
   const marker = `prod-e2e-${Date.now()}`;
+  const rawMarkdown = `  # ${marker}\n\n- [ ] <script>alert("xss")</script>  \n`;
   const dialogTrap: string[] = [];
   page.on("dialog", (dialog) => {
     dialogTrap.push(dialog.message());
@@ -22,12 +24,19 @@ test("web journey covers cards, search, settings, upload, and revoked key", asyn
   await expect(
     page.getByText(/Welcome to Teak|Let's add your first card/i)
   ).toBeVisible();
-  await page
-    .getByPlaceholder(/Write a note/i)
-    .fill(`${marker} <script>alert("xss")</script>`);
+  await page.getByPlaceholder(/Write a note/i).fill(rawMarkdown);
   await page.getByRole("button", { name: "Save", exact: true }).click();
   const savedCard = page.locator("main p").filter({ hasText: marker }).first();
   await expect(savedCard).toBeVisible();
+  await expect
+    .poll(
+      async () =>
+        (await api.cards.search({ query: marker })).items.find((card) =>
+          card.content?.includes(marker)
+        )?.content,
+      { timeout: 30_000, intervals: [1000, 2000, 3000, 5000] }
+    )
+    .toBe(rawMarkdown);
   await page.getByPlaceholder("Search for anything...").fill(marker);
   await page.keyboard.press("Enter");
   await expect(savedCard).toBeVisible();
@@ -45,7 +54,6 @@ test("web journey covers cards, search, settings, upload, and revoked key", asyn
     timeout: 45_000,
   });
 
-  const api = clientFor(state.primary.apiKey);
   const png = Buffer.from(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
     "base64"

--- a/packages/tests/src/journey/10-file-format-ui.e2e.ts
+++ b/packages/tests/src/journey/10-file-format-ui.e2e.ts
@@ -20,7 +20,8 @@ test("web picker and drag-drop upload files with safe opened previews", async ({
       mimeType: "text/mdx",
       name: pickedName,
     });
-  await expect(page.getByText(`${pickedName} uploaded`)).toBeVisible({
+  const pickedCard = page.getByText(pickedName).first();
+  await expect(pickedCard).toBeVisible({
     timeout: 45_000,
   });
 
@@ -41,18 +42,16 @@ test("web picker and drag-drop upload files with safe opened previews", async ({
       fileName: droppedName,
     }
   );
-  await expect(page.getByText(`${droppedName} uploaded`)).toBeVisible({
+  await expect(page.getByText(droppedName).first()).toBeVisible({
     timeout: 45_000,
   });
 
-  const markdownCard = page.getByText(pickedName).first();
-  await expect(markdownCard).toBeVisible();
   const prefetchedFile = page.waitForRequest((request) =>
     decodeURIComponent(request.url()).includes(pickedName)
   );
-  await markdownCard.hover();
+  await pickedCard.hover();
   await prefetchedFile;
-  await markdownCard.click();
+  await pickedCard.click();
   const dialog = page.getByRole("dialog");
   await expect(dialog.getByText("Open file")).toBeVisible();
   await expect(dialog.getByText(marker, { exact: false }).first()).toBeVisible({
@@ -70,9 +69,6 @@ test("web picker and drag-drop upload files with safe opened previews", async ({
       mimeType: "text/markdown",
       name: markdownName,
     });
-  await expect(page.getByText(`${markdownName} uploaded`)).toBeVisible({
-    timeout: 45_000,
-  });
   await page.getByPlaceholder("Search for anything...").fill(`${marker}-text`);
   await page.keyboard.press("Enter");
   const textCard = page


### PR DESCRIPTION
## Summary
- preserve submitted source exactly when implicit classification resolves to a text card
- keep URL extraction behavior unchanged for implicit link cards
- harden production web and extension journeys around durable state instead of transient timing

## Validation
- bun run test
- bun run typecheck
- bun run lint
- bun run pre-commit
- git diff --check

Production Convex dry-run could not run locally because this checkout has no CONVEX_DEPLOYMENT configured; the protected backend deploy workflow remains the deployment validation path.