### PR TITLE
fix(release): reconcile Apple review drafts

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -599,14 +599,62 @@ jobs:
           asc versions attach-build --version-id "$VERSION_ID" --build-id "$BUILD_ID" > "$RUNNER_TEMP/ios-attach.json"
           asc validate --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" --strict > "$RUNNER_TEMP/ios-validate.json"
           asc review doctor --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" > "$RUNNER_TEMP/ios-doctor.json"
-          asc review submit \
-            --app "$ASC_APP_ID" \
-            --version-id "$VERSION_ID" \
-            --build "$BUILD_ID" \
-            --platform "$PLATFORM" \
-            --confirm > "$RUNNER_TEMP/ios-submit.json"
 
-          submission_id="$(jq -r '.submissionId // .id // empty' "$RUNNER_TEMP/ios-submit.json")"
+          ready_submissions="$RUNNER_TEMP/ios-ready-submissions.json"
+          asc review submissions-list \
+            --app "$ASC_APP_ID" \
+            --platform "$PLATFORM" \
+            --state READY_FOR_REVIEW \
+            --paginate > "$ready_submissions"
+          matching_submission=""
+          empty_submission=""
+          while IFS= read -r candidate_id; do
+            candidate_items="$RUNNER_TEMP/ios-review-items-$candidate_id.json"
+            asc review items-list \
+              --submission "$candidate_id" \
+              --fields appStoreVersion \
+              --include appStoreVersion \
+              --paginate > "$candidate_items"
+            item_count="$(jq '.data | length' "$candidate_items")"
+            target_count="$(jq --arg target "$VERSION_ID" '[.data[]? | select(.relationships.appStoreVersion.data.id == $target)] | length' "$candidate_items")"
+            if [ "$target_count" -eq 1 ] && [ "$item_count" -eq 1 ]; then
+              if [ -n "$matching_submission" ] && [ "$matching_submission" != "$candidate_id" ]; then
+                echo "Multiple READY_FOR_REVIEW submissions contain iOS version $VERSION_ID." >&2
+                exit 1
+              fi
+              matching_submission="$candidate_id"
+            elif [ "$item_count" -eq 0 ] && [ -z "$empty_submission" ]; then
+              empty_submission="$candidate_id"
+            fi
+          done < <(jq -r '.data[]?.id' "$ready_submissions")
+
+          submission_id="$matching_submission"
+          if [ -z "$submission_id" ]; then
+            submission_id="$empty_submission"
+            if [ -z "$submission_id" ]; then
+              asc review submissions-create --app "$ASC_APP_ID" --platform "$PLATFORM" > "$RUNNER_TEMP/ios-submission-create.json"
+              submission_id="$(jq -r '.data.id // .id // empty' "$RUNNER_TEMP/ios-submission-create.json")"
+            fi
+            if [ -z "$submission_id" ]; then
+              echo "Could not resolve an iOS review submission." >&2
+              exit 1
+            fi
+            asc review items-add \
+              --submission "$submission_id" \
+              --item-type appStoreVersions \
+              --item-id "$VERSION_ID" > "$RUNNER_TEMP/ios-review-item-add.json"
+          fi
+
+          asc review items-list \
+            --submission "$submission_id" \
+            --fields appStoreVersion \
+            --include appStoreVersion \
+            --paginate > "$RUNNER_TEMP/ios-review-items-final.json"
+          if ! jq -e --arg target "$VERSION_ID" '.data | length == 1 and .[0].relationships.appStoreVersion.data.id == $target' "$RUNNER_TEMP/ios-review-items-final.json" > /dev/null; then
+            echo "Refusing to submit an iOS review draft that is empty or contains unrelated items." >&2
+            exit 1
+          fi
+          asc review submissions-submit --id "$submission_id" --confirm > "$RUNNER_TEMP/ios-submit.json"
           echo "submission_id=$submission_id" >> "$GITHUB_OUTPUT"
 
       - name: Prove iOS reached App Review

--- a/.github/workflows/safari-extension-release.yml
+++ b/.github/workflows/safari-extension-release.yml
@@ -538,13 +538,62 @@ jobs:
           asc versions attach-build --version-id "$VERSION_ID" --build-id "$build_id" > "$RUNNER_TEMP/safari-attach.json"
           asc validate --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" --strict > "$RUNNER_TEMP/safari-validate.json"
           asc review doctor --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" > "$RUNNER_TEMP/safari-doctor.json"
-          asc review submit \
+
+          ready_submissions="$RUNNER_TEMP/safari-ready-submissions.json"
+          asc review submissions-list \
             --app "$ASC_APP_ID" \
-            --version-id "$VERSION_ID" \
-            --build "$build_id" \
             --platform "$PLATFORM" \
