### PR TITLE
fix: reserve aspect ratio for video cards in masonry grid

### DIFF
--- a/apps/docs/src/content/changelog/2026-07.mdx
+++ b/apps/docs/src/content/changelog/2026-07.mdx
@@ -29,3 +29,4 @@ date: "2026-07-10"
 - Signing out on the web now works reliably instead of showing an error screen.
 - Large image cards now finish previews, colors, and AI details more reliably, and deleting a card while it is still processing no longer produces follow-up errors.
 - Moving between web screens now responds immediately while account data loads.
+- Video cards in your library keep a stable height while loading, so the grid no longer jumps when a video appears.

--- a/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
+++ b/packages/convex/__tests__/shared/hooks/useFileUpload.test.ts
@@ -35,7 +35,14 @@ const originalURL = global.URL;
 beforeAll(() => {
   global.fetch = mockFetch;
   global.window = {} as any;
-  global.document = {} as any;
+  global.document = {
+    createElement: (tag: string) => {
+      if (tag === "video") {
+        return new MockVideo();
+      }
+      return {};
+    },
+  } as any;
   global.URL = {
     createObjectURL: mock(() => "blob:url"),
     revokeObjectURL: mock(),
@@ -73,6 +80,30 @@ class MockImage {
   }
 }
 global.Image = MockImage as any;
+
+class MockVideo {
+  muted = false;
+  playsInline = false;
+  preload = "";
+  onloadedmetadata: any;
+  onerror: any;
+  videoWidth = 0;
+  videoHeight = 0;
+  _src = "";
+
+  set src(value: string) {
+    this._src = value;
+    setTimeout(() => {
+      if (value === "blob:url") {
+        this.videoWidth = 1280;
+        this.videoHeight = 720;
+        this.onloadedmetadata?.();
+      } else {
+        this.onerror?.();
+      }
+    }, 10);
+  }
+}
 
 import {
   type FileUploadDependencies,
@@ -797,6 +828,60 @@ describe("useFileUploadCore", () => {
       expect(mockUploadAndCreateCard).toHaveBeenCalledWith(
         expect.objectContaining({
           additionalMetadata: { width: 100, height: 200 },
+        })
+      );
+    });
+
+    test("extracts video dimensions when not provided", async () => {
+      const file = { size: 100, name: "test.mp4", type: "video/mp4" } as any;
+
+      mockUploadAndCreateCard.mockResolvedValue({
+        success: true,
+        uploadUrl: "https://upload",
+        uploadKey: "store_1",
+      });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ storageId: "store_1" }),
+      });
+      mockFinalizeUploadedCard.mockResolvedValue({
+        success: true,
+        cardId: "card_1",
+      });
+
+      await hook.uploadFile(file);
+
+      expect(mockUploadAndCreateCard).toHaveBeenCalledWith(
+        expect.objectContaining({
+          additionalMetadata: { width: 1280, height: 720 },
+        })
+      );
+    });
+
+    test("handles video load failure gracefully", async () => {
+      const file = { size: 100, name: "test.mp4", type: "video/mp4" } as any;
+
+      (global.URL.createObjectURL as any).mockReturnValueOnce("blob:fail");
+
+      mockUploadAndCreateCard.mockResolvedValue({
+        success: true,
+        uploadUrl: "https://upload",
+        uploadKey: "store_1",
+      });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ storageId: "store_1" }),
+      });
+      mockFinalizeUploadedCard.mockResolvedValue({
+        success: true,
+        cardId: "card_1",
+      });
+
+      await hook.uploadFile(file);
+
+      expect(mockUploadAndCreateCard).toHaveBeenCalledWith(
+        expect.objectContaining({
+          additionalMetadata: undefined,
         })
       );
     });

--- a/packages/convex/client/hooks/useFileUpload.client.tsx
+++ b/packages/convex/client/hooks/useFileUpload.client.tsx
@@ -52,6 +52,48 @@ function getImageDimensions(
   });
 }
 
