### PR TITLE
feat: play muted video previews on hover in masonry grid

### DIFF
--- a/apps/docs/src/content/changelog/2026-07.mdx
+++ b/apps/docs/src/content/changelog/2026-07.mdx
@@ -30,3 +30,4 @@ date: "2026-07-10"
 - Large image cards now finish previews, colors, and AI details more reliably, and deleting a card while it is still processing no longer produces follow-up errors.
 - Moving between web screens now responds immediately while account data loads.
 - Video cards in your library keep a stable height while loading, so the grid no longer jumps when a video appears.
+- Hover a video card in your library to preview it muted.

--- a/packages/ui/src/components/cards/previews/GridVideoPreview.tsx
+++ b/packages/ui/src/components/cards/previews/GridVideoPreview.tsx
@@ -1,5 +1,6 @@
 import { Image } from "antd";
 import { Play } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 interface GridVideoPreviewProps {
   height?: number;
@@ -19,6 +20,92 @@ function PlayOverlay() {
   );
 }
 
+function HoverVideoPreview({
+  aspectRatio,
+  thumbnailUrl,
+  videoUrl,
+}: {
+  aspectRatio: number;
+  thumbnailUrl?: string;
+  videoUrl: string;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [isHovering, setIsHovering] = useState(false);
+  // Defer mounting the video until first hover when a thumbnail can cover idle.
+  // Without a thumbnail, mount immediately so the card still shows a frame.
+  const [shouldLoadVideo, setShouldLoadVideo] = useState(!thumbnailUrl);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || !shouldLoadVideo) {
+      return;
+    }
+
+    if (isHovering) {
+      void video.play().catch(() => {
+        // Autoplay may be blocked; keep the idle thumbnail/frame visible.
+      });
+      return;
+    }
+
+    video.pause();
+    try {
+      // Seek slightly into the clip so idle frames aren't a leading black frame.
+      video.currentTime = 0.1;
+    } catch {
+      // Ignore seek errors before metadata is ready.
+    }
+  }, [isHovering, shouldLoadVideo]);
+
+  return (
+    <div
+      className="relative h-full w-full overflow-hidden rounded-xl border bg-card"
+      onMouseEnter={() => {
+        setShouldLoadVideo(true);
+        setIsHovering(true);
+      }}
+      onMouseLeave={() => {
+        setIsHovering(false);
+      }}
+      style={{ aspectRatio }}
+    >
+      {thumbnailUrl ? (
+        <div className={isHovering ? "invisible" : undefined}>
+          <Image
+            alt="Video thumbnail"
+            className="h-full w-full object-cover"
+            loading="lazy"
+            preview={false}
+            rootClassName="h-full w-full"
+            src={thumbnailUrl}
+            style={{ objectFit: "cover" }}
+          />
+        </div>
+      ) : null}
+
+      {shouldLoadVideo ? (
+        <video
+          className={
+            thumbnailUrl
+              ? `absolute inset-0 h-full w-full object-cover ${isHovering ? "" : "invisible"}`
+              : "h-full w-full object-cover"
+          }
+          loop
+          muted
+          playsInline
+          preload="metadata"
+          ref={videoRef}
+          src={videoUrl}
+        >
+          <track kind="captions" />
+        </video>
+      ) : null}
+
+      {isHovering ? null : <PlayOverlay />}
+    </div>
+  );
+}
+
 export function GridVideoPreview({
   height,
   isGif,
@@ -27,6 +114,34 @@ export function GridVideoPreview({
   width,
 }: GridVideoPreviewProps) {
   const aspectRatio = width && height ? width / height : 16 / 9;
+
+  if (isGif && videoUrl) {
+    return (
+      <div
+        className="relative h-full w-full overflow-hidden rounded-xl border bg-card"
+        style={{ aspectRatio }}
+      >
+        <img
+          alt="GIF preview"
+          className="h-full w-full object-cover"
+          height={height ?? 480}
+          loading="lazy"
+          src={videoUrl}
+          width={width ?? 640}
+        />
+      </div>
+    );
+  }
+
+  if (videoUrl) {
+    return (
+      <HoverVideoPreview
+        aspectRatio={aspectRatio}
+        thumbnailUrl={thumbnailUrl}
+        videoUrl={videoUrl}
+      />
+    );
+  }
 
   if (thumbnailUrl) {
     return (
@@ -43,48 +158,6 @@ export function GridVideoPreview({
           src={thumbnailUrl}
           style={{ objectFit: "cover" }}
         />
-        <PlayOverlay />
-      </div>
-    );
-  }
-
-  // No generated thumbnail yet: render a real frame from the media itself so
-  // the card never falls back to an empty black cover.
-  if (videoUrl) {
-    if (isGif) {
-      return (
-        <div
-          className="relative h-full w-full overflow-hidden rounded-xl border bg-card"
-          style={{ aspectRatio }}
-        >
-          <img
-            alt="GIF preview"
-            className="h-full w-full object-cover"
-            height={height ?? 480}
-            loading="lazy"
-            src={videoUrl}
-            width={width ?? 640}
-          />
-        </div>
-      );
-    }
-
-    return (
-      <div
-        className="relative h-full w-full overflow-hidden rounded-xl border bg-card"
-        style={{ aspectRatio }}
-      >
-        <video
-          className="h-full w-full object-cover"
-          muted
-          playsInline
-          preload="metadata"
-          // Seek slightly into the clip so we render actual content instead of
-          // a leading black frame.
-          src={`${videoUrl}#t=0.1`}
-        >
-          <track kind="captions" />
-        </video>
         <PlayOverlay />
       </div>
     );


### PR DESCRIPTION
## Summary
- Hover video cards in the library to preview them muted and looping
- Keep the thumbnail idle state (and aspect-ratio reservation); mount the video on first hover when a thumbnail exists
- GIFs stay as animated images; changelog notes the hover preview

## Test plan
- [ ] Hover a video card with a thumbnail and confirm muted looping playback starts
- [ ] Move the cursor away and confirm it pauses and returns to the thumbnail with the play overlay
- [ ] Confirm GIF cards still animate without hover logic
- [ ] Confirm video cards without a thumbnail still show a frame and play on hover
- [ ] Confirm a grid of many videos does not load all video media until hovered


Made with [Cursor](https://cursor.com)