### PR TITLE
fix(release): build iOS locally in Actions

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -233,7 +233,7 @@ jobs:
           openssl req -new -key "$private_key" -out "$csr" -subj "/CN=Teak iOS Distribution/O=$APPLE_TEAM_ID/C=US"
           private_hash="$(openssl pkey -in "$private_key" -pubout -outform DER | shasum -a 256 | awk '{print $1}')"
 
-          asc certificates list --certificate-type DISTRIBUTION --paginate > "$RUNNER_TEMP/ios-certificates.json"
+          asc certificates list --certificate-type IOS_DISTRIBUTION --paginate > "$RUNNER_TEMP/ios-certificates.json"
           certificate_id=""
           certificate_path="$RUNNER_TEMP/ios-distribution.pem"
           while IFS= read -r row; do
@@ -251,7 +251,7 @@ jobs:
           done < <(jq -c '.data[]?' "$RUNNER_TEMP/ios-certificates.json")
 
           if [ -z "$certificate_id" ]; then
-            asc certificates create --certificate-type DISTRIBUTION --csr "$csr" > "$RUNNER_TEMP/ios-certificate-create.json"
+            asc certificates create --certificate-type IOS_DISTRIBUTION --csr "$csr" > "$RUNNER_TEMP/ios-certificate-create.json"
             certificate_id="$(jq -r '.data.id // .id // empty' "$RUNNER_TEMP/ios-certificate-create.json")"
             content="$(jq -r '.data.attributes.certificateContent // .attributes.certificateContent // empty' "$RUNNER_TEMP/ios-certificate-create.json")"
             printf '%s' "$content" | base64 --decode | openssl x509 -inform DER -out "$certificate_path"

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -28,9 +28,9 @@ env:
   ASC_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
   ASC_NO_UPDATE: "1"
   ASC_VERSION: "3.6.1"
-  EAS_CLI_VERSION: "21.7.0"
-  EXPO_PROJECT_ID: "a5a2124f-d673-47f8-90e2-ed4ae3d41cc1"
-  EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+  APPLE_TEAM_ID: LW385M78LW
+  IOS_APP_BUNDLE_ID: com.praveenjuge.teak
+  IOS_EXTENSION_BUNDLE_ID: com.praveenjuge.teak.share-extension
   PLATFORM: IOS
   RELEASE_NOTES: "Small fixes and polish to keep saving and organizing your ideas smooth and reliable."
   VERSION: ${{ inputs.version }}
@@ -75,10 +75,13 @@ jobs:
       - name: Verify release identity and canonical version
         env:
           DRY_RUN: ${{ inputs.dry_run }}
+          GITHUB_APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          GITHUB_APPLE_DISTRIBUTION_PRIVATE_KEY_BASE64: ${{ secrets.APPLE_DISTRIBUTION_PRIVATE_KEY_BASE64 }}
           GITHUB_SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          GITHUB_SENTRY_MOBILE_DSN: ${{ secrets.SENTRY_MOBILE_DSN }}
         run: |
-          if [ -z "$EXPO_TOKEN" ] || [ -z "$GITHUB_SENTRY_AUTH_TOKEN" ]; then
-            echo "Missing EXPO_TOKEN or SENTRY_AUTH_TOKEN." >&2
+          if [ -z "$GITHUB_APPLE_CERTIFICATE_PASSWORD" ] || [ -z "$GITHUB_APPLE_DISTRIBUTION_PRIVATE_KEY_BASE64" ] || [ -z "$GITHUB_SENTRY_AUTH_TOKEN" ] || [ -z "$GITHUB_SENTRY_MOBILE_DSN" ]; then
+            echo "Missing iOS signing or Sentry release credentials." >&2
             exit 1
           fi
           node scripts/release-version.mjs lockstep "$VERSION"
@@ -103,17 +106,8 @@ jobs:
             echo "Expo resolved $expo_version, expected root package version $VERSION." >&2
             exit 1
           fi
-
-          project_id="$(cd apps/mobile && bunx eas-cli@"$EAS_CLI_VERSION" project:info | awk '/^ID[[:space:]]/{print $2}')"
-          if [ "$project_id" != "$EXPO_PROJECT_ID" ]; then
-            echo "Expo project mismatch: $project_id" >&2
-            exit 1
-          fi
-          if ! (cd apps/mobile && bunx eas-cli@"$EAS_CLI_VERSION" env:list production --format short) \
-            | grep -q '^SENTRY_AUTH_TOKEN='; then
-            echo "The EAS production environment is missing SENTRY_AUTH_TOKEN." >&2
-            exit 1
-          fi
+          xcodebuild -version
+          pod --version
 
           asc auth status --validate --output table
           asc_version="$(asc --version | awk '{print $1}')"
@@ -155,7 +149,7 @@ jobs:
               echo "- App: $ASC_APP_ID"
               echo "- Target: $VERSION (${target_state:-not created})"
               echo "- Metadata source: ${source_version:-not found}"
-              echo "- Expo project: $EXPO_PROJECT_ID"
+              echo "- Native build: GitHub Actions macOS runner"
             } >> "$GITHUB_STEP_SUMMARY"
           else
             case "$target_state" in
@@ -183,99 +177,279 @@ jobs:
             echo "mutate=$mutate"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Find, build, and wait for the exact EAS production build
-        id: eas_build
+      - name: Reuse an exact valid build or allocate the next Apple build number
+        id: build_state
         if: steps.release_state.outputs.mutate == 'true'
-        working-directory: apps/mobile
         run: |
-          builds_json="$RUNNER_TEMP/eas-builds.json"
-          bunx eas-cli@"$EAS_CLI_VERSION" build:list \
-            --platform ios \
-            --build-profile production \
-            --limit 50 \
-            --json \
-            --non-interactive > "$builds_json"
+          exact_builds="$RUNNER_TEMP/apple-ios-exact-builds.json"
+          asc builds list \
+            --app "$ASC_APP_ID" \
+            --platform "$PLATFORM" \
+            --version "$VERSION" \
+            --processing-state VALID \
+            --exclude-expired \
+            --sort=-uploadedDate \
+            --limit 1 > "$exact_builds"
+          build_id="$(jq -r '.data[0].id // empty' "$exact_builds")"
+          build_number="$(jq -r '.data[0].attributes.version // empty' "$exact_builds")"
 
