### PR TITLE
fix(release): recover Apple App Store submissions

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -82,9 +82,20 @@ jobs:
             exit 1
           fi
           node scripts/release-version.mjs lockstep "$VERSION"
-          if [ "$DRY_RUN" != "true" ] && [ "$GITHUB_REF_NAME" != "v$VERSION" ]; then
-            echo "A real release must run from v$VERSION; received $GITHUB_REF_NAME." >&2
-            exit 1
+          if [ "$DRY_RUN" != "true" ]; then
+            release_tag="v$VERSION"
+            tag_commit="$(git rev-list -n 1 "$release_tag" 2>/dev/null || true)"
+            if [ -z "$tag_commit" ]; then
+              echo "A real release requires the existing $release_tag tag." >&2
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "$tag_commit" "$GITHUB_SHA"; then
+              echo "A real release must run from $release_tag or one of its descendant recovery commits." >&2
+              exit 1
+            fi
+            if [ "$tag_commit" != "$GITHUB_SHA" ]; then
+              echo "- Recovery source: $GITHUB_SHA (descends from $release_tag at $tag_commit)" >> "$GITHUB_STEP_SUMMARY"
+            fi
           fi
 
           expo_version="$(cd apps/mobile && bunx expo config --type public --json | jq -r '.version')"
@@ -181,7 +192,7 @@ jobs:
           bunx eas-cli@"$EAS_CLI_VERSION" build:list \
             --platform ios \
             --build-profile production \
-            --limit 100 \
+            --limit 50 \
             --json \
             --non-interactive > "$builds_json"
 

--- a/.github/workflows/safari-extension-release.yml
+++ b/.github/workflows/safari-extension-release.yml
@@ -73,9 +73,20 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           node scripts/release-version.mjs lockstep "$VERSION"
-          if [ "$DRY_RUN" != "true" ] && [ "$GITHUB_REF_NAME" != "v$VERSION" ]; then
-            echo "A real release must run from v$VERSION; received $GITHUB_REF_NAME." >&2
-            exit 1
+          if [ "$DRY_RUN" != "true" ]; then
+            release_tag="v$VERSION"
+            tag_commit="$(git rev-list -n 1 "$release_tag" 2>/dev/null || true)"
+            if [ -z "$tag_commit" ]; then
+              echo "A real release requires the existing $release_tag tag." >&2
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "$tag_commit" "$GITHUB_SHA"; then
+              echo "A real release must run from $release_tag or one of its descendant recovery commits." >&2
+              exit 1
+            fi
+            if [ "$tag_commit" != "$GITHUB_SHA" ]; then
+              echo "- Recovery source: $GITHUB_SHA (descends from $release_tag at $tag_commit)" >> "$GITHUB_STEP_SUMMARY"
+            fi
           fi
           asc auth status --validate --output table
           asc_version="$(asc --version | awk '{print $1}')"
@@ -256,9 +267,8 @@ jobs:
         env:
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_DISTRIBUTION_PRIVATE_KEY_BASE64: ${{ secrets.APPLE_DISTRIBUTION_PRIVATE_KEY_BASE64 }}
-          EXPECTED_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
         run: |
-          if [ -z "$APPLE_CERTIFICATE_PASSWORD" ] || [ -z "$APPLE_DISTRIBUTION_PRIVATE_KEY_BASE64" ] || [ -z "$EXPECTED_SIGNING_IDENTITY" ]; then
+          if [ -z "$APPLE_CERTIFICATE_PASSWORD" ] || [ -z "$APPLE_DISTRIBUTION_PRIVATE_KEY_BASE64" ]; then
             echo "Missing Safari signing credentials." >&2
             exit 1
           fi
@@ -309,8 +319,8 @@ jobs:
 
           distribution_identity="$(openssl x509 -in "$RUNNER_TEMP/distribution.pem" -noout -subject -nameopt multiline | awk -F'= ' '/commonName/{print $2; exit}')"
           installer_identity="$(openssl x509 -in "$RUNNER_TEMP/installer.pem" -noout -subject -nameopt multiline | awk -F'= ' '/commonName/{print $2; exit}')"
