### PR TITLE
fix(release): accept ready draft doctor state

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -594,11 +594,24 @@ jobs:
         if: steps.release_state.outputs.mutate == 'true'
         env:
           BUILD_ID: ${{ steps.apple_build.outputs.id }}
+          CURRENT_STATE: ${{ steps.release_state.outputs.target_state }}
           VERSION_ID: ${{ steps.apple_version.outputs.id }}
         run: |
           asc versions attach-build --version-id "$VERSION_ID" --build-id "$BUILD_ID" > "$RUNNER_TEMP/ios-attach.json"
           asc validate --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" --strict > "$RUNNER_TEMP/ios-validate.json"
-          asc review doctor --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" > "$RUNNER_TEMP/ios-doctor.json"
+          doctor_exit=0
+          asc review doctor --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" > "$RUNNER_TEMP/ios-doctor.json" || doctor_exit=$?
+          if [ "$doctor_exit" -ne 0 ]; then
+            if [ "$CURRENT_STATE" != "READY_FOR_REVIEW" ] || ! jq -e '
+              .summary.errors == 1
+              and .summary.blocking == 1
+              and ([.blockingChecks[]?.id] == ["version.state.editable"])
+            ' "$RUNNER_TEMP/ios-doctor.json" > /dev/null; then
+              echo "asc review doctor found unexpected iOS submission blockers." >&2
+              exit "$doctor_exit"
+            fi
+            echo "asc review doctor confirmed the only blocker is the expected existing READY_FOR_REVIEW draft." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
           ready_submissions="$RUNNER_TEMP/ios-ready-submissions.json"
           asc review submissions-list \

--- a/.github/workflows/safari-extension-release.yml
+++ b/.github/workflows/safari-extension-release.yml
@@ -525,6 +525,7 @@ jobs:
         id: submit
         if: steps.release_state.outputs.mutate == 'true'
         env:
+          CURRENT_STATE: ${{ steps.release_state.outputs.target_state }}
           NEW_BUILD_ID: ${{ steps.uploaded_build.outputs.id }}
           REUSED_BUILD_ID: ${{ steps.reuse.outputs.build_id }}
           VERSION_ID: ${{ steps.apple_version.outputs.id }}
@@ -537,7 +538,19 @@ jobs:
           fi
           asc versions attach-build --version-id "$VERSION_ID" --build-id "$build_id" > "$RUNNER_TEMP/safari-attach.json"
           asc validate --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" --strict > "$RUNNER_TEMP/safari-validate.json"
-          asc review doctor --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" > "$RUNNER_TEMP/safari-doctor.json"
+          doctor_exit=0
+          asc review doctor --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" > "$RUNNER_TEMP/safari-doctor.json" || doctor_exit=$?
+          if [ "$doctor_exit" -ne 0 ]; then
+            if [ "$CURRENT_STATE" != "READY_FOR_REVIEW" ] || ! jq -e '
+              .summary.errors == 1
+              and .summary.blocking == 1
+              and ([.blockingChecks[]?.id] == ["version.state.editable"])
+            ' "$RUNNER_TEMP/safari-doctor.json" > /dev/null; then
+              echo "asc review doctor found unexpected Safari submission blockers." >&2
+              exit "$doctor_exit"
+            fi
+            echo "asc review doctor confirmed the only blocker is the expected existing READY_FOR_REVIEW draft." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
           ready_submissions="$RUNNER_TEMP/safari-ready-submissions.json"
           asc review submissions-list \

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -121,6 +121,13 @@ describe("Apple release workflows", () => {
   });
 
   test("continues an exact version already attached to a review draft", () => {
+    const exactDoctorException = `if [ "$doctor_exit" -ne 0 ]; then
+            if [ "$CURRENT_STATE" != "READY_FOR_REVIEW" ] || ! jq -e '
+              .summary.errors == 1
+              and .summary.blocking == 1
+              and ([.blockingChecks[]?.id] == ["version.state.editable"])
+            '`;
+
     for (const workflow of [mobile, safari]) {
       expect(workflow).toContain(
         '""|PREPARE_FOR_SUBMISSION|READY_FOR_REVIEW)'
@@ -128,9 +135,7 @@ describe("Apple release workflows", () => {
       expect(workflow).not.toContain(
         "WAITING_FOR_REVIEW|READY_FOR_REVIEW|IN_REVIEW"
       );
-      expect(workflow).toContain(
-        "and ([.blockingChecks[]?.id] == [\"version.state.editable\"])"
-      );
+      expect(workflow.split(exactDoctorException)).toHaveLength(2);
       expect(workflow).toContain(
         "the only blocker is the expected existing READY_FOR_REVIEW draft"
       );

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -128,6 +128,12 @@ describe("Apple release workflows", () => {
       expect(workflow).not.toContain(
         "WAITING_FOR_REVIEW|READY_FOR_REVIEW|IN_REVIEW"
       );
+      expect(workflow).toContain(
+        "and ([.blockingChecks[]?.id] == [\"version.state.editable\"])"
+      );
+      expect(workflow).toContain(
+        "the only blocker is the expected existing READY_FOR_REVIEW draft"
+      );
     }
   });
 


### PR DESCRIPTION
## Summary
- preserve strict asc review doctor gating for editable releases
- allow recovery of an existing READY_FOR_REVIEW draft only when doctor reports exactly the expected non-editable-state blocker
- apply the same fail-closed behavior to iOS and Safari and cover it deterministically

## Validation
- bun test scripts/apple-workflows.test.ts (10 pass, 86 expectations)
- both workflows parse as YAML
- NEXT_PUBLIC_CONVEX_URL=https://example.convex.cloud NEXT_PUBLIC_CONVEX_SITE_URL=https://example.convex.site bun run pre-commit (22/22 tasks)

## Live evidence
Safari recovery run 31295556387 reused exact VALID build 35.1 and showed asc review doctor reports only version.state.editable for its existing READY_FOR_REVIEW draft. This patch accepts only that exact condition and keeps all other doctor failures terminal.