-          build="$(jq -c \
-            --arg version "$VERSION" \
-            --arg commit "$GITHUB_SHA" \
-            '[.[] | select(.appVersion == $version and .gitCommitHash == $commit and .buildProfile == "production" and .distribution == "STORE" and .status == "FINISHED")][0] // empty' \
-            "$builds_json")"
-
-          if [ -z "$build" ]; then
-            active="$(jq -c \
-              --arg version "$VERSION" \
-              --arg commit "$GITHUB_SHA" \
-              '[.[] | select(.appVersion == $version and .gitCommitHash == $commit and .buildProfile == "production" and (.status == "NEW" or .status == "IN_QUEUE" or .status == "IN_PROGRESS"))][0] // empty' \
-              "$builds_json")"
-            active_id="$(jq -r '.id // empty' <<< "$active")"
-            if [ -n "$active_id" ]; then
-              echo "Waiting for existing EAS build $active_id."
-              deadline=$((SECONDS + 7200))
-              while [ "$SECONDS" -lt "$deadline" ]; do
-                build="$(bunx eas-cli@"$EAS_CLI_VERSION" build:view "$active_id" --json)"
-                build_state="$(jq -r '.status' <<< "$build")"
-                case "$build_state" in
-                  FINISHED) break ;;
-                  ERRORED|CANCELED) echo "EAS build $active_id ended $build_state." >&2; exit 1 ;;
-                esac
-                sleep 30
-              done
-              if [ "$(jq -r '.status' <<< "$build")" != "FINISHED" ]; then
-                echo "Timed out waiting for EAS build $active_id." >&2
-                exit 1
-              fi
-            else
-              echo "Starting a hosted EAS production build."
-              build="$(bunx eas-cli@"$EAS_CLI_VERSION" build \
-                --platform ios \
-                --profile production \
-                --non-interactive \
-                --wait \
-                --json)"
-            fi
+          if [ -n "$build_id" ]; then
+            reuse=true
+            echo "Reusing VALID App Store Connect build $build_id ($VERSION/$build_number)."
           else
-            echo "Reusing successful EAS build $(jq -r '.id' <<< "$build")."
+            reuse=false
+            all_builds="$RUNNER_TEMP/apple-ios-all-builds.json"
+            asc builds list --app "$ASC_APP_ID" --platform "$PLATFORM" --paginate > "$all_builds"
+            build_number="$(node scripts/apple-build-number.mjs "$all_builds")"
+            if ! [[ "$build_number" =~ ^[1-9][0-9]*$ ]]; then
+              echo "Could not allocate a positive integer iOS build number from App Store Connect." >&2
+              exit 1
+            fi
           fi
+          {
+            echo "reuse=$reuse"
+            echo "build_id=$build_id"
+            echo "build_number=$build_number"
+          } >> "$GITHUB_OUTPUT"
 
-          build="$(jq -c 'if type == "array" then .[0] else . end' <<< "$build")"
-
-          build_id="$(jq -r '.id // empty' <<< "$build")"
-          build_number="$(jq -r '.appBuildVersion // empty' <<< "$build")"
-          artifact_url="$(jq -r '.artifacts.applicationArchiveUrl // .artifacts.buildUrl // empty' <<< "$build")"
-          if [ -z "$build_id" ] || [ -z "$build_number" ] || [ -z "$artifact_url" ]; then
-            echo "EAS did not return a complete production build." >&2
+      - name: Prepare iOS distribution certificate and secure temporary keychain with asc
+        id: signing
+        if: steps.release_state.outputs.mutate == 'true' && steps.build_state.outputs.reuse != 'true'
+        env:
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_DISTRIBUTION_PRIVATE_KEY_BASE64: ${{ secrets.APPLE_DISTRIBUTION_PRIVATE_KEY_BASE64 }}
+        run: |
+          if [ -z "$APPLE_CERTIFICATE_PASSWORD" ] || [ -z "$APPLE_DISTRIBUTION_PRIVATE_KEY_BASE64" ]; then
+            echo "Missing iOS signing credentials." >&2
             exit 1
           fi
-          if [ "$(jq -r '.appVersion' <<< "$build")" != "$VERSION" ]; then
-            echo "EAS app version does not match $VERSION." >&2
+
+          private_key="$RUNNER_TEMP/apple-distribution-private-key.pem"
+          csr="$RUNNER_TEMP/apple-distribution.csr"
+          printf '%s' "$APPLE_DISTRIBUTION_PRIVATE_KEY_BASE64" | base64 --decode > "$private_key"
+          chmod 600 "$private_key"
+          openssl req -new -key "$private_key" -out "$csr" -subj "/CN=Teak iOS Distribution/O=$APPLE_TEAM_ID/C=US"
+          private_hash="$(openssl pkey -in "$private_key" -pubout -outform DER | shasum -a 256 | awk '{print $1}')"
+
+          asc certificates list --certificate-type DISTRIBUTION --paginate > "$RUNNER_TEMP/ios-certificates.json"
+          certificate_id=""
+          certificate_path="$RUNNER_TEMP/ios-distribution.pem"
+          while IFS= read -r row; do
+            candidate_id="$(jq -r '.id' <<< "$row")"
+            content="$(jq -r '.attributes.certificateContent // empty' <<< "$row")"
+            if [ -z "$content" ]; then continue; fi
+            candidate="$RUNNER_TEMP/ios-${candidate_id}.cer"
+            printf '%s' "$content" | base64 --decode > "$candidate"
+            candidate_hash="$(openssl x509 -inform DER -in "$candidate" -pubkey -noout | openssl pkey -pubin -outform DER | shasum -a 256 | awk '{print $1}')"
+            if [ "$candidate_hash" = "$private_hash" ]; then
+              certificate_id="$candidate_id"
+              openssl x509 -inform DER -in "$candidate" -out "$certificate_path"
+              break
+            fi
+          done < <(jq -c '.data[]?' "$RUNNER_TEMP/ios-certificates.json")
+
+          if [ -z "$certificate_id" ]; then
+            asc certificates create --certificate-type DISTRIBUTION --csr "$csr" > "$RUNNER_TEMP/ios-certificate-create.json"
+            certificate_id="$(jq -r '.data.id // .id // empty' "$RUNNER_TEMP/ios-certificate-create.json")"
+            content="$(jq -r '.data.attributes.certificateContent // .attributes.certificateContent // empty' "$RUNNER_TEMP/ios-certificate-create.json")"
+            printf '%s' "$content" | base64 --decode | openssl x509 -inform DER -out "$certificate_path"
+          fi
+          if [ -z "$certificate_id" ] || [ ! -s "$certificate_path" ]; then
+            echo "Could not resolve the iOS distribution certificate with asc." >&2
             exit 1
           fi
