### PR TITLE
fix(release): resume ready review drafts

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -155,7 +155,7 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           else
             case "$target_state" in
-              ""|PREPARE_FOR_SUBMISSION)
+              ""|PREPARE_FOR_SUBMISSION|READY_FOR_REVIEW)
                 mutate=true
                 ;;
               WAITING_FOR_REVIEW|IN_REVIEW|PENDING_APPLE_RELEASE|PROCESSING_FOR_DISTRIBUTION|READY_FOR_DISTRIBUTION|READY_FOR_SALE)

--- a/.github/workflows/safari-extension-release.yml
+++ b/.github/workflows/safari-extension-release.yml
@@ -133,7 +133,7 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           else
             case "$target_state" in
-              ""|PREPARE_FOR_SUBMISSION)
+              ""|PREPARE_FOR_SUBMISSION|READY_FOR_REVIEW)
                 mutate=true
                 ;;
               WAITING_FOR_REVIEW|IN_REVIEW|PENDING_APPLE_RELEASE|PROCESSING_FOR_DISTRIBUTION|READY_FOR_DISTRIBUTION|READY_FOR_SALE)

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -120,6 +120,17 @@ describe("Apple release workflows", () => {
     expect(status).toContain("apple-release-issue.mjs status");
   });
 
+  test("continues an exact version already attached to a review draft", () => {
+    for (const workflow of [mobile, safari]) {
+      expect(workflow).toContain(
+        '""|PREPARE_FOR_SUBMISSION|READY_FOR_REVIEW)'
+      );
+      expect(workflow).not.toContain(
+        "WAITING_FOR_REVIEW|READY_FOR_REVIEW|IN_REVIEW"
+      );
+    }
+  });
+
   test("serializes failure deduplication by version", () => {
     for (const workflow of [mobile, safari, status]) {
       expect(workflow).toContain("apple-release-issue-");


### PR DESCRIPTION
## Summary
- classify App Store version state READY_FOR_REVIEW as a mutable pre-submission state on iOS and Safari
- keep WAITING_FOR_REVIEW and all later review/distribution states immutable
- add a deterministic guard test distinguishing READY_FOR_REVIEW from WAITING_FOR_REVIEW

## Production evidence
Safari recovery run [31295231039](https://github.com/praveenjuge/teak/actions/runs/31295231039) read version 1.0.60 as READY_FOR_REVIEW after the previous asc draft had attached the exact target version. The old guard treated this valid pre-submission state as unknown. The review draft has not been submitted yet; the next run must resume it through the explicit asc lifecycle merged in #299.

## Validation
- focused workflow tests: 10 passed, 82 assertions
- actionlint passed for both Apple release workflows
- pre-commit: 22/22 tasks passed
