### PR TITLE
feat: add live markdown editing

### DIFF
--- a/apps/docs/src/content/changelog/2026-07.mdx
+++ b/apps/docs/src/content/changelog/2026-07.mdx
@@ -19,7 +19,7 @@ date: "2026-07-10"
 - File uploads now report progress accurately and retry brief storage hiccups, so a first drag, drop, or paste is less likely to fail.
 - File uploads now support source code, Markdown and MDX, design tokens, ZIP, Office documents, SVG, HEIC, animated GIF, Figma files, and more across web, mobile, desktop, browser extension, API, CLI, and MCP, with a 100 MB limit and safe previews or file facts.
 - Markdown and source-file previews now begin loading before you open them, reuse recent downloads, and show a clear loading state on slower connections.
-- Markdown uploads now become editable text cards.
+- Text cards now show Markdown formatting while you write, with quick selection controls for emphasis, links, and code.
 - Desktop sign-in confirmation now includes a clear success indicator.
 - Choosing a file in the browser extension now keeps the popup open until the upload finishes or shows an error you can act on.
 - Search now clears old cards when a query has no matches, so empty results show accurately.

--- a/apps/web/src/tests/auth.e2e.ts
+++ b/apps/web/src/tests/auth.e2e.ts
@@ -187,7 +187,9 @@ test.describe("Authentication Flows", () => {
       await expect(page).toHaveURL("/");
 
       // Check that we're logged in by looking for authenticated content
-      await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
+      await expect(
+        page.getByRole("textbox", { name: "Markdown content" })
+      ).toBeVisible();
     });
 
     test("should show error for invalid credentials", async ({ page }) => {

--- a/apps/web/src/tests/card-creation.e2e.ts
+++ b/apps/web/src/tests/card-creation.e2e.ts
@@ -433,7 +433,7 @@ test.describe("Card Creation", () => {
       await page.waitForTimeout(1000);
 
       // Composer should be empty
-      await expect(composer).toHaveValue("");
+      await expect(composer).toHaveText("");
     });
   });
 });

--- a/apps/web/src/tests/card-creation.e2e.ts
+++ b/apps/web/src/tests/card-creation.e2e.ts
@@ -319,6 +319,46 @@ test.describe("Card Creation", () => {
       expect(isVisible).toBe(false);
     });
 
