### PR TITLE
Probe upload ETag after HEAD retries

### DIFF
--- a/packages/convex/__tests__/card/uploadCard.test.ts
+++ b/packages/convex/__tests__/card/uploadCard.test.ts
@@ -302,8 +302,45 @@ describe("card uploads", () => {
         message: "Uploaded file metadata is unavailable",
       },
     });
-    expect(send).toHaveBeenCalledTimes(5);
+    expect(send).toHaveBeenCalledTimes(6);
     expect(wait).toHaveBeenCalledTimes(4);
+  });
+
+  test("uses a bounded GET probe when HEAD omits the object ETag", async () => {
+    const transformToByteArray = mock().mockResolvedValue(new Uint8Array([1]));
+    const send = mock(async (command) =>
+      command.constructor.name === "GetObjectCommand"
+        ? {
+            Body: { transformToByteArray },
+            ContentType: "image/svg+xml",
+            ETag: '"etag"',
+          }
+        : {
+            ContentLength: 10,
+            ContentType: "image/svg+xml",
+          }
+    );
+    const wait = mock().mockResolvedValue(undefined);
+
+    await expect(
+      inspectUploadedCardSource(
+        "u1",
+        {
+          cardType: "image",
+          fileKey: VALID_FILE_KEY,
+          fileName: "icon.svg",
+          fileSize: 10,
+          fileType: "image/svg+xml",
+        },
+        { bucket: "test", client: { send }, wait }
+      )
+    ).resolves.toMatchObject({
+      cardType: "image",
+      storedFileSize: 10,
+      storedMimeType: "image/svg+xml",
+    });
+    expect(send).toHaveBeenCalledTimes(6);
+    expect(transformToByteArray).toHaveBeenCalledTimes(1);
   });
 
   test("rejects oversized and invalid UTF-8 Markdown objects without reading partial text", async () => {

--- a/packages/convex/card/uploadCardAction.ts
+++ b/packages/convex/card/uploadCardAction.ts
@@ -90,7 +90,7 @@ const headUploadedObject = async (
   storage: UploadStorage,
   key: string
 ): Promise<CompleteHeadMetadata> => {
-  let sawIncompleteMetadata = false;
+  let incompleteHead: HeadObjectCommandOutput | undefined;
   for (let attempt = 0; attempt <= HEAD_RETRY_DELAYS_MS.length; attempt += 1) {
     try {
       const head = await storage.client.send(
@@ -103,7 +103,7 @@ const headUploadedObject = async (
       ) {
         return head as CompleteHeadMetadata;
       }
-      sawIncompleteMetadata = true;
+      incompleteHead = head;
     } catch {
       // A just-uploaded object may not be readable on the first HEAD attempt.
     }
@@ -114,9 +114,37 @@ const headUploadedObject = async (
     }
   }
 
+  if (
+    incompleteHead &&
+    typeof incompleteHead.ContentLength === "number" &&
+    Number.isFinite(incompleteHead.ContentLength)
+  ) {
+    try {
+      const probe = await storage.client.send(
+        new GetObjectCommand({
+          Bucket: storage.bucket,
+          Key: key,
+          Range: "bytes=0-0",
+        })
+      );
+      if (probe.Body) {
+        await probe.Body.transformToByteArray();
+      }
+      if (probe.ETag) {
+        return {
+          ...incompleteHead,
+          ContentType: incompleteHead.ContentType ?? probe.ContentType,
+          ETag: probe.ETag,
+        } as CompleteHeadMetadata;
+      }
+    } catch {
+      // Preserve the stable metadata error below when the bounded probe fails.
+    }
+  }
+
   return convexUploadError(
     "INVALID_INPUT",
-    sawIncompleteMetadata
+    incompleteHead
       ? "Uploaded file metadata is unavailable"
       : "Uploaded file was not found"
   );


### PR DESCRIPTION
## Summary
- retain bounded HEAD readiness retries for newly uploaded objects
- when HEAD repeatedly omits ETag, perform a one-byte GET probe and use its ETag with the verified HEAD size/type metadata
- preserve the existing stable terminal metadata error if the probe also fails

## Production evidence
The isolated extension journey reproduced R2 HEAD responses with ContentLength but no ETag across the full four-second readiness window. A range probe verifies the same object without downloading it in full.

## Validation
- bun run test
- bun run typecheck
- bun run lint
- bun run pre-commit
- git diff --check