+
+          identity="$(openssl x509 -in "$certificate_path" -noout -subject -nameopt multiline | awk -F'= ' '/commonName/{print $2; exit}')"
+          if [ -z "$identity" ]; then
+            echo "Could not resolve the matched iOS certificate identity." >&2
+            exit 1
+          fi
+          distribution_p12="$RUNNER_TEMP/ios-distribution.p12"
+          openssl pkcs12 -legacy -export -inkey "$private_key" -in "$certificate_path" -out "$distribution_p12" -passout "pass:$APPLE_CERTIFICATE_PASSWORD" -name "$identity"
+
+          keychain="$RUNNER_TEMP/teak-ios-signing.keychain-db"
+          keychain_password="$(uuidgen)"
+          echo "::add-mask::$keychain_password"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$distribution_p12" -k "$keychain" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security list-keychains -d user -s "$keychain" login.keychain-db
+          security default-keychain -s "$keychain"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain"
 
           {
-            echo "id=$build_id"
-            echo "build_number=$build_number"
-            echo "artifact_url=$artifact_url"
+            echo "certificate_id=$certificate_id"
+            echo "identity=$identity"
           } >> "$GITHUB_OUTPUT"
-          echo "- EAS build: [$build_id](https://expo.dev/accounts/praveenjuge/projects/teak/builds/$build_id) ($VERSION/$build_number)" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Download the exact IPA
-        id: ipa
-        if: steps.release_state.outputs.mutate == 'true'
+      - name: Create or reuse exact iOS provisioning profiles with asc
+        id: profiles
+        if: steps.release_state.outputs.mutate == 'true' && steps.build_state.outputs.reuse != 'true'
         env:
-          ARTIFACT_URL: ${{ steps.eas_build.outputs.artifact_url }}
+          CERTIFICATE_ID: ${{ steps.signing.outputs.certificate_id }}
         run: |
-          ipa_path="$RUNNER_TEMP/teak-mobile-$VERSION-${{ steps.eas_build.outputs.build_number }}.ipa"
-          curl --fail --location --retry 3 --retry-all-errors --connect-timeout 20 --max-time 900 \
-            "$ARTIFACT_URL" --output "$ipa_path"
-          if [ ! -s "$ipa_path" ]; then
-            echo "Downloaded IPA is empty." >&2
+          asc bundle-ids list --paginate > "$RUNNER_TEMP/ios-bundle-ids.json"
+          asc profiles list --profile-type IOS_APP_STORE --profile-state ACTIVE --paginate > "$RUNNER_TEMP/ios-profiles.json"
+          profile_dir="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$profile_dir"
+
+          ensure_profile() {
+            local identifier="$1" label="$2" output_prefix="$3"
+            local bundle_id
+            bundle_id="$(jq -r --arg identifier "$identifier" '.data[] | select(.attributes.identifier == $identifier and (.attributes.platform == "IOS" or .attributes.platform == "UNIVERSAL")) | .id' "$RUNNER_TEMP/ios-bundle-ids.json" | head -1)"
+            if [ -z "$bundle_id" ]; then
+              echo "Missing exact iOS bundle ID: $identifier" >&2
+              exit 1
+            fi
+            profile_name="$label ${CERTIFICATE_ID: -8}"
+            profile_id="$(jq -r --arg name "$profile_name" '.data[] | select(.attributes.name == $name and .attributes.profileState == "ACTIVE") | .id' "$RUNNER_TEMP/ios-profiles.json" | head -1)"
+            if [ -z "$profile_id" ]; then
+              asc profiles create \
+                --name "$profile_name" \
+                --profile-type IOS_APP_STORE \
+                --bundle "$bundle_id" \
+                --certificate "$CERTIFICATE_ID" > "$RUNNER_TEMP/${output_prefix}-profile-create.json"
+              profile_id="$(jq -r '.data.id // .id // empty' "$RUNNER_TEMP/${output_prefix}-profile-create.json")"
+            fi
+            profile_path="$RUNNER_TEMP/${output_prefix}.mobileprovision"
+            asc profiles download --id "$profile_id" --output "$profile_path" > "$RUNNER_TEMP/${output_prefix}-profile-download.json"
+            plist="$RUNNER_TEMP/${output_prefix}-profile.plist"
+            security cms -D -i "$profile_path" > "$plist"
+            profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$plist")"
+            resolved_name="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$plist")"
+            application_identifier="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' "$plist")"
+            if [ "$application_identifier" != "$APPLE_TEAM_ID.$identifier" ]; then
+              echo "Provisioning profile identity mismatch for $identifier." >&2
+              exit 1
+            fi
+            cp "$profile_path" "$profile_dir/$profile_uuid.mobileprovision"
+            echo "${output_prefix}_name=$resolved_name" >> "$GITHUB_OUTPUT"
+          }
+
+          ensure_profile "$IOS_APP_BUNDLE_ID" "Teak iOS App" "app"
+          ensure_profile "$IOS_EXTENSION_BUNDLE_ID" "Teak iOS Share Extension" "extension"
+
+      - name: Generate the native iOS project and install pods locally
+        if: steps.release_state.outputs.mutate == 'true' && steps.build_state.outputs.reuse != 'true'
+        working-directory: apps/mobile
+        env:
+          APPLE_DISTRIBUTION_IDENTITY: ${{ steps.signing.outputs.identity }}
+          EXPO_PUBLIC_CONVEX_SITE_URL: https://uncommon-ladybug-882.convex.site
+          EXPO_PUBLIC_CONVEX_URL: https://uncommon-ladybug-882.convex.cloud
+          EXPO_PUBLIC_SENTRY_ENVIRONMENT: production
+          EXPO_PUBLIC_SENTRY_MOBILE_DSN: ${{ secrets.SENTRY_MOBILE_DSN }}
+          IOS_APP_PROFILE_NAME: ${{ steps.profiles.outputs.app_name }}
+          IOS_EXTENSION_PROFILE_NAME: ${{ steps.profiles.outputs.extension_name }}
+          TEAK_IOS_BUILD_NUMBER: ${{ steps.build_state.outputs.build_number }}
+          TEAK_IOS_VERSION: ${{ env.VERSION }}
+        run: |
+          bunx expo prebuild --platform ios --clean --no-install
+          (cd ios && pod install)
+          pod_executable="$(pod env | awk -F': ' '/Executable Path/{print $2; exit}')"
+          cocoapods_gem_home="$(cd "$(dirname "$pod_executable")/.." && pwd)"
+          GEM_HOME="$cocoapods_gem_home" ruby scripts/configure-ios-signing.rb ios/Teak.xcodeproj
+          xcodebuild -list -workspace ios/Teak.xcworkspace
+
+      - name: Archive and export the production IPA on the GitHub runner
+        id: ipa
+        if: steps.release_state.outputs.mutate == 'true' && steps.build_state.outputs.reuse != 'true'
+        working-directory: apps/mobile
+        env:
+          APPLE_DISTRIBUTION_IDENTITY: ${{ steps.signing.outputs.identity }}
+          IOS_APP_PROFILE_NAME: ${{ steps.profiles.outputs.app_name }}
+          IOS_EXTENSION_PROFILE_NAME: ${{ steps.profiles.outputs.extension_name }}
+          SENTRY_ALLOW_FAILURE: "false"
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: teakvault
+          SENTRY_PROJECT: teak-mobile-prod
+        run: |
+          archive_path="$RUNNER_TEMP/Teak-iOS.xcarchive"
+          export_path="$RUNNER_TEMP/Teak-iOS-export"
+          xcodebuild \
+            -workspace ios/Teak.xcworkspace \
+            -scheme Teak \
+            -configuration Release \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$archive_path" \
+            archive
+
+          export_options="$RUNNER_TEMP/iOSExportOptions.plist"
+          /usr/libexec/PlistBuddy -c 'Add :method string app-store-connect' "$export_options"
+          /usr/libexec/PlistBuddy -c 'Add :destination string export' "$export_options"
+          /usr/libexec/PlistBuddy -c 'Add :signingStyle string manual' "$export_options"
+          /usr/libexec/PlistBuddy -c "Add :signingCertificate string $APPLE_DISTRIBUTION_IDENTITY" "$export_options"
+          /usr/libexec/PlistBuddy -c "Add :teamID string $APPLE_TEAM_ID" "$export_options"
+          /usr/libexec/PlistBuddy -c 'Add :manageAppVersionAndBuildNumber bool false' "$export_options"
+          /usr/libexec/PlistBuddy -c 'Add :provisioningProfiles dict' "$export_options"
+          /usr/libexec/PlistBuddy -c "Add :provisioningProfiles:$IOS_APP_BUNDLE_ID string $IOS_APP_PROFILE_NAME" "$export_options"
+          /usr/libexec/PlistBuddy -c "Add :provisioningProfiles:$IOS_EXTENSION_BUNDLE_ID string $IOS_EXTENSION_PROFILE_NAME" "$export_options"
+          xcodebuild \
+            -exportArchive \
+            -archivePath "$archive_path" \
+            -exportPath "$export_path" \
+            -exportOptionsPlist "$export_options"
+
+          ipa_count="$(find "$export_path" -maxdepth 1 -type f -name '*.ipa' | wc -l | tr -d ' ')"
+          ipa_path="$(find "$export_path" -maxdepth 1 -type f -name '*.ipa' | head -1)"
+          if [ "$ipa_count" -ne 1 ] || [ ! -s "$ipa_path" ]; then
+            echo "Expected exactly one non-empty locally exported IPA." >&2
             exit 1
           fi
           echo "path=$ipa_path" >> "$GITHUB_OUTPUT"
 
