### PR TITLE
fix: masonry markdown previews, modal scroll, API keys mobile layout, video covers

### DIFF
--- a/apps/web/src/app/HomePageClient.tsx
+++ b/apps/web/src/app/HomePageClient.tsx
@@ -32,12 +32,14 @@ export function HomePageClient() {
     const nextQuery = params.toString();
     const nextUrl = nextQuery ? `${pathname}?${nextQuery}` : pathname;
 
+    // Opening/closing the card modal only toggles a query param; keep the
+    // masonry scroll position instead of letting the router jump to the top.
     if (replace) {
-      router.replace(nextUrl);
+      router.replace(nextUrl, { scroll: false });
       return;
     }
 
-    router.push(nextUrl);
+    router.push(nextUrl, { scroll: false });
   };
 
   const handleUpgrade = () => {

--- a/packages/ui/src/components/card-previews/__tests__/markdownToPlainText.test.ts
+++ b/packages/ui/src/components/card-previews/__tests__/markdownToPlainText.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { markdownToPlainText } from "../../../lib/markdownToPlainText";
+
+describe("markdownToPlainText", () => {
+  test("returns an empty string for empty input", () => {
+    expect(markdownToPlainText("")).toBe("");
+    expect(markdownToPlainText(undefined)).toBe("");
+    expect(markdownToPlainText(null)).toBe("");
+  });
+
+  test("strips leading heading markers", () => {
+    expect(markdownToPlainText("# Hello world")).toBe("Hello world");
+    expect(markdownToPlainText("### Deep heading")).toBe("Deep heading");
+  });
+
+  test("removes HTML comments", () => {
+    expect(
+      markdownToPlainText("# Vadivam <!-- vadivam-icon-count:start -->")
+    ).toBe("Vadivam");
+  });
+
+  test("flattens list markers and collapses whitespace", () => {
+    expect(markdownToPlainText("- asda - sda - sd")).toBe("asda - sda - sd");
+    expect(markdownToPlainText("1. First\n2. Second")).toBe("First Second");
+  });
+
+  test("keeps link and image text without the markup", () => {
+    expect(markdownToPlainText("See [the docs](https://example.com)")).toBe(
+      "See the docs"
+    );
+    expect(markdownToPlainText("![alt text](https://example.com/x.png)")).toBe(
+      "alt text"
+    );
+  });
+
+  test("removes inline emphasis and code markers", () => {
+    expect(markdownToPlainText("**bold** and *italic* and `code`")).toBe(
+      "bold and italic and code"
+    );
+  });
+
+  test("cleans up single-line markdown documents", () => {
+    expect(
+      markdownToPlainText("# AGENTS.md ## Project Overview Vadivam is a Bun")
+    ).toBe("AGENTS.md Project Overview Vadivam is a Bun");
+  });
+
+  test("preserves plain text unchanged", () => {
+    expect(markdownToPlainText("Blog post ideas - I forget CSS")).toBe(
+      "Blog post ideas - I forget CSS"
+    );
+  });
+});

--- a/packages/ui/src/components/cards/Card.tsx
+++ b/packages/ui/src/components/cards/Card.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react";
 import type { SyntheticEvent } from "react";
 import { memo, useState } from "react";
+import { markdownToPlainText } from "../../lib/markdownToPlainText";
 import { prefetchFileTextPreview } from "../card-previews/fileTextPreviewCache";
 import { AudioWavePreview } from "./previews/AudioWavePreview";
 import { GridDocumentPreview } from "./previews/GridDocumentPreview";
@@ -243,7 +244,7 @@ export const Card = memo(function Card({
       return (
         <div className="rounded-xl border bg-card p-4">
           <p className="line-clamp-2 font-medium">
-            {card.content || card.fileMetadata?.fileName}
+            {markdownToPlainText(card.content) || card.fileMetadata?.fileName}
           </p>
         </div>
       );
@@ -254,7 +255,7 @@ export const Card = memo(function Card({
         <div className="rounded-xl border bg-card px-6 py-4">
           <div className="relative">
             <p className="line-clamp-2 text-balance text-center font-medium italic leading-relaxed">
-              {card.content}
+              {markdownToPlainText(card.content)}
             </p>
             <div className="pointer-events-none absolute -top-3.5 -left-4 select-none font-serif text-4xl text-muted-foreground/20 leading-none">
               &ldquo;
@@ -318,7 +319,7 @@ export const Card = memo(function Card({
 
       return (
         <p className="w-full min-w-0 overflow-hidden truncate text-ellipsis whitespace-nowrap rounded-xl border bg-card p-4 font-medium">
-          {card.content || linkCardTitle}
+          {markdownToPlainText(card.content) || linkCardTitle}
         </p>
       );
     }
@@ -335,7 +336,18 @@ export const Card = memo(function Card({
     }
 
     if (card.type === "video") {
-      return <GridVideoPreview thumbnailUrl={card.thumbnailUrl ?? undefined} />;
+      const isGif =
+        card.fileMetadata?.mimeType === "image/gif" ||
+        (card.fileMetadata?.fileName?.toLowerCase().endsWith(".gif") ?? false);
+      return (
+        <GridVideoPreview
+          height={card.fileMetadata?.height}
+          isGif={isGif}
+          thumbnailUrl={card.thumbnailUrl ?? undefined}
+          videoUrl={card.fileUrl ?? undefined}
+          width={card.fileMetadata?.width}
+        />
+      );
     }
 
     if (card.type === "audio") {
@@ -369,7 +381,9 @@ export const Card = memo(function Card({
 
       return (
         <div className="rounded-xl border bg-card p-4">
-          <p className="line-clamp-2 font-medium">{card.content}</p>
+          <p className="line-clamp-2 font-medium">
+            {markdownToPlainText(card.content)}
+          </p>
         </div>
       );
     }
@@ -377,7 +391,7 @@ export const Card = memo(function Card({
     return (
       <div className="rounded-xl border bg-card p-4">
         <p className="line-clamp-2 font-medium">
-          {card.content || card.fileMetadata?.fileName}
+          {markdownToPlainText(card.content) || card.fileMetadata?.fileName}
         </p>
       </div>
     );

--- a/packages/ui/src/components/cards/previews/GridVideoPreview.tsx
+++ b/packages/ui/src/components/cards/previews/GridVideoPreview.tsx
@@ -2,10 +2,30 @@ import { Image } from "antd";
 import { Play } from "lucide-react";
 
 interface GridVideoPreviewProps {
+  height?: number;
+  isGif?: boolean;
   thumbnailUrl?: string;
+  videoUrl?: string;
+  width?: number;
 }
 
-export function GridVideoPreview({ thumbnailUrl }: GridVideoPreviewProps) {
+function PlayOverlay() {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center bg-black/20">
+      <div className="rounded-full bg-black/50 p-2">
+        <Play className="size-6 text-white" />
+      </div>
+    </div>
+  );
+}
+
+export function GridVideoPreview({
+  height,
+  isGif,
+  thumbnailUrl,
+  videoUrl,
+  width,
+}: GridVideoPreviewProps) {
   if (thumbnailUrl) {
     return (
       <div className="relative overflow-hidden rounded-xl border bg-card">
@@ -17,11 +37,43 @@ export function GridVideoPreview({ thumbnailUrl }: GridVideoPreviewProps) {
           preview={false}
           src={thumbnailUrl}
         />
-        <div className="absolute inset-0 flex items-center justify-center bg-black/20">
-          <div className="rounded-full bg-black/50 p-2">
-            <Play className="size-6 text-white" />
-          </div>
+        <PlayOverlay />
+      </div>
+    );
+  }
+
+  // No generated thumbnail yet: render a real frame from the media itself so
+  // the card never falls back to an empty black cover.
+  if (videoUrl) {
+    if (isGif) {
+      return (
+        <div className="relative overflow-hidden rounded-xl border bg-card">
+          <img
+            alt="GIF preview"
+            className="w-full object-cover"
+            height={height ?? 480}
+            loading="lazy"
+            src={videoUrl}
+            width={width ?? 640}
+          />
         </div>
+      );
+    }
+
+    return (
+      <div className="relative overflow-hidden rounded-xl border bg-card">
+        <video
+          className="w-full object-cover"
+          muted
+          playsInline
+          preload="metadata"
+          // Seek slightly into the clip so we render actual content instead of
+          // a leading black frame.
+          src={`${videoUrl}#t=0.1`}
+        >
+          <track kind="captions" />
+        </video>
+        <PlayOverlay />
       </div>
     );
   }

--- a/packages/ui/src/components/settings/ApiKeysDialog.tsx
+++ b/packages/ui/src/components/settings/ApiKeysDialog.tsx
@@ -209,9 +209,13 @@ export function ApiKeysDialog({
               <table className="w-full table-fixed caption-bottom text-sm">
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="w-[58%] pr-2 pl-3">Key</TableHead>
-                    <TableHead className="w-[26%] px-2">Used</TableHead>
-                    <TableHead className="w-[16%] pr-3 pl-2" />
+                    <TableHead className="w-[70%] pr-2 pl-3 sm:w-[58%]">
+                      Key
+                    </TableHead>
+                    <TableHead className="hidden px-2 sm:table-cell sm:w-[26%]">
+                      Used
+                    </TableHead>
+                    <TableHead className="w-[30%] pr-3 pl-2 sm:w-[16%]" />
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -242,8 +246,11 @@ export function ApiKeysDialog({
                           <div className="truncate text-muted-foreground text-xs">
                             Created {formatDate(key.createdAt)}
                           </div>
+                          <div className="truncate text-muted-foreground text-xs sm:hidden">
+                            Used {formatDate(key.lastUsedAt)}
+                          </div>
                         </TableCell>
-                        <TableCell className="whitespace-nowrap px-2 text-muted-foreground">
+                        <TableCell className="hidden whitespace-nowrap px-2 text-muted-foreground sm:table-cell">
                           {formatDate(key.lastUsedAt)}
                         </TableCell>
                         <TableCell className="pr-3 pl-2">

--- a/packages/ui/src/lib/markdownToPlainText.ts
+++ b/packages/ui/src/lib/markdownToPlainText.ts
@@ -1,0 +1,70 @@
+const MAX_PREVIEW_LENGTH = 500;
+
+/**
+ * Convert markdown to plain text for compact card previews.
+ *
+ * Grid cards only show a line or two, so this favours readable text over a
+ * faithful markdown render: block markers (headings, list bullets,
+ * blockquotes, horizontal rules), inline emphasis, links/images, inline code,
+ * HTML tags and comments are stripped, and whitespace is collapsed to single
+ * spaces. Only a short prefix is processed since the preview is clamped.
+ */
+export function markdownToPlainText(input?: string | null): string {
+  if (!input) {
+    return "";
+  }
+
+  const withoutBlocks = input
+    .slice(0, MAX_PREVIEW_LENGTH)
+    // HTML comments, e.g. <!-- vadivam-icon-count:start -->
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    // Fenced code block fences and their language hints
+    .replace(/^\s*(?:```|~~~).*$/gm, " ")
+    // Images: keep the alt text
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    // Inline and reference links: keep the label
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]*)\]\[[^\]]*\]/g, "$1")
+    // Any remaining HTML tags
+    .replace(/<\/?[a-zA-Z][^>]*>/g, " ");
+
+  const lines = withoutBlocks.split(/\r?\n/).map((rawLine) => {
+    const line = rawLine.trim();
+
+    // Horizontal rules -> drop entirely
+    if (/^(?:[-*_]\s*){3,}$/.test(line)) {
+      return "";
+    }
+
+    return (
+      line
+        // Leading heading markers (#, ##, ...)
+        .replace(/^#{1,6}\s+/, "")
+        // Leading blockquote markers, possibly nested
+        .replace(/^(?:>\s?)+/, "")
+        // Task list checkboxes
+        .replace(/^[-*+]\s+\[[ xX]\]\s+/, "")
+        // Unordered list bullets
+        .replace(/^[-*+]\s+/, "")
+        // Ordered list markers (1. or 1))
+        .replace(/^\d+[.)]\s+/, "")
+    );
+  });
+
+  return (
+    lines
+      .join(" ")
+      // Inline code -> keep the contents
+      .replace(/`([^`]+)`/g, "$1")
+      // Bold / italic / strikethrough (paired markers)
+      .replace(/(\*\*|__)(.+?)\1/g, "$2")
+      .replace(/(\*|_)(.+?)\1/g, "$2")
+      .replace(/~~(.+?)~~/g, "$1")
+      // Mid-line heading runs left over from single-line markdown, e.g.
+      // "AGENTS.md ## Project Overview" -> "AGENTS.md Project Overview"
+      .replace(/\s+#{1,6}\s+/g, " ")
+      // Collapse remaining whitespace
+      .replace(/\s+/g, " ")
+      .trim()
+  );
+}


### PR DESCRIPTION
## Summary

Four fixes reported from the mobile web app (`app.teakvault.com`):

1. **Masonry grid shows raw markdown** — text/quote/palette cards rendered raw markdown (`# Hello world`, list bullets, `<!-- comments -->`, emphasis). Now a small `markdownToPlainText` helper strips markdown to plain text for the compact previews.
2. **Opening a card modal scrolled the grid back to the top** — opening a card only toggles the `?card=` query param, but `router.push`/`router.replace` default to `scroll: true`. Now both pass `{ scroll: false }`, preserving the masonry scroll position.
3. **API keys dialog not mobile responsive** — the wide "Used" date column overflowed and overlapped the row action buttons on small screens. The Used column is now hidden on mobile (`hidden sm:table-cell`) with the used date surfaced inline in the key cell; it stays a full column on `sm+`.
4. **Video/GIF cards showed a black cover** — when no generated thumbnail exists, the grid fell back to an empty black box. It now renders a real frame: a `<video>` seeked slightly in (`#t=0.1`) to avoid a leading black frame, or the GIF itself.

## Changes

- `packages/ui/src/lib/markdownToPlainText.ts` — new helper (headings, list/quote markers, HTML comments/tags, links/images, inline code, emphasis → plain text; whitespace collapsed; input capped since previews are clamped).
- `packages/ui/src/components/cards/Card.tsx` — use the helper for text/quote/palette/link/default previews; pass media URL + dimensions and GIF detection to the video preview.
- `packages/ui/src/components/cards/previews/GridVideoPreview.tsx` — real-frame fallback (video frame or GIF) when no thumbnail; shared play overlay.
- `packages/ui/src/components/settings/ApiKeysDialog.tsx` — responsive table (mobile hides the Used column and shows the used date inline).
- `apps/web/src/app/HomePageClient.tsx` — `{ scroll: false }` on card modal navigation.

## Testing

- New unit test `markdownToPlainText.test.ts` (8 cases) — passing.
- Existing `Card.test.tsx` and `ApiKeysDialog` contract assertions verified — passing.
- `@teak/ui` and `@teak/web` `tsc --noEmit` — clean.
- Biome check on all changed files — clean.

## Notes

- The video/GIF fallback is purely client-side, so black covers are fixed regardless of the server thumbnail pipeline; generated thumbnails still take priority when present.
- Not yet verified visually in a running app on a real device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYE9fFqwmpFSnTi1NSYUF3

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYE9fFqwmpFSnTi1NSYUF3)_