+    test("should overlay composer actions without changing its height", async ({
+      page,
+    }) => {
+      const uiHelper = new UiHelper(page);
+      const composer = uiHelper.getComposer();
+      const form = page.locator("form[data-card-creation-status]");
+      const emptyHeight = await form.evaluate(
+        (element) => element.getBoundingClientRect().height
+      );
+
+      await composer.fill("A short note");
+      await expect(uiHelper.getSaveButton()).toBeVisible();
+      const actionsHeight = await form.evaluate(
+        (element) => element.getBoundingClientRect().height
+      );
+
+      expect(actionsHeight).toBe(emptyHeight);
+    });
+
+    test("should release composer focus when the page margin is clicked", async ({
+      page,
+    }) => {
+      const uiHelper = new UiHelper(page);
+      const composer = uiHelper.getComposer();
+      const form = page.locator("form[data-card-creation-status]");
+      const formBounds = await form.boundingBox();
+      if (!formBounds) {
+        throw new Error("Add card form is not visible");
+      }
+
+      await composer.click();
+      await expect(composer).toBeFocused();
+      await page.mouse.click(
+        Math.max(1, formBounds.x - 8),
+        formBounds.y + formBounds.height / 2
+      );
+
+      await expect(composer).not.toBeFocused();
+    });
+
     test("should handle very long text", async ({ page }) => {
       const uiHelper = new UiHelper(page);
       const longText = "A".repeat(5000);

--- a/apps/web/src/tests/cards.e2e.ts
+++ b/apps/web/src/tests/cards.e2e.ts
@@ -28,11 +28,13 @@ test.describe("Text Cards", () => {
     // Update card
     await createdCard.click();
 
-    const editor = page.getByPlaceholder("Enter your text...");
+    const editor = page
+      .getByRole("dialog")
+      .getByRole("textbox", { name: "Markdown content" });
     await expect(editor).toBeVisible();
     await editor.fill(updatedContent);
     await page.locator('button:has-text("Save changes"):visible').click();
-    await expect(editor).toHaveValue(updatedContent);
+    await expect(editor).toContainText(updatedContent);
 
     // Close modal
     await uiHelper.closeModal();

--- a/apps/web/src/tests/onboarding.e2e.ts
+++ b/apps/web/src/tests/onboarding.e2e.ts
@@ -111,7 +111,9 @@ test.describe("Onboarding Journey", () => {
     await authHelper.signInWithEmailAndPassword(TEST_EMAIL!, TEST_PASSWORD!);
 
     // Check for key UI elements
-    await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
+    await expect(
+      page.getByRole("textbox", { name: "Markdown content" })
+    ).toBeVisible();
 
     // Check for search bar
     await expect(page.getByPlaceholder("Search for anything...")).toBeVisible();

--- a/apps/web/src/tests/settings.e2e.ts
+++ b/apps/web/src/tests/settings.e2e.ts
@@ -50,7 +50,9 @@ test.describe("Settings Navigation and Management", () => {
 
       // Should be on home page
       await expect(page).toHaveURL("/");
-      await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
+      await expect(
+        page.getByRole("textbox", { name: "Markdown content" })
+      ).toBeVisible();
     });
   });
 

--- a/apps/web/src/tests/test-helpers.ts
+++ b/apps/web/src/tests/test-helpers.ts
@@ -70,7 +70,7 @@ export class AuthHelper {
 
       // Wait for the main page element to be visible
       await this.page
-        .getByPlaceholder(/Write a note/i)
+        .getByRole("textbox", { name: "Markdown content" })
         .waitFor({ state: "visible", timeout: DEFAULT_TIMEOUT });
       return;
     } catch {
@@ -104,7 +104,7 @@ export class AuthHelper {
 
     // Wait for the main page element to be visible
     await this.page
-      .getByPlaceholder(/Write a note/i)
+      .getByRole("textbox", { name: "Markdown content" })
       .waitFor({ state: "visible", timeout: DEFAULT_TIMEOUT });
   }
 
@@ -148,7 +148,7 @@ export class AuthHelper {
 
       // Wait for the main page element to be visible
       await this.page
-        .getByPlaceholder(/Write a note/i)
+        .getByRole("textbox", { name: "Markdown content" })
         .waitFor({ state: "visible", timeout: DEFAULT_TIMEOUT });
     } catch (error) {
       // Provide more context for debugging
@@ -224,10 +224,10 @@ export class UiHelper {
   }
 
   /**
-   * Get the main composer textarea
+   * Get the main Markdown composer
    */
   getComposer(): Locator {
-    return this.page.getByPlaceholder(/Write a note/i);
+    return this.page.getByRole("textbox", { name: "Markdown content" });
   }
 
   /**
@@ -372,7 +372,7 @@ export class UiHelper {
     await this.page.goto("/");
     // Wait for page to be ready by checking for a key element
     await this.page
-      .getByPlaceholder(/Write a note/i)
+      .getByRole("textbox", { name: "Markdown content" })
       .waitFor({ state: "visible", timeout: DEFAULT_TIMEOUT });
   }
 

--- a/bun.lock
+++ b/bun.lock
@@ -277,6 +277,12 @@
       "name": "@teak/ui",
       "version": "1.0.59",
       "dependencies": {
+        "@codemirror/commands": "6.10.4",
+        "@codemirror/lang-markdown": "6.5.1",
+        "@codemirror/language": "6.12.4",
+        "@codemirror/state": "6.7.1",
+        "@codemirror/view": "6.43.6",
+        "@lezer/markdown": "1.7.2",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-context-menu": "^2.2.16",
@@ -696,6 +702,26 @@
 
     "@clack/prompts": ["@clack/prompts@1.5.1", "", { "dependencies": { "@clack/core": "1.4.1", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw=="],
 
+    "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
+
+    "@codemirror/commands": ["@codemirror/commands@6.10.4", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.7.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg=="],
+
+    "@codemirror/lang-css": ["@codemirror/lang-css@6.3.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.2", "@lezer/css": "^1.1.7" } }, "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg=="],
+
+    "@codemirror/lang-html": ["@codemirror/lang-html@6.4.11", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/language": "^6.4.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/css": "^1.1.0", "@lezer/html": "^1.3.12" } }, "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw=="],
+
+    "@codemirror/lang-javascript": ["@codemirror/lang-javascript@6.2.5", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/lint": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/javascript": "^1.0.0" } }, "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A=="],
+
+    "@codemirror/lang-markdown": ["@codemirror/lang-markdown@6.5.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.7.1", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.3.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/markdown": "^1.0.0" } }, "sha512-6re5avCNfyRMIoi3XNjbEfQM1vTeVD3JS3g/Fyegyso/eoANFM71Cyvbb66LDyYtQLMEcRFlzioywCqDo9SlLA=="],
+
+    "@codemirror/language": ["@codemirror/language@6.12.4", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A=="],
+
+    "@codemirror/lint": ["@codemirror/lint@6.9.7", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.42.0", "crelt": "^1.0.5" } }, "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg=="],
+
+    "@codemirror/state": ["@codemirror/state@6.7.1", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A=="],
+
+    "@codemirror/view": ["@codemirror/view@6.43.6", "", { "dependencies": { "@codemirror/state": "^6.7.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA=="],
+
     "@convex-dev/action-retrier": ["@convex-dev/action-retrier@0.3.0", "", { "peerDependencies": { "convex": "^1.24.8" } }, "sha512-opBNsgOPSuVY3qSARNub98XqPzSpSS7Jga0oGeWFhO+DcWBMt2gD3ssUeEA1Gi7wTNiZBX+T6OBfBnqMfv6Tuw=="],
 
     "@convex-dev/better-auth": ["@convex-dev/better-auth@0.12.5", "", { "dependencies": { "@better-fetch/fetch": "^1.1.18", "common-tags": "^1.8.2", "convex-helpers": "^0.1.95", "jose": "^6.1.0", "remeda": "^2.32.0", "semver": "^7.7.3", "type-fest": "^5.0.0", "zod": "^4.0.0" }, "peerDependencies": { "better-auth": ">=1.6.11 <1.7.0", "convex": "^1.25.0", "react": "^18.3.1 || ^19.0.0" } }, "sha512-YFUbGk04OlINno9FpOTNZN67AP+kSQsblfep5zs1f/WTgMWjD5FymU6rSSh3mu52gukmDNnBJTjC/lj4QRpjlQ=="],
@@ -1076,11 +1102,27 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
+
+    "@lezer/css": ["@lezer/css@1.3.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/html": ["@lezer/html@1.3.13", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg=="],
+
+    "@lezer/javascript": ["@lezer/javascript@1.5.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.1.3", "@lezer/lr": "^1.3.0" } }, "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
+
+    "@lezer/markdown": ["@lezer/markdown@1.7.2", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-iTkYvoVcKt3WkeL7qUDyXHONZEwLio4wj8KTNi2dnjQEXBZKMV63BpQrPqfsM+OkvuRbiSTAcycYAsQzLhRNoQ=="],
+
     "@listr2/prompt-adapter-inquirer": ["@listr2/prompt-adapter-inquirer@2.0.22", "", { "dependencies": { "@inquirer/type": "^1.5.5" }, "peerDependencies": { "@inquirer/prompts": ">= 3 < 8" } }, "sha512-hV36ZoY+xKL6pYOt1nPNnkciFkn89KZwqLhAFzJvYysAvL5uBQdiADZx/8bIDXIukzzwG0QlPYolgMzQUtKgpQ=="],
 
     "@malept/cross-spawn-promise": ["@malept/cross-spawn-promise@2.0.0", "", { "dependencies": { "cross-spawn": "^7.0.1" } }, "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg=="],
 
     "@malept/flatpak-bundler": ["@malept/flatpak-bundler@0.4.0", "", { "dependencies": { "debug": "^4.1.1", "fs-extra": "^9.0.0", "lodash": "^4.17.15", "tmp-promise": "^3.0.2" } }, "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q=="],
+
+    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.3", "", {}, "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
@@ -2249,6 +2291,8 @@
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
     "crc32-stream": ["crc32-stream@7.0.1", "", { "dependencies": { "crc-32": "^1.2.0", "readable-stream": "^4.0.0" } }, "sha512-IBWsY8xznyQrcHn8h4bC8/4ErNke5elzgG8GcqF4RFPw6aHkWWRc7Tgw6upjaTX/CT/yQgqYENkxYsTYN+hW2g=="],
+
+    "crelt": ["crelt@1.0.7", "", {}, "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA=="],
 
     "cross-dirname": ["cross-dirname@0.1.0", "", {}, "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q=="],
 
@@ -4070,6 +4114,8 @@
 
     "stubborn-utils": ["stubborn-utils@1.0.2", "", {}, "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg=="],
 
+    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
+
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
@@ -4355,6 +4401,8 @@
     "vscode-nls": ["vscode-nls@5.2.0", "", {}, "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="],
 
     "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
+
+    "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "walker": ["walker@1.0.8", "", { "dependencies": { "makeerror": "1.0.12" } }, "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ=="],
 

--- a/packages/convex/_generated/api.d.ts
+++ b/packages/convex/_generated/api.d.ts
@@ -43,6 +43,7 @@ import type * as crons from "../crons.js";
 import type * as dataExport from "../dataExport.js";
 import type * as dataImport from "../dataImport.js";
 import type * as devUrls from "../devUrls.js";
+import type * as e2eAccounts from "../e2eAccounts.js";
 import type * as e2eCleanup from "../e2eCleanup.js";
 import type * as export_archiveBuilder from "../export/archiveBuilder.js";
 import type * as export_constants from "../export/constants.js";
@@ -198,6 +199,7 @@ declare const fullApi: ApiFromModules<{
   dataExport: typeof dataExport;
   dataImport: typeof dataImport;
   devUrls: typeof devUrls;
+  e2eAccounts: typeof e2eAccounts;
   e2eCleanup: typeof e2eCleanup;
   "export/archiveBuilder": typeof export_archiveBuilder;
   "export/constants": typeof export_constants;

--- a/packages/tests/src/journey/02-web-journey.e2e.ts
+++ b/packages/tests/src/journey/02-web-journey.e2e.ts
@@ -20,11 +20,12 @@ test("web journey covers cards, search, settings, upload, and revoked key", asyn
     return dialog.dismiss();
   });
   await page.goto("/");
-  await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
+  const composer = page.getByRole("textbox", { name: "Markdown content" });
+  await expect(composer).toBeVisible();
   await expect(
     page.getByText(/Welcome to Teak|Let's add your first card/i)
   ).toBeVisible();
-  await page.getByPlaceholder(/Write a note/i).fill(rawMarkdown);
+  await composer.fill(rawMarkdown);
   await page.getByRole("button", { name: "Save", exact: true }).click();
   const savedCard = page.locator("main p").filter({ hasText: marker }).first();
   await expect(savedCard).toBeVisible();
@@ -100,7 +101,7 @@ test("saving a color in the composer creates a palette card", async ({
   const hex = "#2050D0";
 
   await page.goto("/");
-  await page.getByPlaceholder(/Write a note/i).fill(hex);
+  await page.getByRole("textbox", { name: "Markdown content" }).fill(hex);
   await page.getByRole("button", { name: "Save", exact: true }).click();
   // The optimistic card appears immediately; classification runs server-side.
   await expect(

--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -23,7 +23,7 @@ const pdf = Buffer.from(
 
 const saveTextCard = async (page: Page, content: string) => {
   await page.goto("/");
-  await page.getByPlaceholder(/Write a note/i).fill(content);
+  await page.getByRole("textbox", { name: "Markdown content" }).fill(content);
   await clickVisibleControl(
     page.getByRole("button", { exact: true, name: "Save" })
   );
@@ -94,7 +94,9 @@ const waitForHomeUploadSurface = async (page: Page) => {
   await expect(
     page.getByRole("button", { name: "Upload files" })
   ).toBeVisible();
-  await expect(page.getByPlaceholder(/Write a note/i)).toBeVisible();
+  await expect(
+    page.getByRole("textbox", { name: "Markdown content" })
+  ).toBeVisible();
 };
 
 const showTrash = async (page: Page) => {
@@ -172,18 +174,32 @@ test("web editor, deep links, and link metadata stay usable", async ({
   const marker = markerFor("editor");
   await saveTextCard(page, `${marker} original`);
   await page.getByRole("main").getByText(`${marker} original`).click();
-  const editor = page.getByPlaceholder("Enter your text...");
+  const editor = page
+    .getByRole("dialog")
+    .getByRole("textbox", { name: "Markdown content" });
   await editor.fill(`# ${marker} updated\n\n- **bold** item\n- \`code\``);
+  await expect(
+    editor.locator(
+      "xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' teak-markdown-editor ')]"
+    )
+  ).toHaveClass(/typeset/);
+  await expect(
+    page.getByRole("dialog").locator(".cm-md-heading-1")
+  ).toBeVisible();
+  await expect(page.getByRole("dialog").locator(".cm-editor")).toHaveAttribute(
+    "data-not-typeset",
+    "true"
+  );
   await page.getByRole("button", { name: "Save changes" }).click();
-  await expect(editor).toHaveValue(/updated/);
+  await expect(editor).toContainText("updated");
   const deepLink = page.url();
   const cardId = new URL(deepLink).searchParams.get("card");
   expect(cardId).toBeTruthy();
   await page.reload();
   await expect(page.getByRole("dialog")).toBeVisible();
-  await expect(page.getByPlaceholder("Enter your text...")).toHaveValue(
-    /updated/
-  );
+  await expect(
+    page.getByRole("dialog").getByRole("textbox", { name: "Markdown content" })
+  ).toContainText("updated");
   await page.keyboard.press("Escape");
   await expect(page.getByRole("dialog")).not.toBeVisible();
   await page.goto(deepLink);

--- a/packages/tests/src/journey/10-file-format-ui.e2e.ts
+++ b/packages/tests/src/journey/10-file-format-ui.e2e.ts
@@ -97,9 +97,9 @@ test("web picker and drag-drop upload files with safe opened previews", async ({
   await expect(textCard).toBeVisible();
   await textCard.click();
   const textDialog = page.getByRole("dialog");
-  await expect(textDialog.getByPlaceholder("Enter your text...")).toHaveValue(
-    rawMarkdown.replace(/\r\n?/g, "\n")
-  );
+  await expect(
+    textDialog.getByRole("textbox", { name: "Markdown content" })
+  ).toContainText(`${marker}-text`);
   await expect(
     textDialog.getByRole("button", { name: /Download/i })
   ).toHaveCount(0);

--- a/packages/tests/src/matrix/journey-lite.e2e.ts
+++ b/packages/tests/src/matrix/journey-lite.e2e.ts
@@ -13,7 +13,7 @@ test("signup, create, and search", async ({ page }) => {
   try {
     const marker = `matrix-${Date.now()}`;
     await page.goto("/");
-    const note = page.getByPlaceholder(/Write a note/i);
+    const note = page.getByRole("textbox", { name: "Markdown content" });
     await note.fill(marker);
     await expect(note).toHaveValue(marker);
     await clickVisibleControl(

--- a/packages/tests/src/snapshots/web.snapshots.ts
+++ b/packages/tests/src/snapshots/web.snapshots.ts
@@ -223,7 +223,7 @@ test("captures the deterministic Teak web product surface", async ({
 
     const composer = page.getByPlaceholder(/Write a note/i);
     await composer.fill(DRAFT_TEXT);
-    await expect(composer).toHaveValue(DRAFT_TEXT);
+    await expect(composer).toHaveText(DRAFT_TEXT);
     await capture(page, viewportName, "add-card");
 
     await page.goto("/settings");

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,6 +14,7 @@
     "./cards/previews": "./src/components/cards/previews/index.ts",
     "./card-modal": "./src/components/card-modal/index.ts",
     "./card-previews": "./src/components/card-previews/index.ts",
+    "./text-editor": "./src/components/text-editor/index.ts",
     "./auth": "./src/components/auth/index.ts",
     "./modals": "./src/components/modals/index.ts",
     "./feedback/CardSkeleton": "./src/feedback/CardSkeleton.tsx",
@@ -40,10 +41,16 @@
     "./constants/toast": "./src/constants/toast.ts"
   },
   "scripts": {
-    "test": "bun test src/components/card-previews/__tests__ src/components/forms/__tests__ src/components/settings/__tests__ src/hooks/__tests__ --coverage --dots",
+    "test": "bun test src/components/card-previews/__tests__ src/components/forms/__tests__ src/components/settings/__tests__ src/components/text-editor/__tests__ src/hooks/__tests__ --coverage --dots",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@codemirror/commands": "6.10.4",
+    "@codemirror/lang-markdown": "6.5.1",
+    "@codemirror/language": "6.12.4",
+    "@codemirror/state": "6.7.1",
+    "@codemirror/view": "6.43.6",
+    "@lezer/markdown": "1.7.2",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-context-menu": "^2.2.16",

--- a/packages/ui/src/components/card-modal/CardModal.tsx
+++ b/packages/ui/src/components/card-modal/CardModal.tsx
@@ -20,10 +20,12 @@ import type { CardModalCard, GetCurrentValue } from "./types";
 function CardPreview({
   card,
   getCurrentValue,
+  saveChanges,
   updateContent,
 }: {
   card: CardModalCard;
   getCurrentValue: GetCurrentValue;
+  saveChanges: () => Promise<void>;
   updateContent: (value: string) => void;
 }) {
   switch (card.type) {
@@ -33,6 +35,9 @@ function CardPreview({
           card={card}
           getCurrentValue={getCurrentValue}
           onContentChange={updateContent}
+          onSaveShortcut={() => {
+            void saveChanges();
+          }}
         />
       );
     case "quote":
@@ -160,6 +165,7 @@ export function CardModal({
                     <CardPreview
                       card={card}
                       getCurrentValue={getCurrentValue}
+                      saveChanges={saveChanges}
                       updateContent={updateContent}
                     />
                   </div>

--- a/packages/ui/src/components/card-previews/TextPreview.tsx
+++ b/packages/ui/src/components/card-previews/TextPreview.tsx
@@ -1,5 +1,6 @@
 import type { Doc } from "@teak/convex/_generated/dataModel";
-import { Textarea } from "@teak/ui/components/ui/textarea";
+import { MarkdownTextEditor } from "@teak/ui/text-editor";
+import { toast } from "sonner";
 import type { GetCurrentValue } from "../card-modal/types";
 
 type CardWithUrls = Doc<"cards"> & {
@@ -11,26 +12,32 @@ interface TextPreviewProps {
   card: CardWithUrls;
   getCurrentValue?: GetCurrentValue;
   onContentChange: (content: string) => void;
+  onSaveShortcut?: () => void;
 }
 
 export function TextPreview({
   card,
   onContentChange,
   getCurrentValue,
+  onSaveShortcut,
 }: TextPreviewProps) {
   const currentContent = getCurrentValue
     ? getCurrentValue("content")
     : card.content;
 
   return (
-    <Textarea
-      className="h-full resize-none rounded-none border-0 bg-transparent p-0 text-base leading-relaxed shadow-none focus-visible:border-0 focus-visible:ring-0 dark:bg-transparent"
-      onChange={(e) => {
-        const newContent = e.target.value;
-        onContentChange(newContent);
-      }}
-      placeholder="Enter your text..."
+    <MarkdownTextEditor
+      ariaLabel="Markdown content"
+      className="h-full"
+      minHeight="55vh"
+      onChange={onContentChange}
+      onLimitExceeded={() =>
+        toast.error("Notes can be up to 512 KiB of UTF-8 text")
+      }
+      onSaveShortcut={onSaveShortcut}
+      placeholder="Write a note..."
       value={currentContent || ""}
+      variant="modal"
     />
   );
 }

--- a/packages/ui/src/components/forms/AddCardForm.tsx
+++ b/packages/ui/src/components/forms/AddCardForm.tsx
@@ -4,11 +4,12 @@ import { CARD_ERROR_CODES } from "@teak/convex/shared";
 import { trackCardCreateAttempt } from "@teak/convex/shared/metrics";
 import { Button } from "@teak/ui/components/ui/button";
 import { Card, CardContent } from "@teak/ui/components/ui/card";
-import { Textarea } from "@teak/ui/components/ui/textarea";
 import {
   MANUAL_CLOSE_TOAST_OPTIONS,
   TOAST_IDS,
 } from "@teak/ui/constants/toast";
+import { cn } from "@teak/ui/lib/utils";
+import { MarkdownTextEditor } from "@teak/ui/text-editor";
 import type { OptimisticLocalStore } from "convex/browser";
 import { useMutation } from "convex/react";
 import { Maximize2 } from "lucide-react";
@@ -184,8 +185,6 @@ export function AddCardForm({
     }
   );
 
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-
   const resetDraft = () => {
     setContent("");
   };
@@ -254,22 +253,6 @@ export function AddCardForm({
     setIsFullScreenOpen(false);
   };
 
-  const handleFullScreenShortcut = (
-    event: React.KeyboardEvent<HTMLTextAreaElement>
-  ) => {
-    const isShortcut =
-      (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "e";
-    if (!isShortcut) {
-      return false;
-    }
-    if (!canCreateCard) {
-      return false;
-    }
-    event.preventDefault();
-    setIsFullScreenOpen(true);
-    return true;
-  };
-
   return (
     <>
       <FullScreenAddCardDialog
@@ -285,37 +268,41 @@ export function AddCardForm({
       <Card className="min-h-36 w-full overflow-hidden p-0 shadow-none focus-within:border-primary focus-within:ring-1 focus-within:ring-primary">
         <CardContent className="h-full p-0">
           <form
-            className="flex h-full flex-1 flex-col"
+            className="relative flex min-h-36 flex-1 flex-col"
             data-card-creation-status={
               cardCreationStatus === undefined ? "loading" : "ready"
             }
             onSubmit={handleTextSubmit}
           >
-            <Textarea
+            <MarkdownTextEditor
+              ariaLabel="Markdown content"
               autoFocus={autoFocus}
-              className="h-full min-h-20 flex-1 resize-none rounded-none border-0 bg-transparent p-4 shadow-none focus-visible:outline-none focus-visible:ring-0 dark:bg-transparent"
+              className={cn(
+                "h-full min-h-20 flex-1 p-4",
+                hasContent && "pb-12"
+              )}
               disabled={!canCreateCard}
-              id="content"
-              onChange={(e) => setContent(e.target.value)}
-              onKeyDown={(e) => {
-                if (handleFullScreenShortcut(e)) {
-                  return;
+              minHeight="5rem"
+              onChange={setContent}
+              onLimitExceeded={() =>
+                toast.error("Notes can be up to 512 KiB of UTF-8 text")
+              }
+              onOpenFullScreen={() => {
+                if (canCreateCard) {
+                  setIsFullScreenOpen(true);
                 }
-                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-                  e.preventDefault();
-                  if (hasContent && canCreateCard) {
-                    handleTextSubmit(
-                      e as unknown as React.FormEvent<HTMLFormElement>
-                    ).catch(console.error);
-                  }
+              }}
+              onSaveShortcut={() => {
+                if (hasContent && canCreateCard && !isSubmitting) {
+                  void submitTextCard();
                 }
               }}
               placeholder={inlinePlaceholderText}
-              ref={textareaRef}
               value={content}
+              variant="compact"
             />
 
-            <div className="flex justify-end gap-2 p-3">
+            <div className="absolute right-3 bottom-3 flex justify-end gap-2">
               {hasContent && (
                 <>
                   <Button

--- a/packages/ui/src/components/forms/FullScreenAddCardDialog.tsx
+++ b/packages/ui/src/components/forms/FullScreenAddCardDialog.tsx
@@ -5,8 +5,8 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@teak/ui/components/ui/dialog";
-import { Textarea } from "@teak/ui/components/ui/textarea";
-import { useCallback, useEffect, useRef } from "react";
+import { MarkdownTextEditor } from "@teak/ui/text-editor";
+import { toast } from "sonner";
 
 interface FullScreenAddCardDialogProps {
   canCreateCard: boolean;
@@ -29,68 +29,7 @@ export function FullScreenAddCardDialog({
   onSave,
   onRequestClose,
 }: FullScreenAddCardDialogProps) {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const scrollContainerRef = useRef<HTMLLabelElement>(null);
-
-  const resizeTextarea = useCallback((keepBottom = false) => {
-    if (!textareaRef.current) {
-      return;
-    }
-
-    const textarea = textareaRef.current;
-    textarea.style.height = "0px";
-    textarea.style.height = `${textarea.scrollHeight}px`;
-
-    if (keepBottom && scrollContainerRef.current) {
-      const container = scrollContainerRef.current;
-      container.scrollTop = container.scrollHeight - container.clientHeight;
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    const focusTextarea = () => {
-      if (!textareaRef.current) {
-        return;
-      }
-      textareaRef.current.focus();
-      const length = textareaRef.current.value.length;
-      textareaRef.current.setSelectionRange(length, length);
-      resizeTextarea(true);
-    };
-
-    const frame = requestAnimationFrame(focusTextarea);
-    return () => cancelAnimationFrame(frame);
-  }, [open, resizeTextarea]);
-
   const canSave = Boolean(content.trim() && canCreateCard && !isSubmitting);
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-      event.preventDefault();
-      if (canSave) {
-        void onSave();
-      }
-    }
-  };
-
-  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const target = event.currentTarget;
-    const container = scrollContainerRef.current;
-    const wasNearBottom = container
-      ? container.scrollTop + container.clientHeight >=
-        container.scrollHeight - 24
-      : false;
-    target.style.height = "0px";
-    target.style.height = `${target.scrollHeight}px`;
-    if (container && wasNearBottom) {
-      container.scrollTop = container.scrollHeight - container.clientHeight;
-    }
-    onContentChange(target.value);
-  };
 
   return (
     <Dialog
@@ -110,8 +49,8 @@ export function FullScreenAddCardDialog({
           Add a new note in full-screen mode
         </DialogDescription>
 
-        <div className="relative h-dvh w-full">
-          <div className="fixed top-0 right-0 left-0 z-20 flex items-center justify-between border-b bg-background/90 px-6 py-2 backdrop-blur">
+        <div className="flex h-dvh w-full flex-col">
+          <div className="z-20 flex items-center justify-between border-b bg-background/90 px-4 py-2 backdrop-blur sm:px-6">
             <Button
               onClick={() => void onRequestClose()}
               size="sm"
@@ -130,26 +69,24 @@ export function FullScreenAddCardDialog({
             </Button>
           </div>
 
-          <label
-            className="block h-full w-full cursor-text overflow-y-auto"
-            htmlFor="fullscreen-content"
-            ref={scrollContainerRef}
-          >
-            <div className="w-full px-6 pt-20 pb-16">
-              <div className="mx-auto w-full max-w-3xl">
-                <Textarea
-                  className="min-h-[60vh] resize-none rounded-none border-0 bg-transparent! p-0 text-2xl leading-relaxed shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent!"
-                  disabled={!canCreateCard}
-                  id="fullscreen-content"
-                  onChange={handleChange}
-                  onKeyDown={handleKeyDown}
-                  placeholder={placeholder}
-                  ref={textareaRef}
-                  value={content}
-                />
-              </div>
-            </div>
-          </label>
+          <MarkdownTextEditor
+            ariaLabel="Markdown content"
+            autoFocus
+            className="mx-auto h-full w-full max-w-3xl overflow-y-auto px-4 py-6 sm:px-7 sm:py-8"
+            disabled={!canCreateCard}
+            minHeight="60vh"
+            onChange={onContentChange}
+            onLimitExceeded={() =>
+              toast.error("Notes can be up to 512 KiB of UTF-8 text")
+            }
+            onSaveShortcut={() => {
+              if (canSave) {
+                void onSave();
+              }
+            }}
+            placeholder={placeholder}
+            value={content}
+          />
         </div>
       </DialogContent>
     </Dialog>

--- a/packages/ui/src/components/forms/__tests__/AddCardForm.test.tsx
+++ b/packages/ui/src/components/forms/__tests__/AddCardForm.test.tsx
@@ -169,9 +169,9 @@ describe("AddCardForm", () => {
   });
 
   test("exposes loading and ready card-creation states", () => {
-    expect(renderToStaticMarkup(<AddCardForm />)).toContain(
-      'data-card-creation-status="loading"'
-    );
+    const loadingMarkup = renderToStaticMarkup(<AddCardForm />);
+    expect(loadingMarkup).toContain('data-card-creation-status="loading"');
+    expect(loadingMarkup).toContain('data-editor-variant="compact"');
 
     cardCreationStatusResult = { canCreateCard: true };
     expect(renderToStaticMarkup(<AddCardForm />)).toContain(

--- a/packages/ui/src/components/text-editor/MarkdownTextEditor.tsx
+++ b/packages/ui/src/components/text-editor/MarkdownTextEditor.tsx
@@ -151,6 +151,7 @@ export function MarkdownTextEditor({
         EditorView.contentAttributes.of({
           "aria-label": initial.ariaLabel,
           "aria-multiline": "true",
+          "aria-placeholder": initial.placeholder,
           role: "textbox",
           spellcheck: "true",
         }),

--- a/packages/ui/src/components/text-editor/MarkdownTextEditor.tsx
+++ b/packages/ui/src/components/text-editor/MarkdownTextEditor.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { markdown, markdownKeymap } from "@codemirror/lang-markdown";
+import { Annotation, Compartment, EditorState } from "@codemirror/state";
+import {
+  drawSelection,
+  EditorView,
+  placeholder as editorPlaceholder,
+  keymap,
+} from "@codemirror/view";
+import {
+  MARKDOWN_CONTENT_MAX_BYTES,
+  markdownContentByteLength,
+} from "@teak/convex/shared/markdown";
+import { cn } from "@teak/ui/lib/utils";
+import { useEffect, useRef } from "react";
+import {
+  applyInlineFormat,
+  createLiveMarkdownPlugin,
+  isSafeExternalUrl,
+  selectionFormatTooltip,
+} from "./liveMarkdown";
+import { markdownEditorTheme } from "./markdownEditorTheme";
+import type { MarkdownTextEditorProps } from "./types";
+
+const externalContentUpdate = Annotation.define<boolean>();
+
+function pasteLinkOverSelection(event: ClipboardEvent, view: EditorView) {
+  const selection = view.state.selection.main;
+  if (selection.empty) {
+    return false;
+  }
+  const pasted = event.clipboardData?.getData("text/plain").trim() ?? "";
+  if (!isSafeExternalUrl(pasted)) {
+    return false;
+  }
+
+  const label = view.state.sliceDoc(selection.from, selection.to);
+  const insertion = `[${label}](${pasted})`;
+  event.preventDefault();
+  view.dispatch({
+    changes: {
+      from: selection.from,
+      insert: insertion,
+      to: selection.to,
+    },
+    selection: {
+      anchor: selection.from + 1,
+      head: selection.from + 1 + label.length,
+    },
+  });
+  return true;
+}
+
+export function MarkdownTextEditor({
+  ariaLabel = "Markdown note",
+  autoFocus = false,
+  className,
+  disabled = false,
+  minHeight,
+  onChange,
+  onLimitExceeded,
+  onOpenFullScreen,
+  onSaveShortcut,
+  placeholder = "Write a note...",
+  value,
+  variant = "document",
+}: MarkdownTextEditorProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const readOnlyCompartmentRef = useRef(new Compartment());
+  const initialRef = useRef({
+    ariaLabel,
+    autoFocus,
+    disabled,
+    placeholder,
+    value,
+  });
+  const callbacksRef = useRef({
+    onChange,
+    onLimitExceeded,
+    onOpenFullScreen,
+    onSaveShortcut,
+  });
+  callbacksRef.current = {
+    onChange,
+    onLimitExceeded,
+    onOpenFullScreen,
+    onSaveShortcut,
+  };
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const initial = initialRef.current;
+    const state = EditorState.create({
+      doc: initial.value,
+      extensions: [
+        EditorState.lineSeparator.of("\n"),
+        markdown(),
+        history(),
+        drawSelection(),
+        EditorView.lineWrapping,
+        markdownEditorTheme,
+        EditorView.editorAttributes.of({
+          "data-not-typeset": "true",
+        }),
+        createLiveMarkdownPlugin(),
+        selectionFormatTooltip,
+        EditorView.domEventHandlers({
+          paste: pasteLinkOverSelection,
+        }),
+        keymap.of([
+          {
+            key: "Mod-b",
+            run: (view) => applyInlineFormat(view, "bold"),
+          },
+          {
+            key: "Mod-i",
+            run: (view) => applyInlineFormat(view, "italic"),
+          },
+          {
+            key: "Mod-k",
+            run: (view) => applyInlineFormat(view, "link"),
+          },
+          {
+            key: "Mod-`",
+            run: (view) => applyInlineFormat(view, "code"),
+          },
+          {
+            key: "Mod-Enter",
+            run: () => {
+              callbacksRef.current.onSaveShortcut?.();
+              return Boolean(callbacksRef.current.onSaveShortcut);
+            },
+          },
+          {
+            key: "Mod-e",
+            run: () => {
+              callbacksRef.current.onOpenFullScreen?.();
+              return Boolean(callbacksRef.current.onOpenFullScreen);
+            },
+          },
+          ...markdownKeymap,
+          ...defaultKeymap,
+          ...historyKeymap,
+        ]),
+        EditorView.contentAttributes.of({
+          "aria-label": initial.ariaLabel,
+          "aria-multiline": "true",
+          role: "textbox",
+          spellcheck: "true",
+        }),
+        editorPlaceholder(initial.placeholder),
+        readOnlyCompartmentRef.current.of([
+          EditorState.readOnly.of(initial.disabled),
+          EditorView.editable.of(!initial.disabled),
+        ]),
+        EditorState.transactionFilter.of((transaction) => {
+          if (
+            transaction.docChanged &&
+            markdownContentByteLength(transaction.newDoc.toString()) >
+              MARKDOWN_CONTENT_MAX_BYTES
+          ) {
+            callbacksRef.current.onLimitExceeded?.();
+            return [];
+          }
+          return transaction;
+        }),
+        EditorView.updateListener.of((update) => {
+          if (!update.docChanged) {
+            return;
+          }
+          const isExternal = update.transactions.every((transaction) =>
+            transaction.annotation(externalContentUpdate)
+          );
+          if (!isExternal) {
+            callbacksRef.current.onChange(update.state.doc.toString());
+          }
+        }),
+      ],
+    });
+    const view = new EditorView({ parent: container, state });
+    viewRef.current = view;
+    const releaseFocusOutsideEditor = (event: PointerEvent) => {
+      if (
+        event.target instanceof Node &&
+        !container.contains(event.target) &&
+        view.hasFocus
+      ) {
+        view.contentDOM.blur();
+      }
+    };
+    document.addEventListener("pointerdown", releaseFocusOutsideEditor, true);
+
+    if (initial.autoFocus) {
+      requestAnimationFrame(() => {
+        view.dispatch({ selection: { anchor: view.state.doc.length } });
+        view.focus();
+      });
+    }
+
+    return () => {
+      document.removeEventListener(
+        "pointerdown",
+        releaseFocusOutsideEditor,
+        true
+      );
+      viewRef.current = null;
+      view.destroy();
+    };
+  }, []);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view || view.state.doc.toString() === value) {
+      return;
+    }
+    view.dispatch({
+      annotations: externalContentUpdate.of(true),
+      changes: { from: 0, insert: value, to: view.state.doc.length },
+    });
+  }, [value]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) {
+      return;
+    }
+    view.dispatch({
+      effects: readOnlyCompartmentRef.current.reconfigure([
+        EditorState.readOnly.of(disabled),
+        EditorView.editable.of(!disabled),
+      ]),
+    });
+  }, [disabled]);
+
+  return (
+    <div
+      className={cn(
+        "teak-markdown-editor typeset typeset-docs w-full min-w-0",
+        variant === "modal" && "h-full",
+        className
+      )}
+      data-editor-variant={variant}
+      ref={containerRef}
+      style={
+        minHeight
+          ? ({ "--teak-editor-min-height": minHeight } as React.CSSProperties)
+          : undefined
+      }
+    />
+  );
+}

--- a/packages/ui/src/components/text-editor/MarkdownTextEditor.tsx
+++ b/packages/ui/src/components/text-editor/MarkdownTextEditor.tsx
@@ -152,6 +152,7 @@ export function MarkdownTextEditor({
           "aria-label": initial.ariaLabel,
           "aria-multiline": "true",
           "aria-placeholder": initial.placeholder,
+          placeholder: initial.placeholder,
           role: "textbox",
           spellcheck: "true",
         }),

--- a/packages/ui/src/components/text-editor/__tests__/liveMarkdown.test.ts
+++ b/packages/ui/src/components/text-editor/__tests__/liveMarkdown.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import { markdown } from "@codemirror/lang-markdown";
+import { EditorState } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
+import {
+  activeMarkdownConstructs,
+  applyInlineFormat,
+  isSafeExternalUrl,
+} from "../liveMarkdown";
+
+function createTestView(
+  source: string,
+  selection: { anchor: number; head?: number }
+) {
+  let state = EditorState.create({
+    doc: source,
+    extensions: [EditorState.lineSeparator.of("\n"), markdown()],
+    selection,
+  });
+  const view = {
+    focus() {
+      // This test double only verifies document transactions.
+    },
+    get state() {
+      return state;
+    },
+    dispatch(spec: Parameters<EditorState["update"]>[0]) {
+      state = state.update(spec).state;
+    },
+  } as unknown as EditorView;
+  return {
+    get state() {
+      return state;
+    },
+    view,
+  };
+}
+
+describe("live Markdown editor", () => {
+  test("identifies the complete construct around the caret", () => {
+    const state = EditorState.create({
+      doc: "# Heading\n\n**Bold** and plain",
+      extensions: markdown(),
+      selection: { anchor: 15 },
+    });
+
+    expect(activeMarkdownConstructs(state)).toContainEqual({
+      from: 11,
+      to: 19,
+    });
+    expect(activeMarkdownConstructs(state)).not.toContainEqual({
+      from: 0,
+      to: 9,
+    });
+  });
+
+  test("wraps and unwraps selected text without changing the text", () => {
+    const testView = createTestView("Keep this exact", {
+      anchor: 5,
+      head: 9,
+    });
+
+    expect(applyInlineFormat(testView.view, "bold")).toBe(true);
+    expect(testView.state.doc.toString()).toBe("Keep **this** exact");
+    expect(applyInlineFormat(testView.view, "bold")).toBe(true);
+    expect(testView.state.doc.toString()).toBe("Keep this exact");
+  });
+
+  test("creates an editable Markdown link and selects its destination", () => {
+    const testView = createTestView("Read Teak", { anchor: 5, head: 9 });
+
+    applyInlineFormat(testView.view, "link");
+
+    expect(testView.state.doc.toString()).toBe("Read [Teak](https://)");
+    expect(
+      testView.state.sliceDoc(
+        testView.state.selection.main.from,
+        testView.state.selection.main.to
+      )
+    ).toBe("https://");
+  });
+
+  test("chooses a safe inline-code delimiter", () => {
+    const testView = createTestView("Use `code` here", {
+      anchor: 4,
+      head: 10,
+    });
+
+    applyInlineFormat(testView.view, "code");
+
+    expect(testView.state.doc.toString()).toBe("Use `` `code` `` here");
+  });
+
+  test("accepts only browser-safe external links", () => {
+    expect(isSafeExternalUrl("https://teakvault.com/docs")).toBe(true);
+    expect(isSafeExternalUrl("http://localhost:3000")).toBe(true);
+    expect(isSafeExternalUrl("javascript:alert(1)")).toBe(false);
+    expect(isSafeExternalUrl("data:text/html,unsafe")).toBe(false);
+    expect(isSafeExternalUrl("not a url")).toBe(false);
+  });
+
+  test("round-trips LF, CRLF, mixed whitespace, and trailing spaces", () => {
+    const sources = [
+      "# LF\n\nText  \n",
+      "# CRLF\r\n\r\nText  \r\n",
+      "# Mixed\r\n\n\tText  \n",
+    ];
+
+    for (const source of sources) {
+      const state = EditorState.create({
+        doc: source,
+        extensions: EditorState.lineSeparator.of("\n"),
+      });
+      expect(state.doc.toString()).toBe(source);
+    }
+  });
+});

--- a/packages/ui/src/components/text-editor/index.ts
+++ b/packages/ui/src/components/text-editor/index.ts
@@ -1,0 +1,10 @@
+export {
+  applyInlineFormat,
+  buildMarkdownDecorations,
+  isSafeExternalUrl,
+} from "./liveMarkdown";
+export { MarkdownTextEditor } from "./MarkdownTextEditor";
+export type {
+  MarkdownInlineFormat,
+  MarkdownTextEditorProps,
+} from "./types";

--- a/packages/ui/src/components/text-editor/liveMarkdown.ts
+++ b/packages/ui/src/components/text-editor/liveMarkdown.ts
@@ -1,0 +1,511 @@
+import { syntaxTree } from "@codemirror/language";
+import {
+  EditorSelection,
+  type EditorState,
+  type Range,
+} from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  type EditorView,
+  showTooltip,
+  ViewPlugin,
+  type ViewUpdate,
+  WidgetType,
+} from "@codemirror/view";
+import type { MarkdownInlineFormat } from "./types";
+
+const ACTIVE_CONSTRUCTS = new Set([
+  "ATXHeading1",
+  "ATXHeading2",
+  "ATXHeading3",
+  "ATXHeading4",
+  "ATXHeading5",
+  "ATXHeading6",
+  "Blockquote",
+  "Emphasis",
+  "FencedCode",
+  "InlineCode",
+  "Link",
+  "ListItem",
+  "StrongEmphasis",
+]);
+
+const HIDDEN_MARKS = new Set([
+  "CodeMark",
+  "EmphasisMark",
+  "HeaderMark",
+  "LinkMark",
+  "QuoteMark",
+]);
+
+interface SourceRange {
+  from: number;
+  to: number;
+}
+
+export function isSafeExternalUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function rangesOverlap(
+  first: SourceRange,
+  second: SourceRange,
+  includeEdges = false
+) {
+  if (includeEdges) {
+    return first.from <= second.to && first.to >= second.from;
+  }
+  return first.from < second.to && first.to > second.from;
+}
+
+function selectionRanges(state: EditorState): SourceRange[] {
+  return state.selection.ranges.map((range) => ({
+    from: Math.min(range.anchor, range.head),
+    to: Math.max(range.anchor, range.head),
+  }));
+}
+
+export function activeMarkdownConstructs(state: EditorState): SourceRange[] {
+  const tree = syntaxTree(state);
+  const selections = selectionRanges(state);
+  const active: SourceRange[] = [];
+
+  tree.iterate({
+    enter(node) {
+      if (!ACTIVE_CONSTRUCTS.has(node.name)) {
+        return;
+      }
+      const nodeRange = { from: node.from, to: node.to };
+      if (
+        selections.some((selection) =>
+          selection.from === selection.to
+            ? selection.from >= node.from && selection.from <= node.to
+            : rangesOverlap(selection, nodeRange, true)
+        )
+      ) {
+        active.push(nodeRange);
+      }
+    },
+  });
+
+  return active;
+}
+
+function belongsToActiveConstruct(
+  active: SourceRange[],
+  from: number,
+  to: number
+) {
+  return active.some((range) => from >= range.from && to <= range.to);
+}
+
+function addBlockLineDecorations(
+  view: EditorView,
+  from: number,
+  to: number,
+  className: string,
+  ranges: Range<Decoration>[]
+) {
+  let line = view.state.doc.lineAt(from);
+  while (line.from <= to) {
+    ranges.push(Decoration.line({ class: className }).range(line.from));
+    if (line.to >= to || line.number >= view.state.doc.lines) {
+      break;
+    }
+    line = view.state.doc.line(line.number + 1);
+  }
+}
+
+class ListMarkerWidget extends WidgetType {
+  readonly marker: string;
+
+  constructor(marker: string) {
+    super();
+    this.marker = marker;
+  }
+
+  eq(other: ListMarkerWidget) {
+    return other.marker === this.marker;
+  }
+
+  toDOM() {
+    const marker = document.createElement("span");
+    marker.className = "cm-md-list-marker";
+    marker.setAttribute("aria-hidden", "true");
+    marker.textContent = /^\d+[.)]$/u.test(this.marker) ? this.marker : "•";
+    return marker;
+  }
+}
+
+class LinkWidget extends WidgetType {
+  readonly from: number;
+  readonly href: string;
+  readonly label: string;
+  readonly safe: boolean;
+
+  constructor(from: number, label: string, href: string, safe: boolean) {
+    super();
+    this.from = from;
+    this.href = href;
+    this.label = label;
+    this.safe = safe;
+  }
+
+  eq(other: LinkWidget) {
+    return (
+      other.from === this.from &&
+      other.label === this.label &&
+      other.href === this.href &&
+      other.safe === this.safe
+    );
+  }
+
+  toDOM(view: EditorView) {
+    const link = document.createElement("span");
+    link.className = this.safe ? "cm-md-link" : "cm-md-link cm-md-link-unsafe";
+    link.textContent = this.label;
+    link.setAttribute("role", "link");
+    link.tabIndex = 0;
+    link.title = this.safe
+      ? "Command-click or Control-click to open"
+      : "This link cannot be opened";
+
+    const reveal = () => {
+      view.dispatch({
+        scrollIntoView: true,
+        selection: { anchor: this.from },
+      });
+      view.focus();
+    };
+    const open = () => {
+      if (this.safe) {
+        window.open(this.href, "_blank", "noopener,noreferrer");
+      }
+    };
+
+    link.addEventListener("mousedown", (event) => {
+      event.preventDefault();
+      if (event.metaKey || event.ctrlKey) {
+        open();
+      } else {
+        reveal();
+      }
+    });
+    link.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        open();
+      } else if (event.key === "F2") {
+        event.preventDefault();
+        reveal();
+      }
+    });
+
+    return link;
+  }
+
+  ignoreEvent() {
+    return true;
+  }
+}
+
+function parseMarkdownLink(source: string) {
+  const match = /^\[([\s\S]*?)\]\((\S+?)(?:\s+["'][^"']*["'])?\)$/u.exec(
+    source
+  );
+  if (!(match?.[1] && match[2])) {
+    return null;
+  }
+  return { href: match[2], label: match[1].replace(/\\([\\\]])/gu, "$1") };
+}
+
+function codeFenceClasses(view: EditorView, from: number, to: number) {
+  const ranges: Range<Decoration>[] = [];
+  let line = view.state.doc.lineAt(from);
+  while (line.from <= to) {
+    const classes = ["cm-md-code-line"];
+    if (line.from === view.state.doc.lineAt(from).from) {
+      classes.push("cm-md-code-first");
+    }
+    if (line.to >= to) {
+      classes.push("cm-md-code-last");
+    }
+    ranges.push(Decoration.line({ class: classes.join(" ") }).range(line.from));
+    if (line.to >= to || line.number >= view.state.doc.lines) {
+      break;
+    }
+    line = view.state.doc.line(line.number + 1);
+  }
+  return ranges;
+}
+
+export function buildMarkdownDecorations(view: EditorView): DecorationSet {
+  const ranges: Range<Decoration>[] = [];
+  const active = view.hasFocus ? activeMarkdownConstructs(view.state) : [];
+  const visibleFrom = view.visibleRanges[0]?.from ?? 0;
+  let visibleTo = view.state.doc.length;
+  for (const visibleRange of view.visibleRanges) {
+    visibleTo = visibleRange.to;
+  }
+
+  syntaxTree(view.state).iterate({
+    from: visibleFrom,
+    to: visibleTo,
+    enter(node) {
+      const { from, name, to } = node;
+      const source = view.state.sliceDoc(from, to);
+      const isActive = belongsToActiveConstruct(active, from, to);
+
+      if (name === "Image") {
+        ranges.push(
+          Decoration.mark({ class: "cm-md-image-source" }).range(from, to)
+        );
+        return false;
+      }
+
+      if (/^ATXHeading[1-6]$/u.test(name)) {
+        ranges.push(
+          Decoration.line({
+            class: `cm-md-heading cm-md-heading-${name.slice(-1)}`,
+          }).range(view.state.doc.lineAt(from).from)
+        );
+      } else if (name === "StrongEmphasis") {
+        ranges.push(Decoration.mark({ class: "cm-md-strong" }).range(from, to));
+      } else if (name === "Emphasis") {
+        ranges.push(
+          Decoration.mark({ class: "cm-md-emphasis" }).range(from, to)
+        );
+      } else if (name === "InlineCode") {
+        ranges.push(
+          Decoration.mark({ class: "cm-md-inline-code" }).range(from, to)
+        );
+      } else if (name === "Blockquote") {
+        addBlockLineDecorations(view, from, to, "cm-md-quote", ranges);
+      } else if (name === "FencedCode") {
+        ranges.push(...codeFenceClasses(view, from, to));
+      } else if (name === "HorizontalRule") {
+        ranges.push(
+          Decoration.line({ class: "cm-md-divider" }).range(
+            view.state.doc.lineAt(from).from
+          )
+        );
+        ranges.push(
+          (isActive
+            ? Decoration.mark({ class: "cm-md-syntax" })
+            : Decoration.replace({})
+          ).range(from, to)
+        );
+        return false;
+      }
+
+      if (name === "Link" && !isActive) {
+        const link = parseMarkdownLink(source);
+        if (!link) {
+          return;
+        }
+        ranges.push(
+          Decoration.replace({
+            widget: new LinkWidget(
+              from,
+              link.label,
+              link.href,
+              isSafeExternalUrl(link.href)
+            ),
+          }).range(from, to)
+        );
+        return false;
+      }
+
+      if (name === "ListMark") {
+        ranges.push(
+          (isActive
+            ? Decoration.mark({ class: "cm-md-syntax" })
+            : Decoration.replace({
+                widget: new ListMarkerWidget(source),
+              })
+          ).range(from, to)
+        );
+      } else if (HIDDEN_MARKS.has(name)) {
+        ranges.push(
+          (isActive
+            ? Decoration.mark({ class: "cm-md-syntax" })
+            : Decoration.replace({})
+          ).range(from, to)
+        );
+      }
+    },
+  });
+
+  ranges.sort(
+    (first, second) =>
+      first.from - second.from || first.value.startSide - second.value.startSide
+  );
+  return Decoration.set(ranges, true);
+}
+
+export function createLiveMarkdownPlugin() {
+  return ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet;
+
+      constructor(view: EditorView) {
+        this.decorations = buildMarkdownDecorations(view);
+      }
+
+      update(update: ViewUpdate) {
+        if (
+          update.docChanged ||
+          update.selectionSet ||
+          update.viewportChanged ||
+          update.focusChanged
+        ) {
+          this.decorations = buildMarkdownDecorations(update.view);
+        }
+      }
+    },
+    { decorations: (plugin) => plugin.decorations }
+  );
+}
+
+function backtickDelimiter(content: string) {
+  const runs = content.match(/`+/gu) ?? [];
+  const longest = Math.max(0, ...runs.map((run) => run.length));
+  return "`".repeat(longest + 1);
+}
+
+function formatParts(format: MarkdownInlineFormat, content: string) {
+  if (format === "bold") {
+    return { prefix: "**", suffix: "**" };
+  }
+  if (format === "italic") {
+    return { prefix: "*", suffix: "*" };
+  }
+  if (format === "code") {
+    const delimiter = backtickDelimiter(content);
+    const padding = content.startsWith("`") || content.endsWith("`") ? " " : "";
+    return {
+      prefix: `${delimiter}${padding}`,
+      suffix: `${padding}${delimiter}`,
+    };
+  }
+  return { prefix: "[", suffix: "](https://)" };
+}
+
+export function applyInlineFormat(
+  view: EditorView,
+  format: MarkdownInlineFormat
+): boolean {
+  const selection = view.state.selection.main;
+  if (selection.empty) {
+    return false;
+  }
+
+  const selected = view.state.sliceDoc(selection.from, selection.to);
+  const { prefix, suffix } = formatParts(format, selected);
+  const before = view.state.sliceDoc(
+    Math.max(0, selection.from - prefix.length),
+    selection.from
+  );
+  const after = view.state.sliceDoc(
+    selection.to,
+    Math.min(view.state.doc.length, selection.to + suffix.length)
+  );
+
+  if (format !== "link" && before === prefix && after === suffix) {
+    view.dispatch({
+      changes: [
+        {
+          from: selection.from - prefix.length,
+          to: selection.from,
+          insert: "",
+        },
+        { from: selection.to, to: selection.to + suffix.length, insert: "" },
+      ],
+      selection: EditorSelection.range(
+        selection.from - prefix.length,
+        selection.to - prefix.length
+      ),
+    });
+    view.focus();
+    return true;
+  }
+
+  const insertion = `${prefix}${selected}${suffix}`;
+  const selectionAfter =
+    format === "link"
+      ? EditorSelection.range(
+          selection.from + prefix.length + selected.length + 2,
+          selection.from + insertion.length - 1
+        )
+      : EditorSelection.range(
+          selection.from + prefix.length,
+          selection.to + prefix.length
+        );
+  view.dispatch({
+    changes: {
+      from: selection.from,
+      insert: insertion,
+      to: selection.to,
+    },
+    selection: selectionAfter,
+  });
+  view.focus();
+  return true;
+}
+
+const FORMAT_LABELS: Array<{
+  format: MarkdownInlineFormat;
+  glyph: string;
+  label: string;
+  shortcut: string;
+}> = [
+  { format: "bold", glyph: "B", label: "Bold", shortcut: "⌘B" },
+  { format: "italic", glyph: "I", label: "Italic", shortcut: "⌘I" },
+  { format: "link", glyph: "↗", label: "Link", shortcut: "⌘K" },
+  { format: "code", glyph: "</>", label: "Code", shortcut: "⌘`" },
+];
+
+export const selectionFormatTooltip = showTooltip.compute(
+  ["selection"],
+  (state) => {
+    const selection = state.selection.main;
+    if (selection.empty) {
+      return null;
+    }
+
+    return {
+      above: true,
+      arrow: false,
+      create(view: EditorView) {
+        const toolbar = document.createElement("div");
+        toolbar.className = "cm-md-format-toolbar";
+        toolbar.setAttribute("aria-label", "Text formatting");
+        toolbar.setAttribute("role", "toolbar");
+
+        for (const item of FORMAT_LABELS) {
+          const button = document.createElement("button");
+          button.className = "cm-md-format-button";
+          button.type = "button";
+          button.textContent = item.glyph;
+          button.setAttribute("aria-label", item.label);
+          button.title = `${item.label} (${item.shortcut})`;
+          button.addEventListener("mousedown", (event) => {
+            event.preventDefault();
+            applyInlineFormat(view, item.format);
+          });
+          toolbar.append(button);
+        }
+
+        return { dom: toolbar };
+      },
+      end: selection.to,
+      pos: selection.from,
+    };
+  }
+);

--- a/packages/ui/src/components/text-editor/markdownEditorTheme.ts
+++ b/packages/ui/src/components/text-editor/markdownEditorTheme.ts
@@ -1,0 +1,146 @@
+import { EditorView } from "@codemirror/view";
+
+export const markdownEditorTheme = EditorView.theme({
+  "&": {
+    backgroundColor: "transparent",
+    color: "var(--color-foreground, currentColor)",
+    fontFamily: "var(--typeset-font-body, inherit)",
+    fontSize: "var(--typeset-size, 1rem)",
+    height: "100%",
+  },
+  "&.cm-focused": { outline: "none" },
+  ".cm-scroller": {
+    fontFamily: "var(--typeset-font-body, inherit)",
+    overflow: "auto",
+  },
+  ".cm-content": {
+    caretColor: "var(--color-foreground, currentColor)",
+    lineHeight: "var(--typeset-leading, 1.75)",
+    minHeight: "var(--teak-editor-min-height, 5rem)",
+    padding: "0",
+  },
+  ".cm-cursor, .cm-dropCursor": {
+    borderLeftColor: "var(--color-foreground, currentColor)",
+  },
+  ".cm-gutters": { display: "none" },
+  ".cm-line": {
+    padding: "0",
+  },
+  ".cm-placeholder": {
+    color: "var(--typeset-muted, var(--muted-foreground))",
+    fontStyle: "normal",
+  },
+  ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
+    backgroundColor: "color-mix(in oklch, var(--primary) 18%, transparent)",
+  },
+  ".cm-tooltip": {
+    backgroundColor: "transparent",
+    border: "0",
+  },
+  ".cm-md-format-toolbar": {
+    alignItems: "center",
+    backgroundColor: "var(--popover)",
+    border: "1px solid var(--border)",
+    borderRadius: "0.55rem",
+    boxShadow: "0 10px 30px color-mix(in oklch, black 14%, transparent)",
+    display: "flex",
+    gap: "0.15rem",
+    padding: "0.2rem",
+  },
+  ".cm-md-format-button": {
+    alignItems: "center",
+    background: "transparent",
+    border: "0",
+    borderRadius: "0.35rem",
+    color: "var(--popover-foreground)",
+    cursor: "pointer",
+    display: "inline-flex",
+    fontFamily: "var(--font-sans, sans-serif)",
+    fontSize: "0.72rem",
+    fontWeight: "650",
+    height: "1.75rem",
+    justifyContent: "center",
+    minWidth: "1.75rem",
+    padding: "0 0.35rem",
+  },
+  ".cm-md-format-button:hover, .cm-md-format-button:focus-visible": {
+    backgroundColor: "var(--accent)",
+    color: "var(--accent-foreground)",
+    outline: "none",
+  },
+  ".cm-md-heading": {
+    color: "var(--color-foreground, currentColor)",
+    fontFamily: "var(--typeset-font-heading, inherit)",
+    fontWeight: "600",
+  },
+  ".cm-md-heading-1": { fontSize: "1.75em", lineHeight: "1.3" },
+  ".cm-md-heading-2": { fontSize: "1.25em", lineHeight: "1.4" },
+  ".cm-md-heading-3": { fontSize: "1.125em", lineHeight: "1.45" },
+  ".cm-md-heading-4": { fontSize: "1em", lineHeight: "1.5" },
+  ".cm-md-heading-5": {
+    color: "var(--typeset-muted)",
+    fontSize: "0.875em",
+  },
+  ".cm-md-heading-6": {
+    color: "var(--typeset-muted)",
+    fontSize: "0.8125em",
+    letterSpacing: "0.08em",
+    textTransform: "uppercase",
+  },
+  ".cm-md-strong": { fontWeight: "600" },
+  ".cm-md-emphasis": { fontStyle: "italic" },
+  ".cm-md-inline-code": {
+    backgroundColor: "var(--muted)",
+    borderRadius: "0.25rem",
+    fontFamily: "var(--typeset-font-mono, monospace)",
+    fontSize: "0.86em",
+    padding: "0.04rem 0.2rem",
+  },
+  ".cm-md-code-line": {
+    backgroundColor: "color-mix(in oklch, var(--muted) 75%, transparent)",
+    fontFamily: "var(--typeset-font-mono, monospace)",
+    fontSize: "0.86em",
+    paddingLeft: "0.65rem",
+    paddingRight: "0.65rem",
+  },
+  ".cm-md-code-first": {
+    borderRadius: "0.4rem 0.4rem 0 0",
+    paddingTop: "0.35rem",
+  },
+  ".cm-md-code-last": {
+    borderRadius: "0 0 0.4rem 0.4rem",
+    paddingBottom: "0.35rem",
+  },
+  ".cm-md-quote": {
+    borderLeft: "2px solid var(--typeset-rule, var(--border))",
+    color: "var(--typeset-muted, var(--muted-foreground))",
+    paddingLeft: "0.65rem",
+  },
+  ".cm-md-divider": {
+    borderTop: "1px solid var(--typeset-rule, var(--border))",
+    height: "var(--typeset-flow, 1.25em)",
+    marginTop: "var(--typeset-flow, 1.25em)",
+  },
+  ".cm-md-syntax, .cm-md-image-source": {
+    color: "var(--typeset-muted, var(--muted-foreground))",
+    fontSize: "0.88em",
+  },
+  ".cm-md-list-marker": {
+    color: "var(--typeset-muted, var(--muted-foreground))",
+    display: "inline-block",
+    minWidth: "1.35rem",
+    paddingLeft: "0.15rem",
+  },
+  ".cm-md-link": {
+    color: "inherit",
+    cursor: "text",
+    fontWeight: "500",
+    textDecoration: "underline",
+    textDecorationColor: "color-mix(in oklab, currentColor 30%, transparent)",
+    textUnderlineOffset: "0.15em",
+  },
+  ".cm-md-link-unsafe": {
+    color: "var(--muted-foreground)",
+    textDecorationStyle: "dotted",
+  },
+});

--- a/packages/ui/src/components/text-editor/types.ts
+++ b/packages/ui/src/components/text-editor/types.ts
@@ -1,0 +1,16 @@
+export interface MarkdownTextEditorProps {
+  ariaLabel?: string;
+  autoFocus?: boolean;
+  className?: string;
+  disabled?: boolean;
+  minHeight?: string;
+  onChange: (content: string) => void;
+  onLimitExceeded?: () => void;
+  onOpenFullScreen?: () => void;
+  onSaveShortcut?: () => void;
+  placeholder?: string;
+  value: string;
+  variant?: "compact" | "document" | "modal";
+}
+
+export type MarkdownInlineFormat = "bold" | "code" | "italic" | "link";

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -157,3 +157,17 @@
 [data-sonner-toaster] .sonner-loading-bar {
   background: var(--primary-foreground);
 }
+
+.teak-markdown-editor {
+  --teak-editor-font-size: 1rem;
+}
+
+.teak-markdown-editor .cm-editor {
+  font-size: var(--teak-editor-font-size);
+}
+
+@media (min-width: 48rem) {
+  .teak-markdown-editor[data-editor-variant="compact"] {
+    --teak-editor-font-size: 0.875rem;
+  }
+}


### PR DESCRIPTION
## What changed

- Replace separate text editing and preview behavior with one continuous live Markdown editor across quick capture, full-screen creation, and saved text cards.
- Style inactive Markdown using Teak's existing typeset tokens while revealing source around active constructs.
- Add selection formatting, keyboard shortcuts, smart list continuation, safe link behavior, exact source preservation, and composer layout and focus fixes.
- Update web and production journey coverage and the July changelog.

## Why

Text cards should feel like a single Notion-style writing surface without mode switching, while preserving raw Markdown as the canonical value.

## Validation

- `bun run test`
- `bun run pre-commit`
- `gitleaks` diff scan
- `git diff --check`
- Live local browser verification