-      - name: Upload IPA to Sentry Size Analysis
-        if: steps.release_state.outputs.mutate == 'true'
+      - name: Verify the exact local IPA identity, version, build, profiles, and signature
+        if: steps.release_state.outputs.mutate == 'true' && steps.build_state.outputs.reuse != 'true'
+        env:
+          BUILD_NUMBER: ${{ steps.build_state.outputs.build_number }}
+          IPA_PATH: ${{ steps.ipa.outputs.path }}
+        run: |
+          entries="$RUNNER_TEMP/ios-ipa-entries.txt"
+          unzip -Z1 "$IPA_PATH" > "$entries"
+          app_info="$(grep -E '^Payload/[^/]+\.app/Info\.plist$' "$entries")"
+          extension_info="$(grep -E '^Payload/[^/]+\.app/PlugIns/[^/]+\.appex/Info\.plist$' "$entries")"
+          app_count="$(grep -Ec '^Payload/[^/]+\.app/Info\.plist$' "$entries")"
+          extension_count="$(grep -Ec '^Payload/[^/]+\.app/PlugIns/[^/]+\.appex/Info\.plist$' "$entries")"
+          if [ "$app_count" -ne 1 ] || [ "$extension_count" -ne 1 ]; then
+            echo "Expected one app and one share extension in the IPA." >&2
+            exit 1
+          fi
+
+          verify_info() {
+            local entry="$1" expected_bundle="$2" prefix="$3"
+            local plist="$RUNNER_TEMP/${prefix}-Info.plist"
+            unzip -p "$IPA_PATH" "$entry" > "$plist"
+            bundle_id="$(plutil -extract CFBundleIdentifier raw "$plist")"
+            version="$(plutil -extract CFBundleShortVersionString raw "$plist")"
+            build_number="$(plutil -extract CFBundleVersion raw "$plist")"
+            if [ "$bundle_id" != "$expected_bundle" ] || [ "$version" != "$VERSION" ] || [ "$build_number" != "$BUILD_NUMBER" ]; then
+              echo "$prefix identity mismatch: $bundle_id $version ($build_number)." >&2
+              exit 1
+            fi
+          }
+          verify_info "$app_info" "$IOS_APP_BUNDLE_ID" app
+          verify_info "$extension_info" "$IOS_EXTENSION_BUNDLE_ID" extension
+
+          expanded="$RUNNER_TEMP/ios-ipa-expanded"
+          unzip -q "$IPA_PATH" -d "$expanded"
+          app_path="$(find "$expanded/Payload" -maxdepth 1 -type d -name '*.app' | head -1)"
+          extension_path="$(find "$app_path/PlugIns" -maxdepth 1 -type d -name '*.appex' | head -1)"
+          codesign --verify --deep --strict "$app_path"
+          codesign --verify --strict "$extension_path"
+          for item in "$app_path:$IOS_APP_BUNDLE_ID" "$extension_path:$IOS_EXTENSION_BUNDLE_ID"; do
+            path="${item%%:*}"
+            bundle_id="${item#*:}"
+            security cms -D -i "$path/embedded.mobileprovision" > "$RUNNER_TEMP/profile.plist"
+            application_identifier="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' "$RUNNER_TEMP/profile.plist")"
+            if [ "$application_identifier" != "$APPLE_TEAM_ID.$bundle_id" ]; then
+              echo "Embedded provisioning profile mismatch for $bundle_id." >&2
+              exit 1
+            fi
+          done
+          echo "- Local IPA: verified $VERSION/$BUILD_NUMBER for app and share extension" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload local IPA to Sentry Size Analysis
+        if: steps.release_state.outputs.mutate == 'true' && steps.build_state.outputs.reuse != 'true'
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
@@ -285,24 +459,18 @@ jobs:
           fi
           bun run --cwd apps/mobile build:sentry -- "${{ steps.ipa.outputs.path }}"
 
