### PR TITLE
Fix exact object verification after direct uploads

### DIFF
--- a/apps/cli/src/files.ts
+++ b/apps/cli/src/files.ts
@@ -94,13 +94,14 @@ export const addCard = async (
       fileSize,
       mimeType,
     });
-    await api.uploads.putFile(
+    const uploaded = await api.uploads.putFile(
       upload.uploadUrl,
       readFileSync(candidate),
       mimeType
     );
     return api.cards.create({
       fileKey: upload.fileKey,
+      fileEtag: uploaded.fileEtag,
       fileName,
       fileSize,
       mimeType,

--- a/apps/docs/src/content/docs/docs/api.mdx
+++ b/apps/docs/src/content/docs/docs/api.mdx
@@ -173,7 +173,7 @@ Content-Type: application/json
 }
 ```
 
-The response includes a presigned `uploadUrl` and `fileKey`. Upload the bytes with `PUT`, then create the card with `POST /v1/cards`.
+The response includes a presigned `uploadUrl` and `fileKey`. Upload the bytes with `PUT`, retain the `ETag` response header, then create the card with `POST /v1/cards`.
 
 ```json
 {
@@ -198,6 +198,7 @@ Idempotency-Key: upload-image-123
 
 ```json
 {
+  "fileEtag": "\"d41d8cd98f00b204e9800998ecf8427e\"",
   "fileKey": "users/user_1/file/...",
   "fileName": "image.png",
   "mimeType": "image/png",

--- a/apps/docs/src/content/docs/docs/mcp.mdx
+++ b/apps/docs/src/content/docs/docs/mcp.mdx
@@ -64,7 +64,7 @@ shown above, so MCP clients validate and connect to the same public resource.
   - Input: `{ cardId: string }`
   - Output: full card object
 - `teak_v1_create_card`
-  - Input: text/URL fields or uploaded-file fields `{ fileKey, fileName, mimeType, fileSize?, cardType? }`. Explicit `cardType: "text"` stores raw Markdown exactly; automatic URL, quote, and palette detection remains when the type is omitted.
+  - Input: text/URL fields or uploaded-file fields `{ fileKey, fileEtag?, fileName, mimeType, fileSize?, cardType? }`. Pass the `ETag` response header from the upload PUT as `fileEtag` so Teak can verify the exact stored object. Explicit `cardType: "text"` stores raw Markdown exactly; automatic URL, quote, and palette detection remains when the type is omitted.
   - Output: `{ status: "created", cardId: string, appUrl: string }`
 - `teak_v1_list_tags`
   - Input: `{}`

--- a/apps/extension/__tests__/lib/saveFileToTeak.test.ts
+++ b/apps/extension/__tests__/lib/saveFileToTeak.test.ts
@@ -33,7 +33,12 @@ const createDependencies = () => {
         Response.json({ token: "header.payload.signature" })
       );
     }
-    return Promise.resolve(new Response(null, { status: 200 }));
+    return Promise.resolve(
+      new Response(null, {
+        headers: { ETag: '"upload-etag"' },
+        status: 200,
+      })
+    );
   }) as unknown as typeof fetch;
 
   return {
@@ -71,6 +76,7 @@ describe("extension file saving", () => {
     expect(action).toHaveBeenCalledTimes(1);
     expect(action.mock.calls[0]?.[1]).toMatchObject({
       cardType: "document",
+      fileEtag: '"upload-etag"',
       fileName: "component.tsx",
       fileType: "text/tsx",
     });

--- a/apps/extension/lib/saveFileToTeak.ts
+++ b/apps/extension/lib/saveFileToTeak.ts
@@ -149,6 +149,7 @@ export async function saveFileToTeak(
       fileName,
       fileSize: input.bytes.size,
       fileType: mimeType,
+      fileEtag: uploadResponse.headers.get("etag") ?? undefined,
     });
     if (!(finalized.success && finalized.cardId)) {
       return errorResponse(

--- a/apps/mobile/lib/hooks/useFileUpload.ts
+++ b/apps/mobile/lib/hooks/useFileUpload.ts
@@ -71,6 +71,7 @@ export function useFileUpload(config: UnifiedFileUploadConfig = {}) {
         }
 
         return {
+          headers: result?.headers,
           ok: result ? result.status >= 200 && result.status < 300 : false,
           status: result?.status ?? 0,
         };

--- a/packages/convex/__tests__/card/uploadCard.test.ts
+++ b/packages/convex/__tests__/card/uploadCard.test.ts
@@ -343,6 +343,45 @@ describe("card uploads", () => {
     expect(transformToByteArray).toHaveBeenCalledTimes(1);
   });
 
+  test("verifies an upload-response ETag when storage responses omit it", async () => {
+    const bytes = new TextEncoder().encode("# exact");
+    const commands: Array<{ input?: { IfMatch?: string } }> = [];
+    const send = mock(async (command) => {
+      commands.push(command);
+      if (command.constructor.name === "GetObjectCommand") {
+        return { Body: { transformToByteArray: async () => bytes } };
+      }
+      return {
+        ContentLength: bytes.byteLength,
+        ContentType: "text/markdown",
+      };
+    });
+
+    await expect(
+      inspectUploadedCardSource(
+        "u1",
+        {
+          fileEtag: '"upload-etag"',
+          fileKey: VALID_FILE_KEY,
+          fileName: "README.md",
+          fileSize: bytes.byteLength,
+          fileType: "text/markdown",
+        },
+        { bucket: "test", client: { send } }
+      )
+    ).resolves.toMatchObject({
+      cardType: "text",
+      content: "# exact",
+      storedFileSize: bytes.byteLength,
+    });
+    expect(commands).toHaveLength(3);
+    expect(
+      commands.every(
+        (command) => command.input?.IfMatch === '"upload-etag"'
+      )
+    ).toBe(true);
+  });
+
   test("rejects oversized and invalid UTF-8 Markdown objects without reading partial text", async () => {
     const oversizedSend = mock(async () => ({
       ContentLength: 512 * 1024 + 1,

--- a/packages/convex/__tests__/mcp.test.ts
+++ b/packages/convex/__tests__/mcp.test.ts
@@ -329,6 +329,7 @@ describe("Convex MCP endpoint", () => {
       [
         "teak_v1_create_card",
         {
+          fileEtag: '"upload-etag"',
           fileKey: "users/user_1/file/readme.md",
           fileName: "readme.md",
           fileSize: 42,
@@ -390,6 +391,7 @@ describe("Convex MCP endpoint", () => {
       "GET /v1/cards/card_1",
     ]);
     expect(captured[2]?.body).toEqual({
+      fileEtag: '"upload-etag"',
       fileKey: "users/user_1/file/readme.md",
       fileName: "readme.md",
       fileSize: 42,

--- a/packages/convex/__tests__/publicApiHttp.test.ts
+++ b/packages/convex/__tests__/publicApiHttp.test.ts
@@ -368,6 +368,7 @@ describe("publicApiHttp", () => {
         },
         body: JSON.stringify({
           cardType: "image",
+          fileEtag: '"upload-etag"',
           fileKey: "users/user_1/file/image.png",
           fileName: "image.png",
           fileSize: 123,
@@ -384,6 +385,7 @@ describe("publicApiHttp", () => {
     });
     expect(runAction.mock.calls[0][1]).toMatchObject({
       cardType: "image",
+      fileEtag: '"upload-etag"',
       fileKey: "users/user_1/file/image.png",
       fileName: "image.png",
       fileSize: 123,

--- a/packages/convex/__tests__/sdk.test.ts
+++ b/packages/convex/__tests__/sdk.test.ts
@@ -72,11 +72,16 @@ describe("@teak/convex/sdk", () => {
         const headers = new Headers(init?.headers);
         seenHeaders.contentLength = headers.get("content-length");
         seenHeaders.contentType = headers.get("content-type");
-        return Promise.resolve(new Response(null, { status: 200 }));
+        return Promise.resolve(
+          new Response(null, {
+            headers: { ETag: '"upload-etag"' },
+            status: 200,
+          })
+        );
       }) as typeof fetch,
     });
 
-    await client.uploads.putFile(
+    const uploaded = await client.uploads.putFile(
       "https://upload.example",
       new Uint8Array([1, 2, 3]),
       "image/png"
@@ -86,6 +91,7 @@ describe("@teak/convex/sdk", () => {
       contentLength: "3",
       contentType: "image/png",
     });
+    expect(uploaded).toEqual({ fileEtag: '"upload-etag"' });
   });
 
   test("parses the backwards-compatible upload response contract", async () => {

--- a/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
+++ b/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
@@ -231,6 +231,7 @@ describe("useFileUploadCore", () => {
         uploadKey: "store_1",
       });
       mockFetch.mockResolvedValue({
+        headers: new Headers({ ETag: '"browser-etag"' }),
         ok: true,
         json: async () => ({ storageId: "store_1" }),
       });
@@ -247,7 +248,10 @@ describe("useFileUploadCore", () => {
         expect.any(Object)
       );
       expect(mockFinalizeUploadedCard).toHaveBeenCalledWith(
-        expect.objectContaining({ fileKey: "store_1" })
+        expect.objectContaining({
+          fileEtag: '"browser-etag"',
+          fileKey: "store_1",
+        })
       );
       expect(mockOnSuccess).toHaveBeenCalledWith("card_1");
       expect(result.success).toBe(true);
@@ -336,7 +340,11 @@ describe("useFileUploadCore", () => {
         uploadUrl: "https://upload",
         uploadKey: "store_1",
       });
-      mockUploadBinaryFromUri.mockResolvedValue({ ok: true, status: 200 });
+      mockUploadBinaryFromUri.mockResolvedValue({
+        headers: { ETag: '"mobile-etag"' },
+        ok: true,
+        status: 200,
+      });
       mockFinalizeUploadedCard.mockResolvedValue({
         success: true,
         cardId: "card_1",
@@ -360,6 +368,7 @@ describe("useFileUploadCore", () => {
       expect(mockFinalizeUploadedCard).toHaveBeenCalledWith(
         expect.objectContaining({
           fileKey: "store_1",
+          fileEtag: '"mobile-etag"',
           fileName: "photo.jpg",
           additionalMetadata: { width: 10, height: 20 },
         })

--- a/packages/convex/card/uploadCardAction.ts
+++ b/packages/convex/card/uploadCardAction.ts
@@ -31,6 +31,7 @@ const finalizeArgs = {
   additionalMetadata: v.optional(v.any()),
   cardType: v.optional(cardTypeValidator),
   content: v.optional(v.string()),
+  fileEtag: v.optional(v.string()),
   fileKey: v.string(),
   fileName: v.string(),
   fileSize: v.optional(v.number()),
@@ -58,6 +59,7 @@ interface FinalizeArgs {
     | "palette"
     | "quote";
   content?: string;
+  fileEtag?: string;
   fileKey: string;
   fileName: string;
   fileSize?: number;
@@ -88,20 +90,28 @@ const waitFor = (delayMs: number): Promise<void> =>
 
 const headUploadedObject = async (
   storage: UploadStorage,
-  key: string
+  key: string,
+  expectedEtag?: string
 ): Promise<CompleteHeadMetadata> => {
   let incompleteHead: HeadObjectCommandOutput | undefined;
   for (let attempt = 0; attempt <= HEAD_RETRY_DELAYS_MS.length; attempt += 1) {
     try {
       const head = await storage.client.send(
-        new HeadObjectCommand({ Bucket: storage.bucket, Key: key })
+        new HeadObjectCommand({
+          Bucket: storage.bucket,
+          Key: key,
+          IfMatch: expectedEtag,
+        })
       );
       if (
         typeof head.ContentLength === "number" &&
         Number.isFinite(head.ContentLength) &&
-        head.ETag
+        (head.ETag || expectedEtag)
       ) {
-        return head as CompleteHeadMetadata;
+        return {
+          ...head,
+          ETag: head.ETag || expectedEtag,
+        } as CompleteHeadMetadata;
       }
       incompleteHead = head;
     } catch {
@@ -123,6 +133,7 @@ const headUploadedObject = async (
       const probe = await storage.client.send(
         new GetObjectCommand({
           Bucket: storage.bucket,
+          IfMatch: expectedEtag,
           Key: key,
           Range: "bytes=0-0",
         })
@@ -130,11 +141,11 @@ const headUploadedObject = async (
       if (probe.Body) {
         await probe.Body.transformToByteArray();
       }
-      if (probe.ETag) {
+      if (probe.ETag || expectedEtag) {
         return {
           ...incompleteHead,
           ContentType: incompleteHead.ContentType ?? probe.ContentType,
-          ETag: probe.ETag,
+          ETag: probe.ETag || expectedEtag,
         } as CompleteHeadMetadata;
       }
     } catch {
@@ -199,8 +210,18 @@ export async function inspectUploadedCardSource(
     );
   }
 
+  if (
+    args.fileEtag !== undefined &&
+    !/^"[A-Za-z0-9+/=_-]{1,128}"$/u.test(args.fileEtag)
+  ) {
+    return convexUploadError(
+      "INVALID_INPUT",
+      "Uploaded file ETag is invalid"
+    );
+  }
+
   const { bucket, client } = storage;
-  const head = await headUploadedObject(storage, args.fileKey);
+  const head = await headUploadedObject(storage, args.fileKey, args.fileEtag);
 
   const storedFileSize = head.ContentLength;
   const sourceEtag = head.ETag;
@@ -263,7 +284,10 @@ export async function inspectUploadedCardSource(
         IfMatch: sourceEtag,
       })
     );
-    if (!(object.Body && object.ETag === sourceEtag)) {
+    if (
+      !object.Body ||
+      (object.ETag !== undefined && object.ETag !== sourceEtag)
+    ) {
       return convexUploadError(
         "CONFLICT",
         "Uploaded file changed before it could be saved"
@@ -277,10 +301,14 @@ export async function inspectUploadedCardSource(
       );
     }
     const verified = await client.send(
-      new HeadObjectCommand({ Bucket: bucket, Key: args.fileKey })
+      new HeadObjectCommand({
+        Bucket: bucket,
+        Key: args.fileKey,
+        IfMatch: sourceEtag,
+      })
     );
     if (
-      verified.ETag !== sourceEtag ||
+      (verified.ETag !== undefined && verified.ETag !== sourceEtag) ||
       verified.ContentLength !== storedFileSize
     ) {
       return convexUploadError(

--- a/packages/convex/client/hooks/useFileUpload.client.tsx
+++ b/packages/convex/client/hooks/useFileUpload.client.tsx
@@ -108,6 +108,7 @@ export interface FinalizeUploadedCardArgs {
   additionalMetadata?: any;
   cardType: CardType;
   content?: string;
+  fileEtag?: string;
   fileKey: string;
   fileName: string;
   fileSize?: number;
@@ -133,7 +134,11 @@ export interface FileUploadDependencies {
     fileUri: string;
     signal: AbortSignal;
     uploadUrl: string;
-  }) => Promise<{ ok: boolean; status: number }>;
+  }) => Promise<{
+    headers?: Headers | Record<string, string>;
+    ok: boolean;
+    status: number;
+  }>;
 }
 
 export interface UploadFileFromUriArgs {
@@ -146,7 +151,26 @@ export interface UploadFileFromUriArgs {
 }
 
 type CodedError = Error & { code?: CardErrorCode };
-type UploadResponse = Pick<Response, "ok" | "status">;
+interface UploadResponse {
+  headers?: Headers | Record<string, string>;
+  ok: boolean;
+  status: number;
+}
+
+export const getUploadEtag = (
+  headers?: Headers | Record<string, string>
+): string | undefined => {
+  if (!headers) {
+    return;
+  }
+  if (headers instanceof Headers) {
+    return headers.get("etag") ?? undefined;
+  }
+  const entry = Object.entries(headers).find(
+    ([key]) => key.toLowerCase() === "etag"
+  );
+  return entry?.[1];
+};
 
 const UPLOAD_RETRY_DELAYS_MS = [300, 900] as const;
 
@@ -423,6 +447,7 @@ export function useFileUploadCore(
           fileName: file.name,
           fileSize: file.size,
           fileType,
+          fileEtag: getUploadEtag(uploadResponse.headers),
           cardType,
           content: options.content,
           additionalMetadata: mergedAdditionalMetadata,
@@ -627,6 +652,7 @@ export function useFileUploadCore(
           fileName: name,
           fileSize: size,
           fileType,
+          fileEtag: getUploadEtag(uploadResponse.headers),
           cardType,
           content,
           additionalMetadata,

--- a/packages/convex/client/sdk.ts
+++ b/packages/convex/client/sdk.ts
@@ -96,6 +96,7 @@ export interface TagSummary {
 export interface CreateCardInput {
   cardType?: CardType;
   content?: string;
+  fileEtag?: string;
   fileKey?: string;
   fileName?: string;
   fileSize?: number;
@@ -509,6 +510,7 @@ export const createTeakClient = (options: {
             { status: response.status }
           );
         }
+        return { fileEtag: response.headers.get("etag") ?? undefined };
       },
     },
   };

--- a/packages/convex/mcp/tools.ts
+++ b/packages/convex/mcp/tools.ts
@@ -100,6 +100,7 @@ const createCardInputSchema = z
   .object({
     cardType: cardTypeSchema.optional(),
     content: z.string().optional(),
+    fileEtag: nonEmptyString.optional(),
     fileKey: nonEmptyString.optional(),
     fileName: nonEmptyString.optional(),
     fileSize: z.number().positive().optional(),
@@ -223,6 +224,7 @@ export const TEAK_V1_TOOLS = [
     inputSchema: inputSchema({
       cardType: { enum: cardTypeSchema.options },
       content: { type: "string", minLength: 1 },
+      fileEtag: { type: "string", minLength: 1 },
       fileKey: { type: "string", minLength: 1 },
       fileName: { type: "string", minLength: 1 },
       fileSize: { type: "number", minimum: 1 },

--- a/packages/convex/publicApiHttp.ts
+++ b/packages/convex/publicApiHttp.ts
@@ -63,6 +63,7 @@ interface CardsQueryOptions {
 interface CreateCardPayload {
   cardType?: string;
   content?: string;
+  fileEtag?: string;
   fileKey?: string;
   fileName?: string;
   fileSize?: number;
@@ -673,6 +674,7 @@ const validateCreatePayload = (payload: unknown): CreateCardPayload | null => {
   const allowedKeys = new Set([
     "cardType",
     "content",
+    "fileEtag",
     "fileKey",
     "fileName",
     "fileSize",
@@ -693,6 +695,7 @@ const validateCreatePayload = (payload: unknown): CreateCardPayload | null => {
     typeof source.content === "string" ? source.content : undefined;
   const url = parseOptionalString(source.url);
   const fileKey = parseOptionalString(source.fileKey);
+  const fileEtag = parseOptionalString(source.fileEtag);
   const fileName = parseOptionalString(source.fileName);
   const mimeType = parseOptionalString(source.mimeType);
   const cardType = parseOptionalString(source.cardType);
@@ -733,6 +736,7 @@ const validateCreatePayload = (payload: unknown): CreateCardPayload | null => {
     return {
       cardType,
       content,
+      fileEtag,
       fileKey,
       fileName,
       fileSize,
@@ -956,6 +960,7 @@ export const handleCreateCardRequest = async (
             {
               cardType: createPayload.cardType,
               content: createPayload.content,
+              fileEtag: createPayload.fileEtag,
               fileKey: createPayload.fileKey,
               fileName: createPayload.fileName,
               fileSize: createPayload.fileSize,

--- a/packages/convex/publicApiOpenApi.ts
+++ b/packages/convex/publicApiOpenApi.ts
@@ -142,6 +142,12 @@ const components = {
           example: "  # Draft\r\n\r\n- [ ] Keep spacing  \n",
           type: "string",
         },
+        fileEtag: {
+          description:
+            "ETag returned by the completed upload PUT. Include it when creating an uploaded-file card so Teak can verify the exact stored object.",
+          example: '"d41d8cd98f00b204e9800998ecf8427e"',
+          type: "string",
+        },
         fileKey: { type: "string" },
         fileName: { type: "string" },
         fileSize: { type: "number" },

--- a/packages/tests/src/journey/03-api.e2e.ts
+++ b/packages/tests/src/journey/03-api.e2e.ts
@@ -224,6 +224,8 @@ test("REST API uploads and infers the expanded file-format matrix", async () => 
       method: "PUT",
     });
     expect(put.ok, fixture.fileName).toBe(true);
+    const fileEtag = put.headers.get("etag");
+    expect(fileEtag, fixture.fileName).toBeTruthy();
 
     let explicitCardType: "document" | "image" | undefined;
     if (index === 1) {
@@ -235,6 +237,7 @@ test("REST API uploads and infers the expanded file-format matrix", async () => 
       method: "POST",
       body: JSON.stringify({
         ...(explicitCardType ? { cardType: explicitCardType } : {}),
+        fileEtag,
         fileKey: upload.fileKey,
         fileName: fixture.fileName,
         fileSize: fixture.bytes.byteLength,

--- a/packages/tests/src/journey/05-mcp.e2e.ts
+++ b/packages/tests/src/journey/05-mcp.e2e.ts
@@ -96,10 +96,13 @@ test("MCP uploads, creates, fetches, and searches expanded file cards", async ()
         method: "PUT",
       });
       expect(put.ok).toBe(true);
+      const fileEtag = put.headers.get("etag");
+      expect(fileEtag, fixture.fileName).toBeTruthy();
 
       const created: any = await client.callTool({
         name: "teak_v1_create_card",
         arguments: {
+          fileEtag,
           fileKey: upload.fileKey,
           fileName: fixture.fileName,
           fileSize: fixture.bytes.byteLength,

--- a/packages/tests/src/journey/10-file-format-ui.e2e.ts
+++ b/packages/tests/src/journey/10-file-format-ui.e2e.ts
@@ -107,5 +107,7 @@ test("web picker and drag-drop upload files with safe opened previews", async ({
 
   await page.getByPlaceholder("Search for anything...").fill(marker);
   await page.keyboard.press("Enter");
-  await expect(page.getByText(pickedName).first()).toBeVisible();
+  await expect(page.getByText(pickedName).first()).toBeVisible({
+    timeout: 45_000,
+  });
 });


### PR DESCRIPTION
## Summary
- propagate the R2 PUT ETag through every direct-upload client and public contract
- enforce the exact ETag with conditional storage reads even when R2 omits ETag response fields
- cover the production failure mode and retain stable fallback behavior for older clients
- give the eventual web file-search assertion the same bounded readiness window as upload creation

## Validation
- bun run test
- bun run typecheck
- bun run lint
- bun run pre-commit
- git diff --check
- focused upload, SDK, REST, MCP, shared-client, extension, and OpenAPI tests