-            --confirm > "$RUNNER_TEMP/safari-submit.json"
-          submission_id="$(jq -r '.submissionId // .id // empty' "$RUNNER_TEMP/safari-submit.json")"
+            --state READY_FOR_REVIEW \
+            --paginate > "$ready_submissions"
+          matching_submission=""
+          empty_submission=""
+          while IFS= read -r candidate_id; do
+            candidate_items="$RUNNER_TEMP/safari-review-items-$candidate_id.json"
+            asc review items-list \
+              --submission "$candidate_id" \
+              --fields appStoreVersion \
+              --include appStoreVersion \
+              --paginate > "$candidate_items"
+            item_count="$(jq '.data | length' "$candidate_items")"
+            target_count="$(jq --arg target "$VERSION_ID" '[.data[]? | select(.relationships.appStoreVersion.data.id == $target)] | length' "$candidate_items")"
+            if [ "$target_count" -eq 1 ] && [ "$item_count" -eq 1 ]; then
+              if [ -n "$matching_submission" ] && [ "$matching_submission" != "$candidate_id" ]; then
+                echo "Multiple READY_FOR_REVIEW submissions contain Safari version $VERSION_ID." >&2
+                exit 1
+              fi
+              matching_submission="$candidate_id"
+            elif [ "$item_count" -eq 0 ] && [ -z "$empty_submission" ]; then
+              empty_submission="$candidate_id"
+            fi
+          done < <(jq -r '.data[]?.id' "$ready_submissions")
+
+          submission_id="$matching_submission"
+          if [ -z "$submission_id" ]; then
+            submission_id="$empty_submission"
+            if [ -z "$submission_id" ]; then
+              asc review submissions-create --app "$ASC_APP_ID" --platform "$PLATFORM" > "$RUNNER_TEMP/safari-submission-create.json"
+              submission_id="$(jq -r '.data.id // .id // empty' "$RUNNER_TEMP/safari-submission-create.json")"
+            fi
+            if [ -z "$submission_id" ]; then
+              echo "Could not resolve a Safari review submission." >&2
+              exit 1
+            fi
+            asc review items-add \
+              --submission "$submission_id" \
+              --item-type appStoreVersions \
+              --item-id "$VERSION_ID" > "$RUNNER_TEMP/safari-review-item-add.json"
+          fi
+
+          asc review items-list \
+            --submission "$submission_id" \
+            --fields appStoreVersion \
+            --include appStoreVersion \
+            --paginate > "$RUNNER_TEMP/safari-review-items-final.json"
+          if ! jq -e --arg target "$VERSION_ID" '.data | length == 1 and .[0].relationships.appStoreVersion.data.id == $target' "$RUNNER_TEMP/safari-review-items-final.json" > /dev/null; then
+            echo "Refusing to submit a Safari review draft that is empty or contains unrelated items." >&2
+            exit 1
+          fi
+          asc review submissions-submit --id "$submission_id" --confirm > "$RUNNER_TEMP/safari-submit.json"
           echo "submission_id=$submission_id" >> "$GITHUB_OUTPUT"
 
       - name: Prove Safari macOS reached App Review

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -33,7 +33,8 @@ describe("Apple release workflows", () => {
     expect(mobile).toContain("asc builds upload");
     expect(mobile).toContain("asc validate");
     expect(mobile).toContain("asc review doctor");
-    expect(mobile).toContain("asc review submit");
+    expect(mobile).toContain("asc review submissions-submit");
+    expect(mobile).toContain("--include appStoreVersion");
     expect(mobile).not.toContain("eas submit");
     expect(mobile).not.toContain("eas-cli");
     expect(mobile).not.toContain("EXPO_TOKEN");
@@ -61,7 +62,8 @@ describe("Apple release workflows", () => {
     expect(safari).toContain("asc builds upload");
     expect(safari).toContain("--pkg");
     expect(safari).toContain("teak-safari-$VERSION-mac-app-store.pkg");
-    expect(safari).toContain("asc review submit");
+    expect(safari).toContain("asc review submissions-submit");
+    expect(safari).toContain("--include appStoreVersion");
     expect(safari).not.toContain("apps/safari-extension/scripts/");
     expect(safari).not.toContain("xcrun altool");
     expect(safari).toContain('[ "$candidate_hash" = "$private_hash" ]');


### PR DESCRIPTION
## Summary
- replace asc 3.6.1's failing high-level review wrapper with its explicit review-submission lifecycle commands on iOS and Safari
- reuse only a READY_FOR_REVIEW draft that is empty or contains exactly the target App Store version
- expand and verify the appStoreVersion relationship before submitting, and fail closed on unrelated or duplicate drafts
- keep exact build attachment, strict validation, review doctor, and submission ordering unchanged

## Production evidence
Safari recovery run [31294778012](https://github.com/praveenjuge/teak/actions/runs/31294778012) reused exact VALID build 35.1 and passed metadata, age rating, attachment, strict validation, and doctor. The asc high-level wrapper then failed its own final membership validation because its internal item read omitted the expanded appStoreVersion relationship. The workflow now performs that lifecycle directly through asc and explicitly requests/validates the relationship.

The current iOS run is still producing the local GitHub-runner archive. If it reaches the same wrapper defect after upload, the next recovery run will reuse its exact VALID build.

## Validation
- focused Apple release tests: 15 passed, 92 assertions
- actionlint passed for both changed workflows
- pre-commit: 22/22 tasks passed
- workflow sizes remain below 750 lines
