### PR TITLE
Fix production verification quota and AI resilience

### DIFF
--- a/.github/workflows/prod-e2e.yml
+++ b/.github/workflows/prod-e2e.yml
@@ -26,6 +26,7 @@ env:
   PROD_MCP_URL: https://teakvault.com/mcp
   PROD_E2E_PASSWORD: ${{ secrets.PROD_E2E_PASSWORD }}
   E2E_CLEANUP_TOKEN: ${{ secrets.E2E_CLEANUP_TOKEN }}
+  E2E_EMAIL_DELIVERY_ENABLED: ${{ github.event_name == 'schedule' && 'true' || 'false' }}
   MAILPIT_URL: ${{ secrets.MAILPIT_URL }}
   E2E_EMAIL_DOMAIN: ${{ secrets.E2E_EMAIL_DOMAIN }}
   VITE_PUBLIC_CONVEX_URL: ${{ secrets.VITE_PUBLIC_CONVEX_URL }}

--- a/packages/convex/__tests__/e2eCleanup.test.ts
+++ b/packages/convex/__tests__/e2eCleanup.test.ts
@@ -6,6 +6,7 @@ import {
   isWithinCleanupAge,
   normalizeE2EEmailDomain,
   provisionE2EAccount,
+  requireE2EEmailDomain,
   resolveExactE2ECleanupCandidates,
   resolveOrphanE2ECleanupCandidates,
 } from "../e2eCleanup";