+// Best-effort video dimension extraction (browser-only).
+// Returns undefined when dimensions cannot be determined or we're in a non-DOM environment.
+function getVideoDimensions(
+  file: File
+): Promise<{ width: number; height: number } | undefined> {
+  if (
+    typeof window === "undefined" ||
+    typeof document === "undefined" ||
+    typeof document.createElement !== "function" ||
+    !file.type?.startsWith("video/")
+  ) {
+    return Promise.resolve(undefined);
+  }
+
+  const objectUrl = URL.createObjectURL(file);
+
+  return new Promise((resolve) => {
+    const video = document.createElement("video");
+    video.preload = "metadata";
+    video.muted = true;
+    video.playsInline = true;
+
+    const cleanup = () => {
+      URL.revokeObjectURL(objectUrl);
+    };
+
+    video.onloadedmetadata = () => {
+      const width = video.videoWidth;
+      const height = video.videoHeight;
+      cleanup();
+      resolve(width && height ? { width, height } : undefined);
+    };
+
+    video.onerror = () => {
+      cleanup();
+      resolve(undefined);
+    };
+
+    video.src = objectUrl;
+  });
+}
+
 async function buildAdditionalMetadata(
   file: File,
   metadata?: any
@@ -61,7 +103,8 @@ async function buildAdditionalMetadata(
     return metadata;
   }
 
-  const dimensions = await getImageDimensions(file);
+  const dimensions =
+    (await getImageDimensions(file)) ?? (await getVideoDimensions(file));
   if (dimensions) {
     return { ...dimensions, ...metadata };
   }
@@ -354,7 +397,7 @@ export function useFileUploadCore(
           throw codedError;
         }
 
-        // Attach image dimensions when possible to avoid layout shifts in grids
+        // Attach image/video dimensions when possible to avoid layout shifts in grids
         const mergedAdditionalMetadata = await buildAdditionalMetadata(
           file,
           options.additionalMetadata

--- a/packages/ui/src/components/cards/previews/GridVideoPreview.tsx
+++ b/packages/ui/src/components/cards/previews/GridVideoPreview.tsx
@@ -26,15 +26,22 @@ export function GridVideoPreview({
   videoUrl,
   width,
 }: GridVideoPreviewProps) {
+  const aspectRatio = width && height ? width / height : 16 / 9;
+
   if (thumbnailUrl) {
     return (
-      <div className="relative overflow-hidden rounded-xl border bg-card">
+      <div
+        className="relative h-full w-full overflow-hidden rounded-xl border bg-card"
+        style={{ aspectRatio }}
+      >
         <Image
           alt="Video thumbnail"
-          className="w-full object-cover"
+          className="h-full w-full object-cover"
           loading="lazy"
           preview={false}
+          rootClassName="h-full w-full"
           src={thumbnailUrl}
+          style={{ objectFit: "cover" }}
         />
         <PlayOverlay />
       </div>
@@ -46,10 +53,13 @@ export function GridVideoPreview({
   if (videoUrl) {
     if (isGif) {
       return (
-        <div className="relative overflow-hidden rounded-xl border bg-card">
+        <div
+          className="relative h-full w-full overflow-hidden rounded-xl border bg-card"
+          style={{ aspectRatio }}
+        >
           <img
             alt="GIF preview"
-            className="w-full object-cover"
+            className="h-full w-full object-cover"
             height={height ?? 480}
             loading="lazy"
             src={videoUrl}
@@ -60,9 +70,12 @@ export function GridVideoPreview({
     }
 
     return (
-      <div className="relative overflow-hidden rounded-xl border bg-card">
+      <div
+        className="relative h-full w-full overflow-hidden rounded-xl border bg-card"
+        style={{ aspectRatio }}
+      >
         <video
-          className="w-full object-cover"
+          className="h-full w-full object-cover"
           muted
           playsInline
           preload="metadata"
@@ -78,7 +91,10 @@ export function GridVideoPreview({
   }
 
   return (
-    <div className="flex h-32 w-full items-center justify-center rounded-xl border bg-black text-white">
+    <div
+      className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-xl border bg-black text-white"
+      style={{ aspectRatio }}
+    >
       <Play className="size-6 text-white" />
     </div>
   );


### PR DESCRIPTION
## Summary
- Reserve video card height in the masonry grid with CSS aspect-ratio from stored dimensions (16/9 fallback), matching image cards
- Probe video width/height at upload so new videos keep a stable layout before thumbnail processing
- Changelog note for stable video card heights while loading

## Test plan
- [ ] Upload a video and confirm the grid card height stays stable before/after the thumbnail appears
- [ ] Refresh the library with existing video cards and confirm no height jump on load
- [ ] Confirm images and GIFs still reserve height correctly
- [ ] Confirm `bun test packages/convex/__tests__/shared/hooks/useFileUpload.test.ts` passes


Made with [Cursor](https://cursor.com)