### PR TITLE
test: reset upload journey search filters

### DIFF
--- a/packages/tests/src/journey/10-file-format-ui.e2e.ts
+++ b/packages/tests/src/journey/10-file-format-ui.e2e.ts
@@ -105,6 +105,7 @@ test("web picker and drag-drop upload files with safe opened previews", async ({
   ).toHaveCount(0);
   await page.keyboard.press("Escape");
 
+  await page.getByRole("button", { name: "Clear All" }).click();
   await page.getByPlaceholder("Search for anything...").fill(marker);
   await page.keyboard.press("Enter");
   await expect(page.getByText(pickedName).first()).toBeVisible({


### PR DESCRIPTION
## Summary
- clear the prior Markdown search filter before the final MDX lookup
- prevent the production journey from combining two mutually exclusive filter chips

## Validation
- `bun run typecheck --filter=@teak/tests`
- `bun run lint --filter=@teak/tests`
- `bun run pre-commit`
- `git diff --check`

Production run 30190743667 showed the MDX upload and preview passed; only the final rediscovery failed because both search chips remained active.