-      - name: Upload IPA with asc or reuse the exact valid Apple build
+      - name: Upload local IPA with asc or reuse the exact valid Apple build
         id: apple_build
         if: steps.release_state.outputs.mutate == 'true'
         env:
-          BUILD_NUMBER: ${{ steps.eas_build.outputs.build_number }}
+          BUILD_NUMBER: ${{ steps.build_state.outputs.build_number }}
+          EXISTING_BUILD_ID: ${{ steps.build_state.outputs.build_id }}
           IPA_PATH: ${{ steps.ipa.outputs.path }}
+          REUSE: ${{ steps.build_state.outputs.reuse }}
         run: |
+          build_id="$EXISTING_BUILD_ID"
           builds_path="$RUNNER_TEMP/apple-ios-builds.json"
-          asc builds list \
-            --app "$ASC_APP_ID" \
-            --platform "$PLATFORM" \
-            --version "$VERSION" \
-            --build-number "$BUILD_NUMBER" \
-            --processing-state VALID \
-            --exclude-expired > "$builds_path"
-          build_id="$(jq -r '.data[0].id // empty' "$builds_path")"
-
-          if [ -z "$build_id" ]; then
+          if [ "$REUSE" != "true" ]; then
             asc builds upload \
               --app "$ASC_APP_ID" \
               --ipa "$IPA_PATH" \
@@ -310,24 +478,25 @@ jobs:
               --build-number "$BUILD_NUMBER" \
               --checksum \
               --wait > "$RUNNER_TEMP/ios-upload.json"
-            asc builds list \
-              --app "$ASC_APP_ID" \
-              --platform "$PLATFORM" \
-              --version "$VERSION" \
-              --build-number "$BUILD_NUMBER" \
-              --processing-state VALID \
-              --exclude-expired > "$builds_path"
-            build_id="$(jq -r '.data[0].id // empty' "$builds_path")"
-          else
-            echo "Reusing App Store Connect build $build_id."
           fi
-
-          if [ -z "$build_id" ] || [ "$(jq '.data | length' "$builds_path")" -ne 1 ]; then
+          asc builds list \
+            --app "$ASC_APP_ID" \
+            --platform "$PLATFORM" \
+            --version "$VERSION" \
+            --build-number "$BUILD_NUMBER" \
+            --processing-state VALID \
+            --exclude-expired > "$builds_path"
+          resolved_build_id="$(jq -r '.data[0].id // empty' "$builds_path")"
+          if [ -z "$resolved_build_id" ] || [ "$(jq '.data | length' "$builds_path")" -ne 1 ]; then
             echo "Expected exactly one VALID iOS build for $VERSION/$BUILD_NUMBER." >&2
             exit 1
           fi
-          echo "id=$build_id" >> "$GITHUB_OUTPUT"
-          echo "- App Store build: $build_id ($VERSION/$BUILD_NUMBER, VALID)" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "$build_id" ] && [ "$resolved_build_id" != "$build_id" ]; then
+            echo "The exact reusable App Store build changed unexpectedly." >&2
+            exit 1
+          fi
+          echo "id=$resolved_build_id" >> "$GITHUB_OUTPUT"
+          echo "- App Store build: $resolved_build_id ($VERSION/$BUILD_NUMBER, VALID)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Find or create the iOS version and preserve release metadata
         id: apple_version
@@ -400,6 +569,23 @@ jobs:
 
           echo "id=$version_id" >> "$GITHUB_OUTPUT"
           echo "- App Store version: $version_id (AFTER_APPROVAL)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Complete new Apple age-rating fields without changing the existing declaration
+        if: steps.release_state.outputs.mutate == 'true'
+        env:
+          VERSION_ID: ${{ steps.apple_version.outputs.id }}
+        run: |
+          asc age-rating edit \
+            --version-id "$VERSION_ID" \
+            --social-media false \
+            --social-media-age-restricted false > "$RUNNER_TEMP/ios-age-rating-edit.json"
+          asc age-rating view \
+            --version-id "$VERSION_ID" \
+            --fields socialMedia,socialMediaAgeRestricted > "$RUNNER_TEMP/ios-age-rating-view.json"
+          if ! jq -e '.data.attributes.socialMedia == false and .data.attributes.socialMediaAgeRestricted == false' "$RUNNER_TEMP/ios-age-rating-view.json" > /dev/null; then
+            echo "App Store Connect did not retain the required iOS social-media age-rating declarations." >&2
+            exit 1
+          fi
 
       - name: Attach exact build, validate, run doctor, and submit
         id: submit

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -14,7 +14,9 @@ on:
         type: boolean
 
 concurrency:
