### PR TITLE
Release 1.0.60

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak-cli",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "description": "Command-line client for Teak, the personal knowledge hub for saving and rediscovering ideas.",
   "type": "module",
   "bin": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@teak/desktop",
   "productName": "Teak",
   "private": true,
-  "version": "1.0.59",
+  "version": "1.0.60",
   "type": "module",
   "main": ".vite/build/main.js",
   "scripts": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/docs",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "engines": {
     "node": ">=22.12.0"
   },

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teak/extension",
   "description": "Teak - Your Personal Knowledge Hub. Save, organize, and rediscover web content, text selections, and ideas effortlessly.",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "author": "Praveen Juge (hi@praveenjuge.com)",
   "homepage": "https://teakvault.com",
   "type": "module",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/mobile",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "main": "expo-router/entry",
   "scripts": {
     "build": "expo export --platform web --clear",

--- a/apps/raycast/package-lock.json
+++ b/apps/raycast/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teak-raycast",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teak-raycast",
-      "version": "1.0.59",
+      "version": "1.0.60",
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.19",

--- a/apps/raycast/package.json
+++ b/apps/raycast/package.json
@@ -1,7 +1,7 @@
 {
   "name": "teak-raycast",
   "title": "Teak",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "private": true,
   "license": "MIT",
   "description": "Save ideas fast, search your Teak cards, and access favorites directly from Raycast.",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/web",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/cli": {
       "name": "teak-cli",
-      "version": "1.0.59",
+      "version": "1.0.60",
       "bin": {
         "teak": "./dist/index.js",
       },
@@ -30,7 +30,7 @@
     },
     "apps/desktop": {
       "name": "@teak/desktop",
-      "version": "1.0.59",
+      "version": "1.0.60",
       "dependencies": {
         "@sentry/electron": "7.15.0",
         "@tailwindcss/vite": "^4.3.0",
@@ -64,7 +64,7 @@
     },
     "apps/docs": {
       "name": "@teak/docs",
-      "version": "1.0.59",
+      "version": "1.0.60",
       "dependencies": {
         "@teak/convex": "workspace:*",
         "blume": "^1.2.1",
@@ -77,7 +77,7 @@
     },
     "apps/extension": {
       "name": "@teak/extension",
-      "version": "1.0.59",
+      "version": "1.0.60",
       "dependencies": {
         "@convex-dev/better-auth": "0.12.5",
         "@tailwindcss/vite": "^4.3.0",
@@ -100,7 +100,7 @@
     },
     "apps/mobile": {
       "name": "@teak/mobile",
-      "version": "1.0.59",
+      "version": "1.0.60",
       "dependencies": {
         "@better-auth/expo": "1.6.23",
         "@convex-dev/better-auth": "0.12.5",
@@ -155,7 +155,7 @@
     },
     "apps/raycast": {
       "name": "teak-raycast",
-      "version": "1.0.59",
+      "version": "1.0.60",
       "dependencies": {
         "@raycast/api": "^1.104.19",
         "@raycast/utils": "^2.2.7",
@@ -169,7 +169,7 @@
     },
     "apps/web": {
       "name": "@teak/web",
-      "version": "1.0.59",
+      "version": "1.0.60",
       "dependencies": {
         "@convex-dev/better-auth": "^0.12.5",
         "@polar-sh/checkout": "^0.2.1",
@@ -206,7 +206,7 @@
     },
     "packages/convex": {
       "name": "@teak/convex",
-      "version": "1.0.59",
+      "version": "1.0.60",
       "dependencies": {
         "@ai-sdk/groq": "^3.0.39",
         "@aws-sdk/client-s3": "3.1069.0",
@@ -250,7 +250,7 @@
     },
     "packages/tests": {
       "name": "@teak/tests",
-      "version": "1.0.59",
+      "version": "1.0.60",
       "dependencies": {
         "@axe-core/playwright": "^4.12.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -269,7 +269,7 @@
     },
     "packages/ui": {
       "name": "@teak/ui",
-      "version": "1.0.59",
+      "version": "1.0.60",
       "dependencies": {
         "@codemirror/commands": "6.10.4",
         "@codemirror/lang-markdown": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "private": true,
   "packageManager": "bun@1.3.5",
   "workspaces": [

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/convex",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "type": "module",
   "exports": {
     ".": "./index.ts",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/tests",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/ui",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "private": true,
   "exports": {
     "./logo": "./src/logo.tsx",


### PR DESCRIPTION
## Summary
- bump every tracked package from 1.0.59 to 1.0.60 in lockstep
- refresh the workspace lockfile
- trigger the canonical Version Tag release fanout after merge

## Validation
- exact next-patch and lockstep checks
- Expo resolves marketing version 1.0.60
- bun install --lockfile-only
- full pre-commit matrix: 22/22 typecheck, lint, and build tasks passed

This package-only patch bump is the single manual release action.