### PR TITLE
Derive upload metadata from bounded range reads

### DIFF
--- a/packages/convex/__tests__/card/uploadCard.test.ts
+++ b/packages/convex/__tests__/card/uploadCard.test.ts
@@ -382,6 +382,49 @@ describe("card uploads", () => {
     ).toBe(true);
   });
 
+  test("derives verified size from a bounded range response", async () => {
+    const commands: Array<{ input?: { IfMatch?: string; Range?: string } }> =
+      [];
+    const send = mock(async (command) => {
+      commands.push(command);
+      if (command.constructor.name === "GetObjectCommand") {
+        return {
+          Body: {
+            transformToByteArray: async () => new Uint8Array([60]),
+          },
+          ContentRange: "bytes 0-0/16467",
+          ContentType: "image/svg+xml",
+        };
+      }
+      return {};
+    });
+    const wait = mock().mockResolvedValue(undefined);
+
+    await expect(
+      inspectUploadedCardSource(
+        "u1",
+        {
+          cardType: "image",
+          fileEtag: '"upload-etag"',
+          fileKey: VALID_FILE_KEY,
+          fileName: "icon.svg",
+          fileSize: 16_467,
+          fileType: "image/svg+xml",
+        },
+        { bucket: "test", client: { send }, wait }
+      )
+    ).resolves.toMatchObject({
+      cardType: "image",
+      storedFileSize: 16_467,
+      storedMimeType: "image/svg+xml",
+    });
+    expect(commands).toHaveLength(6);
+    expect(commands.at(-1)?.input).toMatchObject({
+      IfMatch: '"upload-etag"',
+      Range: "bytes=0-0",
+    });
+  });
+
   test("rejects oversized and invalid UTF-8 Markdown objects without reading partial text", async () => {
     const oversizedSend = mock(async () => ({
       ContentLength: 512 * 1024 + 1,

--- a/packages/convex/card/uploadCardAction.ts
+++ b/packages/convex/card/uploadCardAction.ts
@@ -124,11 +124,7 @@ const headUploadedObject = async (
     }
   }
 
-  if (
-    incompleteHead &&
-    typeof incompleteHead.ContentLength === "number" &&
-    Number.isFinite(incompleteHead.ContentLength)
-  ) {
+  if (incompleteHead || expectedEtag) {
     try {
       const probe = await storage.client.send(
         new GetObjectCommand({
@@ -141,10 +137,21 @@ const headUploadedObject = async (
       if (probe.Body) {
         await probe.Body.transformToByteArray();
       }
-      if (probe.ETag || expectedEtag) {
+      const contentRangeSize = /^bytes \d+-\d+\/(\d+)$/u.exec(
+        probe.ContentRange ?? ""
+      )?.[1];
+      const storedSize = contentRangeSize
+        ? Number(contentRangeSize)
+        : incompleteHead?.ContentLength;
+      if (
+        typeof storedSize === "number" &&
+        Number.isFinite(storedSize) &&
+        (probe.ETag || expectedEtag)
+      ) {
         return {
           ...incompleteHead,
-          ContentType: incompleteHead.ContentType ?? probe.ContentType,
+          ContentLength: storedSize,
+          ContentType: incompleteHead?.ContentType ?? probe.ContentType,
           ETag: probe.ETag || expectedEtag,
         } as CompleteHeadMetadata;
       }


### PR DESCRIPTION
## Summary
- fall back to a one-byte conditional GET whenever upload HEAD metadata is incomplete
- derive the exact stored object size from Content-Range while retaining ETag and MIME verification
- reproduce the production R2 response shape in a deterministic contract test

## Validation
- bun run test
- bun run typecheck --filter=@teak/convex
- bun run pre-commit
- git diff --check