-  group: mobile-app-store-${{ inputs.version }}
+  # App Store build numbers are allocated from app-wide ASC history, so keep
+  # allocation through upload atomic even when different patch versions queue.
+  group: mobile-app-store-ios-${{ github.repository }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/safari-extension-release.yml
+++ b/.github/workflows/safari-extension-release.yml
@@ -229,6 +229,23 @@ jobs:
           echo "id=$version_id" >> "$GITHUB_OUTPUT"
           echo "- App Store version: $version_id (AFTER_APPROVAL)" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Complete new Apple age-rating fields without changing the existing declaration
+        if: steps.release_state.outputs.mutate == 'true'
+        env:
+          VERSION_ID: ${{ steps.apple_version.outputs.id }}
+        run: |
+          asc age-rating edit \
+            --version-id "$VERSION_ID" \
+            --social-media false \
+            --social-media-age-restricted false > "$RUNNER_TEMP/safari-age-rating-edit.json"
+          asc age-rating view \
+            --version-id "$VERSION_ID" \
+            --fields socialMedia,socialMediaAgeRestricted > "$RUNNER_TEMP/safari-age-rating-view.json"
+          if ! jq -e '.data.attributes.socialMedia == false and .data.attributes.socialMediaAgeRestricted == false' "$RUNNER_TEMP/safari-age-rating-view.json" > /dev/null; then
+            echo "App Store Connect did not retain the required Safari social-media age-rating declarations." >&2
+            exit 1
+          fi
+
       - name: Reuse an exact uploaded Safari build and PKG when available
         id: reuse
         if: steps.release_state.outputs.mutate == 'true'

--- a/apps/mobile/__tests__/lib/sentry-build-config.test.ts
+++ b/apps/mobile/__tests__/lib/sentry-build-config.test.ts
@@ -21,6 +21,7 @@ test("production mobile builds require Sentry uploads", () => {
   expect(store.apple.version).toBeUndefined();
   expect(appConfig).toContain('require("../../package.json")');
   expect(appConfig).toContain("version: rootPackage.version");
+  expect(appConfig).toContain("TEAK_IOS_BUILD_NUMBER");
   expect(app.expo.plugins).toContainEqual([
     "@sentry/react-native/expo",
     expect.objectContaining({
@@ -31,6 +32,8 @@ test("production mobile builds require Sentry uploads", () => {
   ]);
   expect(eas.build.production.env.SENTRY_DISABLE_AUTO_UPLOAD).toBeUndefined();
   expect(eas.build.production.env.SENTRY_ALLOW_FAILURE).toBe("false");
+  expect(eas.cli.appVersionSource).toBeUndefined();
+  expect(eas.build.production.autoIncrement).toBeUndefined();
   expect(metro).toContain("getSentryExpoConfig");
   expect(packageJson.scripts["build:sentry"]).toContain(
     "sentry-cli build upload"
@@ -38,7 +41,7 @@ test("production mobile builds require Sentry uploads", () => {
   expect(packageJson.scripts["build:sentry"]).toContain("teak-mobile-prod");
 });
 
-test("uploads hosted production builds to Sentry before App Store Connect", () => {
+test("uploads runner-local production builds to Sentry before App Store Connect", () => {
   const packageJson = JSON.parse(
     readFileSync(resolve(mobileRoot, "package.json"), "utf8")
   );
@@ -52,14 +55,21 @@ test("uploads hosted production builds to Sentry before App Store Connect", () =
   );
 
   expect(existsSync(legacyWorkflowPath)).toBe(false);
-  expect(packageJson.scripts["build:local"]).toBeUndefined();
   expect(packageJson.scripts["build:submit"]).toBeUndefined();
   expect(packageJson.scripts["build:sentry"]).toContain(
     "sentry-cli build upload"
   );
-  expect(workflow.indexOf("Upload IPA to Sentry Size Analysis")).toBeLessThan(
-    workflow.indexOf("Upload IPA with asc")
-  );
+  expect(
+    workflow.indexOf("Upload local IPA to Sentry Size Analysis")
+  ).toBeLessThan(workflow.indexOf("Upload local IPA with asc"));
+  expect(workflow).toContain("bunx expo prebuild --platform ios");
+  expect(workflow).toContain("xcodebuild");
+  expect(workflow).not.toContain("eas-cli");
+  expect(workflow).not.toContain("EXPO_TOKEN");
+  expect(workflow).not.toContain("EAS_CLI_VERSION");
+  expect(workflow).toContain("EXPO_PUBLIC_CONVEX_URL");
+  expect(workflow).toContain("EXPO_PUBLIC_CONVEX_SITE_URL");
+  expect(workflow).toContain("secrets.SENTRY_MOBILE_DSN");
 });
 
 test("pins the Expo 56 macro-compatible native build set", () => {

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -1,8 +1,17 @@
 const rootPackage = require("../../package.json");
+const iosBuildNumber = process.env.TEAK_IOS_BUILD_NUMBER;
+
+if (iosBuildNumber && !/^[1-9]\d*$/.test(iosBuildNumber)) {
+  throw new Error("TEAK_IOS_BUILD_NUMBER must be a positive integer.");
+}
 
 module.exports = ({ config }) => ({
   ...config,
   version: rootPackage.version,
+  ios: {
+    ...config.ios,
+    ...(iosBuildNumber ? { buildNumber: iosBuildNumber } : {}),
+  },
   extra: {
     ...config.extra,
   },

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,7 +1,6 @@
 {
   "cli": {
-    "version": ">= 16.18.0",
-    "appVersionSource": "remote"
+    "version": ">= 16.18.0"
   },
   "build": {
     "development": {
@@ -15,7 +14,6 @@
       "distribution": "internal"
     },
     "production": {
-      "autoIncrement": true,
       "environment": "production",
       "env": {
         "EXPO_PUBLIC_SENTRY_ENVIRONMENT": "production",

--- a/apps/mobile/release.md
+++ b/apps/mobile/release.md
@@ -3,8 +3,9 @@
 Teak iOS ships through `.github/workflows/mobile-release.yml`. A lockstep
 `package.json` patch bump merged to `main` is the only normal manual release
 action. Root `package.json` is the sole marketing-version source; Expo resolves
-that version through `app.config.js`, while EAS keeps the remote build number
-and increments it for production builds.
+that version through `app.config.js`. App Store Connect is the sole build-number
+authority; the workflow allocates the next positive integer from its current
+iOS build history.
 
 ## Canonical release
 
@@ -12,22 +13,27 @@ and increments it for production builds.
 2. Merge that scoped bump to `main`.
 3. `Version Tag` verifies that the change is exactly one patch, creates
    `v<version>`, and dispatches `Mobile App Store Release` at that tag.
-4. The workflow verifies the tag, lockstep packages, Expo project, dynamic Expo
-   version, asc version, and credentials.
-5. It reuses an exact successful production EAS build for the tag when one
-   exists. Otherwise it starts a hosted non-interactive production build and
-   waits for completion. EAS owns the remote build number and
-   `build.production.autoIncrement` remains enabled in `eas.json`.
-6. It downloads that IPA and uploads it to Sentry Size Analysis. A failed or
-   missing Sentry upload stops the release.
-7. asc uploads the exact IPA directly to App Store Connect and waits for a
-   `VALID` build. EAS Submit is not part of this flow.
-8. asc finds or creates the iOS App Store version, copies localization metadata
+4. The workflow verifies the tag, lockstep packages, dynamic Expo version, asc
+   version, and credentials.
+5. It reuses an exact valid App Store Connect build for the target marketing
+   version when one exists. Otherwise it allocates the next build number from
+   App Store Connect, generates the native iOS project with Expo Prebuild, and
+   uses CocoaPods plus Xcode directly on the GitHub Actions macOS runner.
+6. asc finds or creates the exact iOS distribution certificate and App Store
+   provisioning profiles for the Teak app and share extension. The workflow
+   archives, exports, and verifies the signed IPA locally, including bundle IDs,
+   marketing version, build number, embedded profiles, and signatures.
+7. The locally exported IPA is uploaded to Sentry Size Analysis. A failed or
+   missing Sentry upload stops the release before App Store Connect upload.
+8. asc uploads the exact IPA directly to App Store Connect and waits for a
+   `VALID` build.
+9. asc finds or creates the iOS App Store version, copies localization metadata
    from the prior live iOS version without copying What's New, applies the
    generic release note, preserves review details, sets `AFTER_APPROVAL`,
-   attaches the exact build, validates readiness, runs review doctor, and
-   submits directly to App Review.
-9. The workflow succeeds only after iOS reaches `WAITING_FOR_REVIEW` or a later
+   sparsely completes Apple's social-media age-rating fields without changing
+   the existing declaration, attaches the exact build, validates readiness,
+   runs review doctor, and submits directly to App Review.
+10. The workflow succeeds only after iOS reaches `WAITING_FOR_REVIEW` or a later
    valid state.
 
 The release note is:
@@ -46,8 +52,9 @@ gh workflow run mobile-release.yml --ref main -f "version=$version" -f dry_run=t
 
 ## Reliability and recovery
 
-- Concurrency is scoped by iOS version. Reruns reuse matching EAS and Apple
-  builds.
+- Concurrency is scoped by iOS version. Reruns reuse the exact valid Apple build
+  after its locally exported IPA has already passed mandatory Sentry Size
+  Analysis and App Store upload in the canonical workflow.
 - In-review or already-live versions are read-only and return success.
 - Rejected versions are never resubmitted or modified automatically.
 - A terminal workflow failure opens or updates the single
@@ -61,3 +68,7 @@ App Store Connect app: `6756574989`
 Bundle ID: `com.praveenjuge.teak`
 
 Expo project: `@praveenjuge/teak` (`a5a2124f-d673-47f8-90e2-ed4ae3d41cc1`)
+
+The Expo project identity remains part of the app configuration for development,
+but production iOS releases do not call or consume Expo's hosted EAS Build
+service.

--- a/apps/mobile/scripts/configure-ios-signing.rb
+++ b/apps/mobile/scripts/configure-ios-signing.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "xcodeproj"
+
+project_path = ARGV.fetch(0)
+version = ENV.fetch("TEAK_IOS_VERSION")
+build_number = ENV.fetch("TEAK_IOS_BUILD_NUMBER")
+team_id = ENV.fetch("APPLE_TEAM_ID")
+identity = ENV.fetch("APPLE_DISTRIBUTION_IDENTITY")
+
+unless version.match?(/\A(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\z/)
+  abort "TEAK_IOS_VERSION must be a stable three-component version."
+end
+unless build_number.match?(/\A[1-9]\d*\z/)
+  abort "TEAK_IOS_BUILD_NUMBER must be a positive integer."
+end
+
+targets = {
+  "Teak" => {
+    bundle_id: "com.praveenjuge.teak",
+    profile: ENV.fetch("IOS_APP_PROFILE_NAME"),
+  },
+  "expo-sharing-extension" => {
+    bundle_id: "com.praveenjuge.teak.share-extension",
+    profile: ENV.fetch("IOS_EXTENSION_PROFILE_NAME"),
+  },
+}
+
+project = Xcodeproj::Project.open(project_path)
+targets.each do |target_name, expected|
+  target = project.targets.find { |candidate| candidate.name == target_name }
+  abort "Missing generated Xcode target #{target_name}." unless target
+
+  target.build_configurations.each do |configuration|
+    settings = configuration.build_settings
+    actual_bundle_id = settings.fetch("PRODUCT_BUNDLE_IDENTIFIER", "").delete('"')
+    unless actual_bundle_id == expected.fetch(:bundle_id)
+      abort "#{target_name} bundle ID is #{actual_bundle_id}, expected #{expected.fetch(:bundle_id)}."
+    end
+
+    settings["CODE_SIGN_IDENTITY"] = identity
+    settings["CODE_SIGN_IDENTITY[sdk=iphoneos*]"] = identity
+    settings["CODE_SIGN_STYLE"] = "Manual"
+    settings["CURRENT_PROJECT_VERSION"] = build_number
+    settings["DEVELOPMENT_TEAM"] = team_id
+    settings["MARKETING_VERSION"] = version
+    settings["PROVISIONING_PROFILE_SPECIFIER"] = expected.fetch(:profile)
+    settings["PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]"] = expected.fetch(:profile)
+  end
+end
+
+project.save
+puts "Configured Teak iOS signing for #{version} (#{build_number})."

--- a/apps/safari-extension/release.md
+++ b/apps/safari-extension/release.md
@@ -15,8 +15,9 @@ patch bump merged to `main` is the only normal manual release action. Root
    Connect credentials.
 4. asc finds or creates the `MAC_OS` App Store version, copies localization
    metadata from the prior live macOS version without copying What's New,
-   applies the generic note, preserves review details, and sets
-   `AFTER_APPROVAL`.
+   applies the generic note, preserves review details and the existing age
+   rating declaration, sparsely completes Apple's new social-media age-rating
+   fields, and sets `AFTER_APPROVAL`.
 5. For a new build, asc resolves or creates the Mac App Distribution and Mac
    Installer Distribution certificates that match the repository's private key,
    then resolves, creates, and downloads the two Mac App Store provisioning

--- a/scripts/apple-build-number.mjs
+++ b/scripts/apple-build-number.mjs
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const positiveIntegerPattern = /^[1-9]\d*$/;
+
+export function nextAppleBuildNumber(response) {
+  if (!(response && Array.isArray(response.data))) {
+    throw new Error("Expected an App Store Connect builds response.");
+  }
+
+  let maximum = 0n;
+  for (const build of response.data) {
+    const value = String(build?.attributes?.version ?? "");
+    if (!positiveIntegerPattern.test(value)) {
+      throw new Error(`Unsafe App Store build number: ${value || "missing"}.`);
+    }
+    const current = BigInt(value);
+    if (current > maximum) {
+      maximum = current;
+    }
+  }
+  return String(maximum + 1n);
+}
+
+function main() {
+  const [filePath] = process.argv.slice(2);
+  if (!filePath) {
+    throw new Error("Usage: node scripts/apple-build-number.mjs <builds.json>");
+  }
+  const response = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  console.log(nextAppleBuildNumber(response));
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/apple-build-number.test.ts
+++ b/scripts/apple-build-number.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { nextAppleBuildNumber } from "./apple-build-number.mjs";
+
+const builds = (...versions: string[]) => ({
+  data: versions.map((version) => ({ attributes: { version } })),
+});
+
+describe("Apple build-number allocation", () => {
+  test("starts at one when the app has no builds", () => {
+    expect(nextAppleBuildNumber(builds())).toBe("1");
+  });
+
+  test("increments the maximum positive integer deterministically", () => {
+    expect(nextAppleBuildNumber(builds("63", "9", "64", "12"))).toBe("65");
+  });
+
+  test("fails closed for missing or non-integer history", () => {
+    expect(() => nextAppleBuildNumber({})).toThrow(
+      "Expected an App Store Connect builds response"
+    );
+    expect(() => nextAppleBuildNumber(builds("63", "1.2.3"))).toThrow(
+      "Unsafe App Store build number: 1.2.3"
+    );
+  });
+});

--- a/scripts/apple-release-issue.mjs
+++ b/scripts/apple-release-issue.mjs
@@ -125,7 +125,7 @@ ${doctor}
 Rerun after remediation:
 
 \`\`\`bash
-gh workflow run ${workflowFile} --ref v${values.version} -f version=${values.version} -f dry_run=false
+gh workflow run ${workflowFile} --ref main -f version=${values.version} -f dry_run=false
 \`\`\``;
 }
 

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -27,6 +27,8 @@ describe("Apple release workflows", () => {
     expect(mobile).toContain("bunx expo prebuild --platform ios");
     expect(mobile).toContain("xcodebuild");
     expect(mobile).toContain("IOS_APP_STORE");
+    expect(mobile).toContain("--certificate-type IOS_DISTRIBUTION");
+    expect(mobile).not.toContain("--certificate-type DISTRIBUTION");
     expect(mobile).toContain("Upload local IPA to Sentry Size Analysis");
     expect(mobile).toContain("asc builds upload");
     expect(mobile).toContain("asc validate");

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -44,6 +44,14 @@ describe("Apple release workflows", () => {
     expect(mobile).toContain("--social-media-age-restricted false");
   });
 
+  test("serializes app-wide iOS build-number allocation through upload", () => {
+    expect(mobile).toContain(
+      "group: mobile-app-store-ios-${{ github.repository }}"
+    );
+    expect(mobile).not.toContain("group: mobile-app-store-${{ inputs.version }}");
+    expect(mobile).toContain("cancel-in-progress: false");
+  });
+
   test("keeps Safari PKG artifacts while using asc for every Apple operation", () => {
     expect(safari).toContain("xcodebuild archive");
     expect(safari).toContain("asc certificates");

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -10,6 +10,7 @@ describe("Apple release workflows", () => {
   const mobile = read(".github/workflows/mobile-release.yml");
   const safari = read(".github/workflows/safari-extension-release.yml");
   const status = read(".github/workflows/apple-release-status.yml");
+  const issueHelper = read("scripts/apple-release-issue.mjs");
   const versionTag = read(".github/workflows/version-tag.yml");
   const setupAscPin =
     "rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d";
@@ -22,18 +23,25 @@ describe("Apple release workflows", () => {
     }
   });
 
-  test("keeps iOS on hosted EAS build plus asc upload and review", () => {
-    expect(mobile).toContain("--profile production");
-    expect(mobile).toContain("--non-interactive");
-    expect(mobile).toContain("Upload IPA to Sentry Size Analysis");
+  test("keeps iOS on a runner-local Xcode build plus asc upload and review", () => {
+    expect(mobile).toContain("bunx expo prebuild --platform ios");
+    expect(mobile).toContain("xcodebuild");
+    expect(mobile).toContain("IOS_APP_STORE");
+    expect(mobile).toContain("Upload local IPA to Sentry Size Analysis");
     expect(mobile).toContain("asc builds upload");
     expect(mobile).toContain("asc validate");
     expect(mobile).toContain("asc review doctor");
     expect(mobile).toContain("asc review submit");
     expect(mobile).not.toContain("eas submit");
+    expect(mobile).not.toContain("eas-cli");
+    expect(mobile).not.toContain("EXPO_TOKEN");
     expect(mobile).not.toContain("submit-app-review.mjs");
-    expect(mobile).toContain("--limit 50");
-    expect(mobile).not.toContain("--limit 100");
+    expect(mobile).toContain("manageAppVersionAndBuildNumber bool false");
+    expect(mobile).toContain("apple-build-number.mjs");
+    expect(mobile).toContain("EXPO_PUBLIC_CONVEX_URL");
+    expect(mobile).toContain("secrets.SENTRY_MOBILE_DSN");
+    expect(mobile).toContain("asc age-rating edit");
+    expect(mobile).toContain("--social-media-age-restricted false");
   });
 
   test("keeps Safari PKG artifacts while using asc for every Apple operation", () => {
@@ -48,6 +56,8 @@ describe("Apple release workflows", () => {
     expect(safari).not.toContain("xcrun altool");
     expect(safari).toContain('[ "$candidate_hash" = "$private_hash" ]');
     expect(safari).not.toContain("EXPECTED_SIGNING_IDENTITY");
+    expect(safari).toContain("asc age-rating edit");
+    expect(safari).toContain("--social-media-age-restricted false");
   });
 
   test("permits real recovery only from a tagged release descendant", () => {
@@ -104,5 +114,7 @@ describe("Apple release workflows", () => {
     }
     expect(mobile).toContain("apple-release-issue.mjs failure");
     expect(safari).toContain("apple-release-issue.mjs failure");
+    expect(issueHelper).toContain("--ref main");
+    expect(issueHelper).not.toContain(" --ref v");
   });
 });


### PR DESCRIPTION
## Summary
- replace the hosted EAS iOS build path with Expo native generation plus direct Xcode archive/export on the GitHub Actions macOS runner
- derive deterministic iOS build numbers from App Store Connect through pinned asc-cli, verify the exact signed IPA, keep mandatory Sentry Size Analysis, and retain asc upload/metadata/validation/doctor/submission
- repair the 1.0.60 Safari recovery by explicitly setting the two newly-required social-media age-rating declarations through asc-cli
- update release documentation and deterministic workflow/helper tests

## Recovery safety
- the prior hosted-EAS recovery run was cancelled during dependency installation, before any EAS build step, so it consumed no hosted EAS build minutes
- recovery dispatches run from `main` while requiring the existing `v1.0.60` tag and descendant history
- existing valid Safari build 35.1 and its GitHub Release PKG remain reusable

## Validation
- pre-commit: 22/22 tasks passed
- focused release tests: 20 passed, 131 assertions
- mobile lint, typecheck, 166 tests, and Expo web export passed
- actionlint and YAML parsing passed for changed release workflows
- local Expo iOS prebuild, CocoaPods install, generated version/build inspection, and Xcode signing configuration passed