-          if [ "$distribution_identity" != "$EXPECTED_SIGNING_IDENTITY" ]; then
-            echo "Resolved certificate identity does not match the configured Apple signing identity." >&2
+          if [ -z "$distribution_identity" ] || [ -z "$installer_identity" ]; then
+            echo "Could not resolve the matched Apple certificate identities." >&2
             exit 1
           fi
 

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -32,6 +32,8 @@ describe("Apple release workflows", () => {
     expect(mobile).toContain("asc review submit");
     expect(mobile).not.toContain("eas submit");
     expect(mobile).not.toContain("submit-app-review.mjs");
+    expect(mobile).toContain("--limit 50");
+    expect(mobile).not.toContain("--limit 100");
   });
 
   test("keeps Safari PKG artifacts while using asc for every Apple operation", () => {
@@ -44,6 +46,18 @@ describe("Apple release workflows", () => {
     expect(safari).toContain("asc review submit");
     expect(safari).not.toContain("apps/safari-extension/scripts/");
     expect(safari).not.toContain("xcrun altool");
+    expect(safari).toContain('[ "$candidate_hash" = "$private_hash" ]');
+    expect(safari).not.toContain("EXPECTED_SIGNING_IDENTITY");
+  });
+
+  test("permits real recovery only from a tagged release descendant", () => {
+    for (const workflow of [mobile, safari]) {
+      expect(workflow).toContain('release_tag="v$VERSION"');
+      expect(workflow).toContain(
+        'git merge-base --is-ancestor "$tag_commit" "$GITHUB_SHA"'
+      );
+      expect(workflow).toContain("descendant recovery commits");
+    }
   });
 
   test("reuses a Safari PKG only for its exact App Store build", () => {

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -46,6 +46,13 @@ export function packageFiles(repoRoot) {
   return files.sort();
 }
 
+export function npmLockFiles(repoRoot) {
+  return packageFiles(repoRoot)
+    .map((relative) => path.join(path.dirname(relative), "package-lock.json"))
+    .filter((relative) => fs.existsSync(path.join(repoRoot, relative)))
+    .sort();
+}
+
 export function assertLockstep(repoRoot, expectedVersion) {
   parseVersion(expectedVersion);
   const mismatches = [];
@@ -57,9 +64,23 @@ export function assertLockstep(repoRoot, expectedVersion) {
       mismatches.push(`${relative}: ${manifest.version ?? "missing"}`);
     }
   }
+  for (const relative of npmLockFiles(repoRoot)) {
+    const lockfile = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, relative), "utf8")
+    );
+    const versions = [
+      ["version", lockfile.version],
+      ['packages[""].version', lockfile.packages?.[""]?.version],
+    ];
+    for (const [field, version] of versions) {
+      if (version !== expectedVersion) {
+        mismatches.push(`${relative} ${field}: ${version ?? "missing"}`);
+      }
+    }
+  }
   if (mismatches.length > 0) {
     throw new Error(
-      `Every package.json must use ${expectedVersion}:\n${mismatches.join("\n")}`
+      `Every package manifest and npm lockfile must use ${expectedVersion}:\n${mismatches.join("\n")}`
     );
   }
 }
@@ -83,7 +104,9 @@ function main() {
   }
   if (command === "lockstep" && first && !second) {
     assertLockstep(repoRoot, first);
-    console.log(`All package.json files are lockstep at ${first}.`);
+    console.log(
+      `All package manifests and npm lockfiles are lockstep at ${first}.`
+    );
     return;
   }
   if (command === "patch" && first && second) {

--- a/scripts/release-version.test.ts
+++ b/scripts/release-version.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
   assertLockstep,
   assertPatchBump,
+  npmLockFiles,
   packageFiles,
   parseVersion,
 } from "./release-version.mjs";
@@ -47,7 +48,29 @@ describe("release versions", () => {
         "package.json",
         "packages/ui/package.json",
       ]);
+      expect(npmLockFiles(root)).toEqual([]);
       expect(() => assertLockstep(root, "1.0.60")).not.toThrow();
+
+      fs.writeFileSync(
+        path.join(root, "apps/web/package-lock.json"),
+        `${JSON.stringify({
+          version: "1.0.60",
+          packages: { "": { version: "1.0.60" } },
+        })}\n`
+      );
+      expect(npmLockFiles(root)).toEqual(["apps/web/package-lock.json"]);
+      expect(() => assertLockstep(root, "1.0.60")).not.toThrow();
+
+      fs.writeFileSync(
+        path.join(root, "apps/web/package-lock.json"),
+        `${JSON.stringify({
+          version: "1.0.59",
+          packages: { "": { version: "1.0.59" } },
+        })}\n`
+      );
+      expect(() => assertLockstep(root, "1.0.60")).toThrow(
+        "apps/web/package-lock.json version: 1.0.59"
+      );
 
       fs.writeFileSync(
         path.join(root, "packages/ui/package.json"),


### PR DESCRIPTION
## Summary
- cap EAS production-build discovery at the pinned CLI's supported maximum
- resolve Safari signing identities from the certificates already matched to the private key
- permit same-version recovery only from the release tag or a descendant commit
- include npm package-lock metadata in release lockstep validation

## Proof
- real EAS production build lookup succeeds non-interactively with the corrected limit
- 17 focused Apple release/mobile tests pass
- actionlint and YAML parsing pass for the affected workflows
- repository pre-commit gate passes: 22/22 affected lint, typecheck, and build tasks

## Release recovery
After merge, rerun the iOS and Safari workflows from main for version 1.0.60. Both workflows verify that v1.0.60 exists and is an ancestor of the checked-out recovery commit before mutating release state.
