### PR TITLE
Wait for upload metadata readiness

### DIFF
--- a/packages/convex/__tests__/card/uploadCard.test.ts
+++ b/packages/convex/__tests__/card/uploadCard.test.ts
@@ -244,9 +244,12 @@ describe("card uploads", () => {
     });
   });
 
-  test("retries incomplete storage metadata before finalizing", async () => {
+  test("retries incomplete storage metadata across the readiness window", async () => {
     const wait = mock().mockResolvedValue(undefined);
     const send = mock()
+      .mockResolvedValueOnce({ ContentLength: 10 })
+      .mockResolvedValueOnce({ ContentLength: 10 })
+      .mockResolvedValueOnce({ ContentLength: 10 })
       .mockResolvedValueOnce({ ContentLength: 10 })
       .mockResolvedValueOnce({
         ContentLength: 10,
@@ -271,8 +274,10 @@ describe("card uploads", () => {
       storedFileSize: 10,
       storedMimeType: "image/png",
     });
-    expect(send).toHaveBeenCalledTimes(2);
-    expect(wait).toHaveBeenCalledWith(75);
+    expect(send).toHaveBeenCalledTimes(5);
+    expect(wait.mock.calls.map(([delay]) => delay)).toEqual([
+      100, 300, 900, 2700,
+    ]);
   });
 
   test("keeps a stable error after incomplete storage metadata retries", async () => {
@@ -297,8 +302,8 @@ describe("card uploads", () => {
         message: "Uploaded file metadata is unavailable",
       },
     });
-    expect(send).toHaveBeenCalledTimes(3);
-    expect(wait).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenCalledTimes(5);
+    expect(wait).toHaveBeenCalledTimes(4);
   });
 
   test("rejects oversized and invalid UTF-8 Markdown objects without reading partial text", async () => {

--- a/packages/convex/card/uploadCardAction.ts
+++ b/packages/convex/card/uploadCardAction.ts
@@ -77,7 +77,7 @@ type CompleteHeadMetadata = HeadObjectCommandOutput & {
   ETag: string;
 };
 
-const HEAD_RETRY_DELAYS_MS = [75, 225] as const;
+const HEAD_RETRY_DELAYS_MS = [100, 300, 900, 2700] as const;
 
 const convexUploadError = (code: string, message: string): never => {
   throw new ConvexError({ code, message });

--- a/packages/tests/src/journey/10-file-format-ui.e2e.ts
+++ b/packages/tests/src/journey/10-file-format-ui.e2e.ts
@@ -72,8 +72,8 @@ test("web picker and drag-drop upload files with safe opened previews", async ({
   await page.getByPlaceholder("Search for anything...").fill(`${marker}-text`);
   await page.keyboard.press("Enter");
   const textCard = page
-    .getByRole("main")
-    .getByText(`${marker}-text`, { exact: false })
+    .locator("main p")
+    .filter({ hasText: `${marker}-text` })
     .first();
   await expect(textCard).toBeVisible();
   await textCard.click();


### PR DESCRIPTION
## Summary
- extend the bounded backend readiness window for just-uploaded object metadata
- cover the full retry schedule and stable terminal error deterministically
- make the production web journey click the durable text-card result instead of a search suggestion

## Production evidence
- extension asset finalization returned INVALID_INPUT because R2 HEAD metadata still lacked an ETag after the previous 300 ms window
- the Markdown web upload succeeded, but the journey clicked the matching filter suggestion rather than the saved card

## Validation
- bun run test
- bun run typecheck
- bun run lint
- bun run pre-commit
- git diff --check