### PR TITLE
Add zero-email production E2E preflight mode

### DIFF
--- a/.github/workflows/prod-e2e.yml
+++ b/.github/workflows/prod-e2e.yml
@@ -5,6 +5,11 @@ on:
     - cron: "17 5 * * *"
   workflow_dispatch:
     inputs:
+      preflight_only:
+        description: Run zero-email production preflight without E2E suites
+        default: false
+        required: false
+        type: boolean
       sweep:
         description: Run orphan account sweep after tests
         default: true
@@ -44,6 +49,7 @@ jobs:
 
   journey:
     needs: gate
+    if: ${{ !inputs.preflight_only }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
@@ -67,6 +73,7 @@ jobs:
 
   docs:
     needs: gate
+    if: ${{ !inputs.preflight_only }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -86,7 +93,7 @@ jobs:
 
   matrix:
     needs: [gate, journey]
-    if: always() && needs.gate.result == 'success'
+    if: always() && needs.gate.result == 'success' && !inputs.preflight_only
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -106,7 +113,7 @@ jobs:
 
   extension:
     needs: gate
-    if: always() && needs.gate.result == 'success'
+    if: always() && needs.gate.result == 'success' && !inputs.preflight_only
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -127,7 +134,7 @@ jobs:
 
   sweep:
     needs: gate
-    if: always() && needs.gate.result == 'success' && (github.event_name == 'schedule' || inputs.sweep)
+    if: always() && needs.gate.result == 'success' && !inputs.preflight_only && (github.event_name == 'schedule' || inputs.sweep)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/packages/tests/README.md
+++ b/packages/tests/README.md
@@ -30,6 +30,9 @@ Useful variables:
 
 Most test accounts are provisioned as already-verified users through the token-protected backend endpoint, so manual runs send no email. The nightly run sends one signup verification and one password-reset message to preserve real delivery coverage. Cleanup is browserless. Exact accounts created by a test are removed during teardown, while the scheduled sweep discovers orphan accounts directly from the production auth database. The backend accepts only the configured `e2e-*` email namespace, enforces account-age bounds, caps each sweep, and reuses the same Teak data-deletion path as user-initiated account deletion. Mailpit messages are deleted separately by exact message ID.
 
+For a zero-email health check without the browser suites, manually dispatch the
+Production E2E workflow with `preflight_only` enabled.
+
 For local parity with GitHub Actions, put the required values in `.env.production-e2e.local` at the repo root and run `bun run --cwd packages/tests e2e:prod:local`. The local runner installs Playwright browsers, executes preflight, docs, journey, browser matrix, extension, and teardown steps, then preserves separate reports under `packages/tests/playwright-report`.
 
 Mailpit preflight:


### PR DESCRIPTION
## Summary
- add a manual preflight-only Production E2E mode
- skip browser suites and sweeps while still verifying direct provisioning, cleanup, and service health
- document the zero-email workflow

## Validation
- bun run pre-commit
- git diff --check

This lets us verify production today without consuming Resend quota.