### PR TITLE
test: stabilize production Markdown journeys

### DIFF
--- a/packages/tests/src/extension/save-page.e2e.ts
+++ b/packages/tests/src/extension/save-page.e2e.ts
@@ -47,7 +47,15 @@ test("extension saves a selected file and safe page asset with private URL fallb
     await expect(signIn).toBeVisible();
     const nextPage = context.waitForEvent("page");
     await signIn.click();
-    await nextPage;
+    const authPage = await nextPage;
+    await authPage.waitForURL(
+      (url) => url.pathname === "/native/auth/complete"
+    );
+
+    // The completion tab can close before its document-idle content script
+    // runs. Reopening the popup exercises the extension's normal fallback poll.
+    const finishingPopup = await context.newPage();
+    await finishingPopup.goto(popupUrl);
 
     await expect
       .poll(

--- a/packages/tests/src/extension/save-page.e2e.ts
+++ b/packages/tests/src/extension/save-page.e2e.ts
@@ -48,9 +48,13 @@ test("extension saves a selected file and safe page asset with private URL fallb
     const nextPage = context.waitForEvent("page");
     await signIn.click();
     const authPage = await nextPage;
-    await authPage.waitForURL(
-      (url) => url.pathname === "/native/auth/complete"
-    );
+    await authPage
+      .waitForURL((url) => url.pathname === "/native/auth/complete")
+      .catch((error: unknown) => {
+        if (!authPage.isClosed()) {
+          throw error;
+        }
+      });
 
     // The completion tab can close before its document-idle content script
     // runs. Reopening the popup exercises the extension's normal fallback poll.

--- a/packages/tests/src/journey/10-file-format-ui.e2e.ts
+++ b/packages/tests/src/journey/10-file-format-ui.e2e.ts
@@ -1,5 +1,7 @@
 import { Buffer } from "node:buffer";
 import { expect, test } from "@playwright/test";
+import { clientFor } from "../helpers/prod";
+import { readState } from "../helpers/run-state";
 
 test("web picker and drag-drop upload files with safe opened previews", async ({
   page,
@@ -9,6 +11,11 @@ test("web picker and drag-drop upload files with safe opened previews", async ({
   const droppedName = `${marker}-drop.tsx`;
   const markdownName = `${marker}-text.MARKDOWN`;
   const rawMarkdown = `\uFEFF  # ${marker}-text\r\n\r\n- [ ] keep spacing  \n`;
+  const state = readState();
+  if (!state.primary?.apiKey) {
+    throw new Error("Missing primary API key");
+  }
+  const api = clientFor(state.primary.apiKey);
 
   await page.goto("/");
   await page.getByRole("button", { name: "Upload files" }).click();
@@ -69,6 +76,18 @@ test("web picker and drag-drop upload files with safe opened previews", async ({
       mimeType: "text/markdown",
       name: markdownName,
     });
+  await expect
+    .poll(
+      async () =>
+        (
+          await api.cards.list({
+            include: "content,metadata",
+            limit: 100,
+          })
+        ).items.find((card) => card.fileName === markdownName)?.content,
+      { timeout: 45_000 }
+    )
+    .toBe(rawMarkdown);
   await page.getByPlaceholder("Search for anything...").fill(`${marker}-text`);
   await page.keyboard.press("Enter");
   const textCard = page
@@ -79,7 +98,7 @@ test("web picker and drag-drop upload files with safe opened previews", async ({
   await textCard.click();
   const textDialog = page.getByRole("dialog");
   await expect(textDialog.getByPlaceholder("Enter your text...")).toHaveValue(
-    rawMarkdown
+    rawMarkdown.replace(/\r\n?/g, "\n")
   );
   await expect(
     textDialog.getByRole("button", { name: /Download/i })


### PR DESCRIPTION
## Summary
- wait for native auth completion, then reopen the extension popup so its documented fallback poll runs deterministically
- verify Markdown upload source exactly through the backend before asserting the browser-normalized textarea value

## Validation
- bun run test
- bun run typecheck
- bun run lint
- bun run pre-commit
- git diff --check