@@ -18,6 +19,12 @@ describe("production E2E cleanup safety", () => {
     for (const domain of ["", "localhost", "@example.com", "-bad.example"]) {
       expect(() => normalizeE2EEmailDomain(domain)).toThrow();
     }
+  });
+
+  test("reports invalid endpoint configuration as unavailable", () => {
+    expect(() => requireE2EEmailDomain("not-a-domain")).toThrow(
+      "E2E account automation is misconfigured"
+    );
   });
 
   test("accepts only the configured E2E namespace", () => {

--- a/packages/convex/__tests__/e2eCleanup.test.ts
+++ b/packages/convex/__tests__/e2eCleanup.test.ts
@@ -5,6 +5,7 @@ import {
   isE2EEmail,
   isWithinCleanupAge,
   normalizeE2EEmailDomain,
+  provisionE2EAccount,
   resolveExactE2ECleanupCandidates,
   resolveOrphanE2ECleanupCandidates,
 } from "../e2eCleanup";
@@ -59,11 +60,92 @@ describe("production E2E cleanup safety", () => {
     ).toBe(false);
   });
 
-  test("registers one schema-free protected cleanup endpoint", () => {
+  test("registers schema-free protected provisioning and cleanup endpoints", () => {
     const plugin = e2eCleanupPlugin({} as never);
     expect(plugin.id).toBe("teak-e2e-cleanup");
     expect(plugin.schema).toBeUndefined();
+    expect(plugin.endpoints?.provisionE2EAccount).toBeDefined();
     expect(plugin.endpoints?.cleanupE2EAccounts).toBeDefined();
+  });
+
+  test("provisions a verified credential account without email delivery", async () => {
+    const findUserByEmail = mock(async () => null);
+    const createUser = mock(async (input: Record<string, unknown>) => ({
+      ...input,
+      id: "user-1",
+    }));
+    const linkAccount = mock(async () => undefined);
+    const deleteUser = mock(async () => undefined);
+    const hash = mock(async (password: string) => `hashed:${password}`);
+    const result = await provisionE2EAccount({
+      authCtx: {
+        internalAdapter: {
+          createUser,
+          deleteUser,
+          findUserByEmail,
+          linkAccount,
+        },
+        password: {
+          config: { maxPasswordLength: 128, minPasswordLength: 8 },
+          hash,
+        },
+      } as never,
+      domain: "tests.example.com",
+      email: "E2E-Primary-123@Tests.Example.Com",
+      password: "safe-password",
+    });
+
+    expect(result).toEqual({
+      email: "e2e-primary-123@tests.example.com",
+    });
+    expect(createUser).toHaveBeenCalledWith({
+      email: "e2e-primary-123@tests.example.com",
+      emailVerified: true,
+      name: "Production E2E",
+    });
+    expect(linkAccount).toHaveBeenCalledWith({
+      accountId: "user-1",
+      password: "hashed:safe-password",
+      providerId: "credential",
+      userId: "user-1",
+    });
+    expect(deleteUser).not.toHaveBeenCalled();
+  });
+
+  test("rejects unsafe provisioning and rolls back credential failures", async () => {
+    const deleteUser = mock(async () => undefined);
+    const authCtx = {
+      internalAdapter: {
+        createUser: mock(async () => ({ id: "user-1" })),
+        deleteUser,
+        findUserByEmail: mock(async () => null),
+        linkAccount: mock(() => {
+          throw new Error("link failed");
+        }),
+      },
+      password: {
+        config: { maxPasswordLength: 128, minPasswordLength: 8 },
+        hash: mock(async () => "hash"),
+      },
+    } as never;
+
+    await expect(
+      provisionE2EAccount({
+        authCtx,
+        domain: "tests.example.com",
+        email: "person@example.com",
+        password: "safe-password",
+      })
+    ).rejects.toThrow("Invalid E2E email");
+    await expect(
+      provisionE2EAccount({
+        authCtx,
+        domain: "tests.example.com",
+        email: "e2e-primary@tests.example.com",
+        password: "safe-password",
+      })
+    ).rejects.toThrow("link failed");
+    expect(deleteUser).toHaveBeenCalledWith("user-1");
   });
 
   test("exact cleanup separates missing, eligible, and unsafe accounts", async () => {

--- a/packages/convex/__tests__/workflows/aiMetadata/generators.test.ts
+++ b/packages/convex/__tests__/workflows/aiMetadata/generators.test.ts
@@ -19,6 +19,7 @@ let maxInputChars: number;
 let maxOutputTokens: number;
 let maxRetries: number;
 let maxValidationRetries: number;
+let isAiProviderCapacityError: any;
 
 const mockResponse = {
   output: {
@@ -39,6 +40,7 @@ describe("aiMetadata generators", () => {
     maxOutputTokens = mod.MAX_AI_METADATA_OUTPUT_TOKENS;
     maxRetries = mod.MAX_AI_METADATA_RETRIES;
     maxValidationRetries = mod.MAX_AI_METADATA_VALIDATION_RETRIES;
+    isAiProviderCapacityError = mod.isAiProviderCapacityError;
   });
 
   beforeEach(() => {
@@ -105,7 +107,7 @@ describe("aiMetadata generators", () => {
   });
 
   test("keeps short metadata input unchanged", () => {
-    expect(maxRetries).toBe(5);
+    expect(maxRetries).toBe(2);
     expect(maxValidationRetries).toBe(2);
     expect(maxOutputTokens).toBe(768);
     expect(boundAiMetadataInput("short content")).toBe("short content");
@@ -164,6 +166,34 @@ describe("aiMetadata generators", () => {
     expect(retryCall.messages[0].content[0].text).toStartWith(
       "JSON validation retry 1:"
     );
+  });
+
+  test("retries AI SDK schema mismatches with a corrective prompt", async () => {
+    mockGenerateText
+      .mockRejectedValueOnce(
+        new Error("No object generated: response did not match schema.")
+      )
+      .mockResolvedValueOnce(mockResponse);
+
+    await generateTextMetadata("content");
+
+    expect(mockGenerateText).toHaveBeenCalledTimes(2);
+    expect(mockGenerateText.mock.calls[1]?.[0].prompt).toStartWith(
+      "JSON validation retry 1:"
+    );
+  });
+
+  test("detects provider capacity errors without treating validation as capacity", () => {
+    expect(
+      isAiProviderCapacityError(
+        new Error("Rate limit reached on tokens per day (TPD), status code 429")
+      )
+    ).toBe(true);
+    expect(
+      isAiProviderCapacityError(
+        new Error("No object generated: response did not match schema")
+      )
+    ).toBe(false);
   });
 
   test("stops after the bounded JSON validation retry budget", async () => {

--- a/packages/convex/__tests__/workflows/steps/metadata.test.ts
+++ b/packages/convex/__tests__/workflows/steps/metadata.test.ts
@@ -222,6 +222,32 @@ describe("metadata handler", () => {
       }
     });
 
+    test("ignores an invalid E2E namespace for normal metadata generation", async () => {
+      const originalDomain = process.env.E2E_EMAIL_DOMAIN;
+      process.env.E2E_EMAIL_DOMAIN = "invalid-domain";
+      mockRunQuery.mockResolvedValueOnce({
+        _id: "c1",
+        content: "content",
+        userId: "user-1",
+      });
+
+      try {
+        const result = await generateHandler(ctx, {
+          cardId: "c1",
+          cardType: "text",
+        });
+
+        expect(result.mode).toBe("completed");
+        expect(aiMocks.generateText).toHaveBeenCalled();
+      } finally {
+        if (originalDomain === undefined) {
+          delete process.env.E2E_EMAIL_DOMAIN;
+        } else {
+          process.env.E2E_EMAIL_DOMAIN = originalDomain;
+        }
+      }
+    });
+
     test("defers metadata when provider capacity is exhausted", async () => {
       mockRunQuery.mockResolvedValue({ _id: "c1", content: "content" });
       aiMocks.generateText.mockRejectedValue(

--- a/packages/convex/__tests__/workflows/steps/metadata.test.ts
+++ b/packages/convex/__tests__/workflows/steps/metadata.test.ts
@@ -190,6 +190,52 @@ describe("metadata handler", () => {
       expect(result.mode).toBe("completed");
       expect(result.aiTags).toEqual(["tag1"]);
     });
+
+    test("skips AI generation for production E2E users", async () => {
+      const originalDomain = process.env.E2E_EMAIL_DOMAIN;
+      process.env.E2E_EMAIL_DOMAIN = "tests.example.com";
+      mockRunQuery
+        .mockResolvedValueOnce({
+          _id: "c1",
+          content: "content",
+          userId: "e2e-user",
+        })
+        .mockResolvedValueOnce({
+          email: "e2e-primary-123@tests.example.com",
+        });
+
+      try {
+        const result = await generateHandler(ctx, {
+          cardId: "c1",
+          cardType: "text",
+        });
+
+        expect(result.mode).toBe("skipped");
+        expect(aiMocks.generateText).not.toHaveBeenCalled();
+        expect(mockRunMutation).toHaveBeenCalled();
+      } finally {
+        if (originalDomain === undefined) {
+          delete process.env.E2E_EMAIL_DOMAIN;
+        } else {
+          process.env.E2E_EMAIL_DOMAIN = originalDomain;
+        }
+      }
+    });
+
+    test("defers metadata when provider capacity is exhausted", async () => {
+      mockRunQuery.mockResolvedValue({ _id: "c1", content: "content" });
+      aiMocks.generateText.mockRejectedValue(
+        new Error("Rate limit reached on tokens per day (TPD): status 429")
+      );
+
+      const result = await generateHandler(ctx, {
+        cardId: "c1",
+        cardType: "text",
+      });
+
+      expect(result.mode).toBe("skipped");
+      expect(mockRunMutation).toHaveBeenCalled();
+    });
   });
 
   describe("text card metadata", () => {

--- a/packages/convex/e2eAccounts.ts
+++ b/packages/convex/e2eAccounts.ts
@@ -1,0 +1,24 @@
+export const normalizeE2EEmailDomain = (value: string): string => {
+  const domain = value.trim().toLowerCase();
+  const isValid =
+    domain.length <= 253 &&
+    domain.includes(".") &&
+    !domain.includes("@") &&
+    domain
+      .split(".")
+      .every((label) => /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label));
+  if (!isValid) {
+    throw new Error("E2E_EMAIL_DOMAIN is invalid");
+  }
+  return domain;
+};
+
+export const isE2EEmail = (email: string, domain: string): boolean => {
+  const normalized = email.trim().toLowerCase();
+  const suffix = `@${domain}`;
+  if (!normalized.endsWith(suffix)) {
+    return false;
+  }
+  const localPart = normalized.slice(0, -suffix.length);
+  return /^e2e-[a-z0-9][a-z0-9-]{0,100}$/.test(localPart);
+};

--- a/packages/convex/e2eCleanup.ts
+++ b/packages/convex/e2eCleanup.ts
@@ -7,6 +7,9 @@ import { z } from "zod";
 import { internal } from "./_generated/api";
 import type { DataModel } from "./_generated/dataModel";
 import type { ActionCtx } from "./_generated/server";
+import { isE2EEmail, normalizeE2EEmailDomain } from "./e2eAccounts";
+
+export { isE2EEmail, normalizeE2EEmailDomain } from "./e2eAccounts";
 
 const CLEANUP_CONCURRENCY = 3;
 const EXACT_EMAIL_LIMIT = 20;
@@ -45,30 +48,10 @@ const requestSchema = z.object({
     .optional(),
 });
 
-export const normalizeE2EEmailDomain = (value: string): string => {
-  const domain = value.trim().toLowerCase();
-  const isValid =
-    domain.length <= 253 &&
-    domain.includes(".") &&
-    !domain.includes("@") &&
-    domain
-      .split(".")
-      .every((label) => /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label));
-  if (!isValid) {
-    throw new Error("E2E_EMAIL_DOMAIN is invalid");
-  }
-  return domain;
-};
-
-export const isE2EEmail = (email: string, domain: string): boolean => {
-  const normalized = email.trim().toLowerCase();
-  const suffix = `@${domain}`;
-  if (!normalized.endsWith(suffix)) {
-    return false;
-  }
-  const localPart = normalized.slice(0, -suffix.length);
-  return /^e2e-[a-z0-9][a-z0-9-]{0,100}$/.test(localPart);
-};
+const provisionRequestSchema = z.object({
+  email: z.string().email().max(254),
+  password: z.string().min(8).max(128),
+});
 
 export const isWithinCleanupAge = ({
   createdAt,
@@ -223,11 +206,81 @@ export const resolveOrphanE2ECleanupCandidates = async ({
   };
 };
 
+export const provisionE2EAccount = async ({
+  authCtx,
+  domain,
+  email,
+  password,
+}: {
+  authCtx: AuthContext;
+  domain: string;
+  email: string;
+  password: string;
+}) => {
+  const normalizedEmail = email.trim().toLowerCase();
+  if (!isE2EEmail(normalizedEmail, domain)) {
+    throw new APIError("BAD_REQUEST", { message: "Invalid E2E email" });
+  }
+  if (
+    password.length < authCtx.password.config.minPasswordLength ||
+    password.length > authCtx.password.config.maxPasswordLength
+  ) {
+    throw new APIError("BAD_REQUEST", { message: "Invalid E2E password" });
+  }
+  if (await authCtx.internalAdapter.findUserByEmail(normalizedEmail)) {
+    throw new APIError("CONFLICT", { message: "E2E account already exists" });
+  }
+
+  const passwordHash = await authCtx.password.hash(password);
+  const user = await authCtx.internalAdapter.createUser({
+    email: normalizedEmail,
+    emailVerified: true,
+    name: "Production E2E",
+  });
+  try {
+    await authCtx.internalAdapter.linkAccount({
+      accountId: user.id,
+      password: passwordHash,
+      providerId: "credential",
+      userId: user.id,
+    });
+  } catch (error) {
+    await authCtx.internalAdapter.deleteUser(user.id);
+    throw error;
+  }
+
+  return { email: normalizedEmail };
+};
+
 export const e2eCleanupPlugin = (
   appCtx: GenericCtx<DataModel>
 ): BetterAuthPlugin => ({
   id: "teak-e2e-cleanup",
   endpoints: {
+    provisionE2EAccount: createAuthEndpoint(
+      "/internal/e2e/provision",
+      { method: "POST", body: provisionRequestSchema },
+      async (ctx) => {
+        const expectedToken = process.env.E2E_CLEANUP_TOKEN;
+        const emailDomain = process.env.E2E_EMAIL_DOMAIN;
+        if (!(expectedToken && emailDomain)) {
+          throw new APIError("SERVICE_UNAVAILABLE", {
+            message: "E2E provisioning is not configured",
+          });
+        }
+        if (ctx.headers?.get("authorization") !== `Bearer ${expectedToken}`) {
+          throw new APIError("UNAUTHORIZED", { message: "Unauthorized" });
+        }
+
+        const result = await provisionE2EAccount({
+          authCtx: ctx.context,
+          domain: normalizeE2EEmailDomain(emailDomain),
+          email: ctx.body.email,
+          password: ctx.body.password,
+        });
+        return ctx.json(result);
+      }
+    ),
     cleanupE2EAccounts: createAuthEndpoint(
       "/internal/e2e/cleanup",
       { method: "POST", body: requestSchema },

--- a/packages/convex/e2eCleanup.ts
+++ b/packages/convex/e2eCleanup.ts
@@ -40,6 +40,16 @@ export interface E2ECleanupResult {
   remainingEligible: boolean;
 }
 
+export const requireE2EEmailDomain = (value: string): string => {
+  try {
+    return normalizeE2EEmailDomain(value);
+  } catch {
+    throw new APIError("SERVICE_UNAVAILABLE", {
+      message: "E2E account automation is misconfigured",
+    });
+  }
+};
+
 const requestSchema = z.object({
   emails: z
     .array(z.string().email().max(254))
@@ -274,7 +284,7 @@ export const e2eCleanupPlugin = (
 
         const result = await provisionE2EAccount({
           authCtx: ctx.context,
-          domain: normalizeE2EEmailDomain(emailDomain),
+          domain: requireE2EEmailDomain(emailDomain),
           email: ctx.body.email,
           password: ctx.body.password,
         });
@@ -296,7 +306,7 @@ export const e2eCleanupPlugin = (
           throw new APIError("UNAUTHORIZED", { message: "Unauthorized" });
         }
 
-        const domain = normalizeE2EEmailDomain(emailDomain);
+        const domain = requireE2EEmailDomain(emailDomain);
         const now = Date.now();
         const exact = ctx.body.emails
           ? await resolveExactE2ECleanupCandidates({

--- a/packages/convex/workflows/aiMetadata/generators.ts
+++ b/packages/convex/workflows/aiMetadata/generators.ts
@@ -40,10 +40,18 @@ const GROQ_LOW_REASONING_JSON_OBJECT_OPTIONS = {
 
 export const MAX_AI_METADATA_INPUT_CHARS = 6000;
 export const MAX_AI_METADATA_OUTPUT_TOKENS = 768;
-export const MAX_AI_METADATA_RETRIES = 5;
+export const MAX_AI_METADATA_RETRIES = 2;
 export const MAX_AI_METADATA_VALIDATION_RETRIES = 2;
 
-const JSON_VALIDATION_ERROR = /failed to validate json|failed_generation/iu;
+const JSON_VALIDATION_ERROR =
+  /failed to validate json|failed_generation|no object generated|response did not match schema|type validation failed/iu;
+const PROVIDER_CAPACITY_ERROR =
+  /\b(?:rate limit(?:ed| reached)?|too many requests|tokens per (?:day|minute)|tpd|tpm|status(?: code)? 429|429)\b/iu;
+
+export const isAiProviderCapacityError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  return PROVIDER_CAPACITY_ERROR.test(message);
+};
 
 const validationRetryPrompt = (prompt: string, attempt: number): string => {
   if (attempt === 0) {
@@ -123,8 +131,8 @@ export const generateTextMetadata = async (content: string, title?: string) => {
             stage: "ai_metadata",
           }),
           model: TEXT_METADATA_MODEL,
-          // Groq's free tier has an 8K TPM window. Keep retrying provider 429s
-          // long enough to cross that reset instead of failing card enrichment.
+          // Keep provider retries bounded so capacity exhaustion does not turn
+          // optional enrichment into a long-running card creation.
           maxRetries: MAX_AI_METADATA_RETRIES,
           maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
           // Static system prompt - will be cached across requests

--- a/packages/convex/workflows/steps/metadata.ts
+++ b/packages/convex/workflows/steps/metadata.ts
@@ -8,9 +8,10 @@
 "use node";
 
 import { v } from "convex/values";
-import { internal } from "../../_generated/api";
+import { components, internal } from "../../_generated/api";
 import { internalAction } from "../../_generated/server";
 import { stageCompleted } from "../../card/processingStatus";
+import { isE2EEmail, normalizeE2EEmailDomain } from "../../e2eAccounts";
 import type { CardType } from "../../schema";
 import { extractVisualStylesFromTags } from "../../shared/constants";
 import { inferFileFormat } from "../../shared/fileFormats";
@@ -22,6 +23,7 @@ import {
   generateImageMetadata,
   generateLinkMetadata,
   generateTextMetadata,
+  isAiProviderCapacityError,
 } from "../aiMetadata/generators";
 import { generateTranscript } from "../aiMetadata/transcript";
 import { extractFileTextForAi } from "../fileProcessing";
@@ -171,151 +173,7 @@ export async function generateHandler(
     };
   }
 
-  let aiTags: string[] = [];
-  let aiSummary = "";
-  let aiTranscript: string | undefined;
-  let visualStyles: string[] | undefined;
-  let confidence = 0.9;
-
-  switch (cardType as CardType) {
-    case "text": {
-      const result = await generateTextMetadata(card.content);
-      aiTags = result.aiTags;
-      aiSummary = result.aiSummary;
-      confidence = 0.95;
-      break;
-    }
-    case "image": {
-      const imageKey = resolveImageAnalysisKey(card);
-
-      if (imageKey) {
-        const imageUrl = await resolveObjectUrl(imageKey);
-        if (imageUrl) {
-          const result = await generateImageMetadata(imageUrl);
-          aiTags = result.aiTags;
-          aiSummary = result.aiSummary;
-          visualStyles = extractVisualStylesFromTags(result.aiTags);
-          confidence = 0.9;
-        }
-      }
-      break;
-    }
-    case "video": {
-      if (card.thumbnailKey) {
-        const thumbnailUrl = await resolveObjectUrl(card.thumbnailKey);
-        if (thumbnailUrl) {
-          const title =
-            card.fileMetadata?.fileName ||
-            (typeof card.content === "string" ? card.content : undefined);
-          const result = await generateImageMetadata(thumbnailUrl, title);
-          aiTags = result.aiTags;
-          aiSummary = result.aiSummary;
-          confidence = 0.88;
-        }
-      }
-      break;
-    }
-    case "audio": {
-      if (card.fileKey) {
-        const audioUrl = await resolveObjectUrl(card.fileKey);
-        if (audioUrl) {
-          const transcriptResult = await generateTranscript(
-            audioUrl,
-            card.fileMetadata?.mimeType
-          );
-          if (transcriptResult) {
-            aiTranscript = transcriptResult;
-            const result = await generateTextMetadata(transcriptResult);
-            aiTags = result.aiTags;
-            aiSummary = result.aiSummary;
-            confidence = 0.85;
-          }
-        }
-      }
-      break;
-    }
-    case "link": {
-      const contentParts = buildLinkContentParts(card);
-
-      const contentToAnalyze = contentParts.join("\n");
-      if (contentToAnalyze.trim()) {
-        const result = await generateLinkMetadata(
-          contentToAnalyze,
-          card.url || card.content
-        );
-        aiTags = result.aiTags;
-        aiSummary = result.aiSummary;
-        confidence = 0.9;
-      }
-      break;
-    }
-    case "document": {
-      const contentParts: string[] = [];
-      if (card.fileMetadata?.fileName) {
-        contentParts.push(card.fileMetadata.fileName);
-      }
-      if (card.fileKey && card.fileMetadata?.fileName) {
-        const format = inferFileFormat({
-          fileName: card.fileMetadata.fileName,
-          mimeType: card.fileMetadata.mimeType,
-        });
-        const fileUrl = await resolveObjectUrl(card.fileKey);
-        if (format && fileUrl) {
-          const extractedText = await extractFileTextForAi(
-            fileUrl,
-            format,
-            card
-          );
-          if (extractedText) {
-            contentParts.push(extractedText);
-          }
-        }
-      }
-      if (card.content?.trim()) {
-        contentParts.push(card.content);
-      }
-      const contentToAnalyze = contentParts.join("\n");
-      if (contentToAnalyze.trim()) {
-        const result = await generateTextMetadata(contentToAnalyze);
-        aiTags = result.aiTags;
-        aiSummary = result.aiSummary;
-        confidence = 0.85;
-      }
-      break;
-    }
-    case "quote": {
-      if (card.content?.trim()) {
-        const result = await generateTextMetadata(card.content);
-        aiTags = result.aiTags;
-        aiSummary = result.aiSummary;
-        confidence = 0.95;
-      }
-      break;
-    }
-    case "palette": {
-      let contentToAnalyze = card.content || "";
-      if (card.colors && card.colors.length > 0) {
-        const colorInfo = card.colors
-          .map(
-            (color: any) =>
-              `${color.hex}${color.name ? ` (${color.name})` : ""}`
-          )
-          .join(", ");
-        contentToAnalyze = `Colors: ${colorInfo}\n${contentToAnalyze}`;
-      }
-      if (contentToAnalyze.trim()) {
-        const result = await generateTextMetadata(contentToAnalyze);
-        aiTags = result.aiTags;
-        aiSummary = result.aiSummary;
-        confidence = 0.9;
-      }
-      break;
-    }
-    default:
-      break;
-  }
-
-  if (aiTags.length === 0 && !aiSummary && !aiTranscript) {
+  const completeWithoutAi = async () => {
     const now = Date.now();
     const processingStatus = card.processingStatus || {};
     await ctx.runMutation((internal as any).ai.mutations.updateCardProcessing, {
@@ -333,6 +191,182 @@ export async function generateHandler(
       confidence: 0,
       mode: "skipped" as const,
     };
+  };
+
+  const configuredE2EDomain = process.env.E2E_EMAIL_DOMAIN;
+  const user =
+    configuredE2EDomain && card.userId
+      ? ((await ctx.runQuery(components.betterAuth.adapter.findOne, {
+          model: "user",
+          where: [{ field: "id", operator: "eq", value: card.userId }],
+        })) as { email?: string } | null)
+      : null;
+  const isProductionE2EUser = Boolean(
+    user?.email &&
+      configuredE2EDomain &&
+      isE2EEmail(user.email, normalizeE2EEmailDomain(configuredE2EDomain))
+  );
+  if (isProductionE2EUser) {
+    return await completeWithoutAi();
+  }
+
+  let aiTags: string[] = [];
+  let aiSummary = "";
+  let aiTranscript: string | undefined;
+  let visualStyles: string[] | undefined;
+  let confidence = 0.9;
+
+  try {
+    switch (cardType as CardType) {
+      case "text": {
+        const result = await generateTextMetadata(card.content);
+        aiTags = result.aiTags;
+        aiSummary = result.aiSummary;
+        confidence = 0.95;
+        break;
+      }
+      case "image": {
+        const imageKey = resolveImageAnalysisKey(card);
+
+        if (imageKey) {
+          const imageUrl = await resolveObjectUrl(imageKey);
+          if (imageUrl) {
+            const result = await generateImageMetadata(imageUrl);
+            aiTags = result.aiTags;
+            aiSummary = result.aiSummary;
+            visualStyles = extractVisualStylesFromTags(result.aiTags);
+            confidence = 0.9;
+          }
+        }
+        break;
+      }
+      case "video": {
+        if (card.thumbnailKey) {
+          const thumbnailUrl = await resolveObjectUrl(card.thumbnailKey);
+          if (thumbnailUrl) {
+            const title =
+              card.fileMetadata?.fileName ||
+              (typeof card.content === "string" ? card.content : undefined);
+            const result = await generateImageMetadata(thumbnailUrl, title);
+            aiTags = result.aiTags;
+            aiSummary = result.aiSummary;
+            confidence = 0.88;
+          }
+        }
+        break;
+      }
+      case "audio": {
+        if (card.fileKey) {
+          const audioUrl = await resolveObjectUrl(card.fileKey);
+          if (audioUrl) {
+            const transcriptResult = await generateTranscript(
+              audioUrl,
+              card.fileMetadata?.mimeType
+            );
+            if (transcriptResult) {
+              aiTranscript = transcriptResult;
+              const result = await generateTextMetadata(transcriptResult);
+              aiTags = result.aiTags;
+              aiSummary = result.aiSummary;
+              confidence = 0.85;
+            }
+          }
+        }
+        break;
+      }
+      case "link": {
+        const contentParts = buildLinkContentParts(card);
+
+        const contentToAnalyze = contentParts.join("\n");
+        if (contentToAnalyze.trim()) {
+          const result = await generateLinkMetadata(
+            contentToAnalyze,
+            card.url || card.content
+          );
+          aiTags = result.aiTags;
+          aiSummary = result.aiSummary;
+          confidence = 0.9;
+        }
+        break;
+      }
+      case "document": {
+        const contentParts: string[] = [];
+        if (card.fileMetadata?.fileName) {
+          contentParts.push(card.fileMetadata.fileName);
+        }
+        if (card.fileKey && card.fileMetadata?.fileName) {
+          const format = inferFileFormat({
+            fileName: card.fileMetadata.fileName,
+            mimeType: card.fileMetadata.mimeType,
+          });
+          const fileUrl = await resolveObjectUrl(card.fileKey);
+          if (format && fileUrl) {
+            const extractedText = await extractFileTextForAi(
+              fileUrl,
+              format,
+              card
+            );
+            if (extractedText) {
+              contentParts.push(extractedText);
+            }
+          }
+        }
+        if (card.content?.trim()) {
+          contentParts.push(card.content);
+        }
+        const contentToAnalyze = contentParts.join("\n");
+        if (contentToAnalyze.trim()) {
+          const result = await generateTextMetadata(contentToAnalyze);
+          aiTags = result.aiTags;
+          aiSummary = result.aiSummary;
+          confidence = 0.85;
+        }
+        break;
+      }
+      case "quote": {
+        if (card.content?.trim()) {
+          const result = await generateTextMetadata(card.content);
+          aiTags = result.aiTags;
+          aiSummary = result.aiSummary;
+          confidence = 0.95;
+        }
+        break;
+      }
+      case "palette": {
+        let contentToAnalyze = card.content || "";
+        if (card.colors && card.colors.length > 0) {
+          const colorInfo = card.colors
+            .map(
+              (color: any) =>
+                `${color.hex}${color.name ? ` (${color.name})` : ""}`
+            )
+            .join(", ");
+          contentToAnalyze = `Colors: ${colorInfo}\n${contentToAnalyze}`;
+        }
+        if (contentToAnalyze.trim()) {
+          const result = await generateTextMetadata(contentToAnalyze);
+          aiTags = result.aiTags;
+          aiSummary = result.aiSummary;
+          confidence = 0.9;
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  } catch (error) {
+    if (!isAiProviderCapacityError(error)) {
+      throw error;
+    }
+    console.warn("[workflow/metadata] AI capacity unavailable; deferring", {
+      cardId,
+      cardType,
+    });
+    return await completeWithoutAi();
+  }
+
+  if (aiTags.length === 0 && !aiSummary && !aiTranscript) {
+    return await completeWithoutAi();
   }
 
   // Update card with AI metadata

--- a/packages/convex/workflows/steps/metadata.ts
+++ b/packages/convex/workflows/steps/metadata.ts
@@ -193,7 +193,16 @@ export async function generateHandler(
     };
   };
 
-  const configuredE2EDomain = process.env.E2E_EMAIL_DOMAIN;
+  let configuredE2EDomain: string | undefined;
+  try {
+    configuredE2EDomain = process.env.E2E_EMAIL_DOMAIN
+      ? normalizeE2EEmailDomain(process.env.E2E_EMAIL_DOMAIN)
+      : undefined;
+  } catch (error) {
+    console.warn("[workflow/metadata] Ignoring invalid E2E email domain", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
   const user =
     configuredE2EDomain && card.userId
       ? ((await ctx.runQuery(components.betterAuth.adapter.findOne, {
@@ -204,7 +213,7 @@ export async function generateHandler(
   const isProductionE2EUser = Boolean(
     user?.email &&
       configuredE2EDomain &&
-      isE2EEmail(user.email, normalizeE2EEmailDomain(configuredE2EDomain))
+      isE2EEmail(user.email, configuredE2EDomain)
   );
   if (isProductionE2EUser) {
     return await completeWithoutAi();

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -15,8 +15,8 @@ bun run --cwd packages/tests teardown
 Required secret:
 
 - `PROD_E2E_PASSWORD`: strong password used only for throwaway `e2e-*` production accounts. The password is never written to `.state`.
-- `E2E_CLEANUP_TOKEN`: bearer token shared only by GitHub Actions and the production backend. It authorizes the server-side E2E account cleanup endpoint.
-- `MAILPIT_URL`: private Mailpit HTTP origin used for verification and reset email polling.
+- `E2E_CLEANUP_TOKEN`: bearer token shared only by GitHub Actions and the production backend. It authorizes server-side E2E account provisioning and cleanup.
+- `MAILPIT_URL`: private Mailpit HTTP origin used by the nightly signup and password-reset email canaries.
 - `E2E_EMAIL_DOMAIN`: private MX-routed domain used for throwaway account inboxes.
 
 Useful variables:
@@ -26,8 +26,9 @@ Useful variables:
 - `PROD_API_URL` defaults to `https://teakvault.com/api`
 - `PROD_MCP_URL` defaults to `https://teakvault.com/mcp`
 - `VITE_PUBLIC_CONVEX_URL` and `VITE_PUBLIC_CONVEX_SITE_URL` are required for the extension build. You can use matching `NEXT_PUBLIC_CONVEX_URL` and `NEXT_PUBLIC_CONVEX_SITE_URL` values locally.
+- `E2E_EMAIL_DELIVERY_ENABLED=true` opts into the two real email-delivery canaries. Scheduled GitHub runs enable it; manual runs leave it disabled.
 
-Cleanup is browserless. Exact accounts created by a test are removed during teardown, while the scheduled sweep discovers orphan accounts directly from the production auth database. The backend accepts only the configured `e2e-*` email namespace, enforces account-age bounds, caps each sweep, and reuses the same Teak data-deletion path as user-initiated account deletion. Mailpit messages are deleted separately by exact message ID.
+Most test accounts are provisioned as already-verified users through the token-protected backend endpoint, so manual runs send no email. The nightly run sends one signup verification and one password-reset message to preserve real delivery coverage. Cleanup is browserless. Exact accounts created by a test are removed during teardown, while the scheduled sweep discovers orphan accounts directly from the production auth database. The backend accepts only the configured `e2e-*` email namespace, enforces account-age bounds, caps each sweep, and reuses the same Teak data-deletion path as user-initiated account deletion. Mailpit messages are deleted separately by exact message ID.
 
 For local parity with GitHub Actions, put the required values in `.env.production-e2e.local` at the repo root and run `bun run --cwd packages/tests e2e:prod:local`. The local runner installs Playwright browsers, executes preflight, docs, journey, browser matrix, extension, and teardown steps, then preserves separate reports under `packages/tests/playwright-report`.
 

--- a/packages/tests/src/extension/save-page.e2e.ts
+++ b/packages/tests/src/extension/save-page.e2e.ts
@@ -3,7 +3,6 @@ import { resolve } from "node:path";
 import { chromium, expect, test } from "@playwright/test";
 import { cleanupE2EAccounts } from "../helpers/e2e-cleanup";
 import { env } from "../helpers/env";
-import { deleteMessagesFor } from "../helpers/mailpit";
 import { clientFor, createAccount } from "../helpers/prod";
 
 interface ExtensionChrome {
@@ -164,8 +163,7 @@ test("extension saves a selected file and safe page asset with private URL fallb
       )
     ).toBe(false);
   } finally {
-    await cleanupE2EAccounts([account.email]);
-    await deleteMessagesFor(account.email);
     await context.close();
+    await cleanupE2EAccounts([account.email]);
   }
 });

--- a/packages/tests/src/helpers/cleanup.test.ts
+++ b/packages/tests/src/helpers/cleanup.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
+  assertE2EProvisioningReady,
   cleanupE2EAccounts,
   isConfiguredE2EEmail,
   isE2ECleanupResult,
@@ -17,12 +18,14 @@ const originalFetch = globalThis.fetch;
 const originalCleanupToken = env.cleanupToken;
 const originalConvexSiteUrl = env.convexSiteUrl;
 const originalEmailDomain = env.emailDomain;
+const originalPassword = env.password;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
   env.cleanupToken = originalCleanupToken;
   env.convexSiteUrl = originalConvexSiteUrl;
   env.emailDomain = originalEmailDomain;
+  env.password = originalPassword;
 });
 
 describe("production E2E cleanup helpers", () => {
@@ -119,5 +122,41 @@ describe("production E2E cleanup helpers", () => {
     await expect(
       provisionE2EAccount("person@example.com", "safe-password")
     ).rejects.toThrow("provisioning email is invalid");
+  });
+
+  test("retries preflight cleanup after a failed first attempt", async () => {
+    env.cleanupToken = "test-token";
+    env.convexSiteUrl = "https://example.convex.site";
+    env.emailDomain = "tests.example.com";
+    env.password = "safe-password";
+    let cleanupAttempts = 0;
+    globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const body = JSON.parse(String(init?.body));
+      if (url.endsWith("/api/auth/internal/e2e/provision")) {
+        return Response.json({ email: body.email });
+      }
+      cleanupAttempts += 1;
+      if (cleanupAttempts === 1) {
+        return Response.json(
+          { message: "temporarily unavailable" },
+          {
+            status: 503,
+          }
+        );
+      }
+      return Response.json({
+        alreadyDeleted: [],
+        deleted: body.emails,
+        failures: [],
+        ignoredOutOfRange: [],
+        remainingEligible: false,
+      });
+    }) as unknown as typeof fetch;
+
+    await expect(assertE2EProvisioningReady()).rejects.toThrow(
+      "invalid response (503)"
+    );
+    expect(cleanupAttempts).toBe(2);
   });
 });

--- a/packages/tests/src/helpers/cleanup.test.ts
+++ b/packages/tests/src/helpers/cleanup.test.ts
@@ -3,6 +3,7 @@ import {
   cleanupE2EAccounts,
   isConfiguredE2EEmail,
   isE2ECleanupResult,
+  provisionE2EAccount,
   summarizeE2ECleanup,
 } from "./e2e-cleanup";
 import { env } from "./env";
@@ -15,11 +16,13 @@ import {
 const originalFetch = globalThis.fetch;
 const originalCleanupToken = env.cleanupToken;
 const originalConvexSiteUrl = env.convexSiteUrl;
+const originalEmailDomain = env.emailDomain;
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
   env.cleanupToken = originalCleanupToken;
   env.convexSiteUrl = originalConvexSiteUrl;
+  env.emailDomain = originalEmailDomain;
 });
 
 describe("production E2E cleanup helpers", () => {
@@ -90,5 +93,31 @@ describe("production E2E cleanup helpers", () => {
     await expect(cleanupE2EAccounts()).rejects.toThrow(
       "invalid response (401)"
     );
+  });
+
+  test("provisions only configured E2E accounts through the protected endpoint", async () => {
+    env.cleanupToken = "test-token";
+    env.convexSiteUrl = "https://example.convex.site";
+    env.emailDomain = "tests.example.com";
+    const fetchMock = mock(
+      async (_input: RequestInfo | URL, init?: RequestInit) =>
+        Response.json({
+          email: JSON.parse(String(init?.body)).email,
+        })
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await provisionE2EAccount("e2e-primary@tests.example.com", "safe-password");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toEndWith("/api/auth/internal/e2e/provision");
+    expect(init?.headers).toEqual({
+      Authorization: "Bearer test-token",
+      "Content-Type": "application/json",
+    });
+    await expect(
+      provisionE2EAccount("person@example.com", "safe-password")
+    ).rejects.toThrow("provisioning email is invalid");
   });
 });

--- a/packages/tests/src/helpers/e2e-cleanup.ts
+++ b/packages/tests/src/helpers/e2e-cleanup.ts
@@ -132,8 +132,17 @@ export const assertE2ECleanupReady = async (): Promise<void> => {
 export const assertE2EProvisioningReady = async (): Promise<void> => {
   const email = `e2e-preflight-${Date.now()}-provision@${env.emailDomain}`;
   await provisionE2EAccount(email, env.password);
-  const result = await cleanupE2EAccounts([email]);
-  if (!result.deleted.includes(email)) {
-    throw new Error("Production E2E provisioning preflight did not clean up");
+  let cleanupConfirmed = false;
+  try {
+    const result = await cleanupE2EAccounts([email]);
+    cleanupConfirmed =
+      result.deleted.includes(email) || result.alreadyDeleted.includes(email);
+    if (!cleanupConfirmed) {
+      throw new Error("Production E2E provisioning preflight did not clean up");
+    }
+  } finally {
+    if (!cleanupConfirmed) {
+      await cleanupE2EAccounts([email]).catch(() => undefined);
+    }
   }
 };

--- a/packages/tests/src/helpers/e2e-cleanup.ts
+++ b/packages/tests/src/helpers/e2e-cleanup.ts
@@ -1,4 +1,4 @@
-import { env, requireE2ECleanup } from "./env";
+import { env, requireE2ECleanup, requireE2ENamespace } from "./env";
 
 export interface E2ECleanupResult {
   alreadyDeleted: string[];
@@ -86,6 +86,39 @@ export const cleanupE2EAccounts = async (
   return result;
 };
 
+export const provisionE2EAccount = async (
+  email: string,
+  password: string
+): Promise<void> => {
+  requireE2ECleanup();
+  requireE2ENamespace();
+  if (!isConfiguredE2EEmail(email)) {
+    throw new Error("Production E2E provisioning email is invalid");
+  }
+  const response = await fetch(
+    `${env.convexSiteUrl}/api/auth/internal/e2e/provision`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.cleanupToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ email, password }),
+    }
+  );
+  const payload: unknown = await response.json().catch(() => null);
+  if (
+    !(
+      response.ok &&
+      payload &&
+      typeof payload === "object" &&
+      (payload as { email?: unknown }).email === email.toLowerCase()
+    )
+  ) {
+    throw new Error(`Production E2E provisioning failed (${response.status})`);
+  }
+};
+
 export const assertE2ECleanupReady = async (): Promise<void> => {
   const email = `e2e-preflight-${Date.now()}-probe@${env.emailDomain}`;
   const result = await cleanupE2EAccounts([email]);
@@ -93,5 +126,14 @@ export const assertE2ECleanupReady = async (): Promise<void> => {
     throw new Error(
       "Production E2E cleanup preflight was not side-effect free"
     );
+  }
+};
+
+export const assertE2EProvisioningReady = async (): Promise<void> => {
+  const email = `e2e-preflight-${Date.now()}-provision@${env.emailDomain}`;
+  await provisionE2EAccount(email, env.password);
+  const result = await cleanupE2EAccounts([email]);
+  if (!result.deleted.includes(email)) {
+    throw new Error("Production E2E provisioning preflight did not clean up");
   }
 };

--- a/packages/tests/src/helpers/env.ts
+++ b/packages/tests/src/helpers/env.ts
@@ -12,6 +12,7 @@ export const env = {
     ""
   ),
   cleanupToken: process.env.E2E_CLEANUP_TOKEN ?? "",
+  emailDeliveryEnabled: process.env.E2E_EMAIL_DELIVERY_ENABLED === "true",
   mailpitUrl: trim(process.env.MAILPIT_URL, ""),
   emailDomain: process.env.E2E_EMAIL_DOMAIN?.trim() || "",
   password: process.env.PROD_E2E_PASSWORD || "",
@@ -35,6 +36,12 @@ export const requireE2ECleanup = () => {
     throw new Error(
       "E2E_CLEANUP_TOKEN and VITE_PUBLIC_CONVEX_SITE_URL are required"
     );
+  }
+};
+
+export const requireE2ENamespace = () => {
+  if (!env.emailDomain) {
+    throw new Error("E2E_EMAIL_DOMAIN is required");
   }
 };
 

--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -5,6 +5,7 @@ import {
   type Page,
 } from "@playwright/test";
 import { createTeakClient } from "@teak/convex/sdk";
+import { provisionE2EAccount } from "./e2e-cleanup";
 import { env, requirePassword, uniqueEmail } from "./env";
 import { waitForEmail } from "./mailpit";
 import { type AccountState, rememberAccount, updateState } from "./run-state";
@@ -109,9 +110,15 @@ export const generateApiKey = async (page: Page) => {
 export const createAccount = async (
   page: Page,
   label = "acct",
-  options: { remember?: boolean } = {}
+  options: { remember?: boolean; viaEmail?: boolean } = {}
 ) => {
-  const email = await signUp(page, uniqueEmail(label));
+  const email = options.viaEmail
+    ? await signUp(page, uniqueEmail(label))
+    : uniqueEmail(label);
+  if (!options.viaEmail) {
+    await provisionE2EAccount(email, requirePassword());
+    await signIn(page, email);
+  }
   const apiKey = await generateApiKey(page);
   const account = { email, apiKey };
   if (options.remember !== false) {

--- a/packages/tests/src/journey/01-signup.setup.ts
+++ b/packages/tests/src/journey/01-signup.setup.ts
@@ -1,5 +1,5 @@
 import { test } from "@playwright/test";
-import { assertMailpitReady } from "../helpers/mailpit";
+import { env } from "../helpers/env";
 import { createAccount } from "../helpers/prod";
 import { storageStateFile, updateState } from "../helpers/run-state";
 
@@ -9,8 +9,9 @@ test("create isolated verified production accounts and API keys", async ({
   browser,
   page,
 }) => {
-  await assertMailpitReady();
-  const account = await createAccount(page, "primary");
+  const account = await createAccount(page, "primary", {
+    viaEmail: env.emailDeliveryEnabled,
+  });
   updateState((state) => {
     state.primary = account;
   });

--- a/packages/tests/src/journey/06-security.e2e.ts
+++ b/packages/tests/src/journey/06-security.e2e.ts
@@ -1,7 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { apiFetch } from "../helpers/api";
 import { cleanupE2EAccounts } from "../helpers/e2e-cleanup";
-import { deleteMessagesFor } from "../helpers/mailpit";
 import { clientFor, createAccount, newAnonymousContext } from "../helpers/prod";
 import { readState } from "../helpers/run-state";
 
@@ -60,8 +59,7 @@ test("cross-tenant, revoked-key, hostile input, headers, and cookie security", a
       )
     ).toBe(true);
   } finally {
-    await cleanupE2EAccounts([second.email]);
-    await deleteMessagesFor(second.email);
     await secondContext.close();
+    await cleanupE2EAccounts([second.email]);
   }
 });

--- a/packages/tests/src/journey/07-account-flows.e2e.ts
+++ b/packages/tests/src/journey/07-account-flows.e2e.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { requirePassword } from "../helpers/env";
+import { env, requirePassword } from "../helpers/env";
 import { waitForEmail } from "../helpers/mailpit";
 import {
   appPath,
@@ -9,7 +9,11 @@ import {
 } from "../helpers/prod";
 import { readState, updateState } from "../helpers/run-state";
 
-test("password reset and Polar checkout entry", async ({ browser }) => {
+test("scheduled email canary resets the password", async ({ browser }) => {
+  test.skip(
+    !env.emailDeliveryEnabled,
+    "Real email delivery runs only in the nightly production canary"
+  );
   const { primary } = readState();
   if (!primary?.email) {
     throw new Error("Missing primary account");
@@ -45,6 +49,20 @@ test("password reset and Polar checkout entry", async ({ browser }) => {
     await page.getByRole("button", { name: /login|sign in/i }).click();
     await expect(page.getByText(/invalid|incorrect/i)).toBeVisible();
     await signIn(page, primary.email, nextPassword);
+  } finally {
+    await context.close();
+  }
+});
+
+test("Polar checkout entry stays usable", async ({ browser }) => {
+  const { primary } = readState();
+  if (!primary?.email) {
+    throw new Error("Missing primary account");
+  }
+  const context = await newAnonymousContext(browser);
+  const page = await context.newPage();
+  try {
+    await signIn(page, primary.email, passwordFor(primary));
     await page.goto(appPath("/settings"));
     await page.getByRole("button", { name: "Upgrade" }).click();
     await expect(

--- a/packages/tests/src/matrix/journey-lite.e2e.ts
+++ b/packages/tests/src/matrix/journey-lite.e2e.ts
@@ -1,6 +1,5 @@
 import { expect, test } from "@playwright/test";
 import { cleanupE2EAccounts } from "../helpers/e2e-cleanup";
-import { deleteMessagesFor } from "../helpers/mailpit";
 import { clickVisibleControl, createAccount } from "../helpers/prod";
 
 test.setTimeout(180_000);
@@ -33,7 +32,7 @@ test("signup, create, and search", async ({ page }) => {
     await search.fill(marker);
     await expect(savedCard).toBeVisible();
   } finally {
+    await page.context().close();
     await cleanupE2EAccounts([account.email]);
-    await deleteMessagesFor(account.email);
   }
 });

--- a/packages/tests/src/scripts/preflight.ts
+++ b/packages/tests/src/scripts/preflight.ts
@@ -1,9 +1,13 @@
 import { resolveMx } from "node:dns/promises";
 import { Socket } from "node:net";
-import { assertE2ECleanupReady } from "../helpers/e2e-cleanup";
+import {
+  assertE2ECleanupReady,
+  assertE2EProvisioningReady,
+} from "../helpers/e2e-cleanup";
 import {
   env,
   requireE2ECleanup,
+  requireE2ENamespace,
   requireMailpit,
   requirePassword,
 } from "../helpers/env";
@@ -27,27 +31,33 @@ const checkPort = (host: string, port: number) =>
 
 const main = async () => {
   requirePassword();
-  requireMailpit();
   requireE2ECleanup();
-  await assertMailpitReady();
+  requireE2ENamespace();
   await assertE2ECleanupReady();
+  await assertE2EProvisioningReady();
 
-  const mx = await resolveMx(env.emailDomain).catch(() => []);
-  if (!mx.length) {
-    throw new Error(`No MX records found for ${env.emailDomain}`);
+  if (env.emailDeliveryEnabled) {
+    requireMailpit();
+    await assertMailpitReady();
+    const mx = await resolveMx(env.emailDomain).catch(() => []);
+    if (!mx.length) {
+      throw new Error(`No MX records found for ${env.emailDomain}`);
+    }
+
+    mx.sort((a, b) => a.priority - b.priority);
+    await checkPort(mx[0].exchange, 25);
+
+    console.log(
+      `Production E2E preflight ok: provisioning=direct email=${env.emailDomain} -> ${mx[0].exchange}:25`
+    );
+    return;
   }
-
-  mx.sort((a, b) => a.priority - b.priority);
-  await checkPort(mx[0].exchange, 25);
-
-  console.log(
-    `Mailpit preflight ok: ${env.emailDomain} -> ${mx[0].exchange}:25`
-  );
+  console.log("Production E2E preflight ok: provisioning=direct email=skipped");
 };
 
 main().catch((error) => {
   console.error(
-    `Mailpit preflight failed: ${error instanceof Error ? error.message : String(error)}`
+    `Production E2E preflight failed: ${error instanceof Error ? error.message : String(error)}`
   );
   process.exit(1);
 });

--- a/packages/tests/src/scripts/sweep.ts
+++ b/packages/tests/src/scripts/sweep.ts
@@ -3,6 +3,7 @@ import {
   isConfiguredE2EEmail,
   summarizeE2ECleanup,
 } from "../helpers/e2e-cleanup";
+import { env } from "../helpers/env";
 import {
   deleteMailpitMessages,
   listMailpitMessages,
@@ -10,18 +11,21 @@ import {
 } from "../helpers/mailpit";
 
 const cleanup = await cleanupE2EAccounts();
-const messages = await listMailpitMessages();
-const recipients = [
-  ...new Set(
-    messages
-      .flatMap((message) => message.To ?? [])
-      .map((recipient) => recipient.Address.toLowerCase())
-      .filter((email) => isConfiguredE2EEmail(email))
-  ),
-];
-const deletedMessages = await deleteMailpitMessages(
-  messageIdsForRecipients(messages, recipients)
-);
+const deletedMessages = env.emailDeliveryEnabled
+  ? await listMailpitMessages().then((messages) => {
+      const recipients = [
+        ...new Set(
+          messages
+            .flatMap((message) => message.To ?? [])
+            .map((recipient) => recipient.Address.toLowerCase())
+            .filter((email) => isConfiguredE2EEmail(email))
+        ),
+      ];
+      return deleteMailpitMessages(
+        messageIdsForRecipients(messages, recipients)
+      );
+    })
+  : 0;
 
 console.log(
   `Production E2E sweep complete: ${summarizeE2ECleanup(cleanup)} mailpitDeleted=${deletedMessages}`

--- a/packages/tests/src/scripts/teardown.ts
+++ b/packages/tests/src/scripts/teardown.ts
@@ -2,6 +2,7 @@ import {
   cleanupE2EAccounts,
   summarizeE2ECleanup,
 } from "../helpers/e2e-cleanup";
+import { env } from "../helpers/env";
 import {
   deleteMailpitMessages,
   listMailpitMessages,
@@ -38,13 +39,16 @@ updateState((state) => {
   }
 });
 
-const messages = await listMailpitMessages();
-const deletedMessages = await deleteMailpitMessages(
-  messageIdsForRecipients(
-    messages,
-    accounts.map((account) => account.email)
-  )
-);
+const deletedMessages = env.emailDeliveryEnabled
+  ? await listMailpitMessages().then((messages) =>
+      deleteMailpitMessages(
+        messageIdsForRecipients(
+          messages,
+          accounts.map((account) => account.email)
+        )
+      )
+    )
+  : 0;
 console.log(
   `Production E2E teardown complete: ${summarizeE2ECleanup(cleanup)} mailpitDeleted=${deletedMessages}`
 );


### PR DESCRIPTION
## Summary
- provision isolated production E2E accounts through the protected backend so manual runs send zero email
- retain exactly two nightly email canaries for signup verification and password reset
- skip AI enrichment for throwaway E2E users and defer optional metadata safely when provider capacity is exhausted
- retry malformed structured AI output with a corrective prompt and bounded retry budget
- close browser contexts before account cleanup to prevent Safari Better Auth abort noise

## Production findings
- the AI and pipeline alerts were caused by the Groq daily token limit plus retry amplification
- the structured-output issue returned tags as a string instead of an array
- the OAuth monitor self-resolved and requires live verification, not a behavior change

## Validation
- bun run test
- bun run typecheck
- bun run lint
- bun run pre-commit
- git diff --check
- focused AI, cleanup, provisioning, and production-test helper suites

The full production E2E workflow is intentionally not rerun today to protect the exhausted Resend quota.