### PR TITLE
Improve Apple release orchestration and proof

### DIFF
--- a/.github/workflows/apple-release-status.yml
+++ b/.github/workflows/apple-release-status.yml
@@ -41,11 +41,12 @@ jobs:
       cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up asc
         uses: rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d # v1.0.1
         with:
+          cache: "false"
           version: ${{ env.ASC_VERSION }}
 
       - name: Prepare App Store Connect key

--- a/.github/workflows/apple-release-status.yml
+++ b/.github/workflows/apple-release-status.yml
@@ -34,14 +34,14 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     concurrency:
       group: apple-release-issue-${{ inputs.version || 'current' }}
       cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up asc
         uses: rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d # v1.0.1
@@ -61,46 +61,60 @@ jobs:
           chmod 600 "$key_path"
           echo "ASC_PRIVATE_KEY_PATH=$key_path" >> "$GITHUB_ENV"
 
-      - name: Resolve target version
-        id: version
-        env:
-          REQUESTED_VERSION: ${{ inputs.version }}
-        run: |
-          version="$REQUESTED_VERSION"
-          if [ -z "$version" ]; then
-            version="$(node -p "require('./package.json').version")"
-          fi
-          node scripts/release-version.mjs version "$version"
-          echo "value=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Read iOS and Safari macOS status with asc
-        id: states
-        env:
-          VERSION: ${{ steps.version.outputs.value }}
-        run: |
-          asc auth status --validate --output table
-          asc versions list --app "$IOS_APP_ID" --platform IOS --version "$VERSION" --limit 1 > "$RUNNER_TEMP/ios-version.json"
-          asc versions list --app "$SAFARI_APP_ID" --platform MAC_OS --version "$VERSION" --limit 1 > "$RUNNER_TEMP/safari-version.json"
-          ios_state="$(jq -r '.data[0].attributes.appVersionState // .data[0].attributes.appStoreState // "NOT_CREATED"' "$RUNNER_TEMP/ios-version.json")"
-          safari_state="$(jq -r '.data[0].attributes.appVersionState // .data[0].attributes.appStoreState // "NOT_CREATED"' "$RUNNER_TEMP/safari-version.json")"
-          ios_id="$(jq -r '.data[0].id // "n/a"' "$RUNNER_TEMP/ios-version.json")"
-          safari_id="$(jq -r '.data[0].id // "n/a"' "$RUNNER_TEMP/safari-version.json")"
-          echo "ios=$ios_state" >> "$GITHUB_OUTPUT"
-          echo "safari=$safari_state" >> "$GITHUB_OUTPUT"
-          {
-            echo "### Apple release v$VERSION"
-            echo "- iOS: $ios_state ($ios_id)"
-            echo "- Safari macOS: $safari_state ($safari_id)"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Update or close the deduplicated release issue
-        if: ${{ github.event_name == 'schedule' || inputs.dry_run == false }}
+      - name: Check every pending Apple release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.version.outputs.value }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+          UPDATE_ISSUES: ${{ github.event_name == 'schedule' || inputs.dry_run == false }}
         run: |
-          node scripts/apple-release-issue.mjs status \
-            --version "$VERSION" \
-            --ios-state "${{ steps.states.outputs.ios }}" \
-            --safari-state "${{ steps.states.outputs.safari }}" \
-            --workflow-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          if [ -n "$REQUESTED_VERSION" ]; then
+            node scripts/release-version.mjs version "$REQUESTED_VERSION"
+            versions="$(jq -cn --arg version "$REQUESTED_VERSION" '[$version]')"
+          elif [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+            versions="$(node scripts/apple-release-issue.mjs versions)"
+            if [ "$versions" = "[]" ]; then
+              root_version="$(node -p "require('./package.json').version")"
+              versions="$(jq -cn --arg version "$root_version" '[$version]')"
+            fi
+          else
+            root_version="$(node -p "require('./package.json').version")"
+            versions="$(jq -cn --arg version "$root_version" '[$version]')"
+          fi
+          asc auth status --validate --output table
+          while IFS= read -r version; do
+            node scripts/release-version.mjs version "$version"
+            ios_path="$RUNNER_TEMP/ios-version-$version.json"
+            safari_path="$RUNNER_TEMP/safari-version-$version.json"
+            for attempt in 1 2 3; do
+              if asc versions list --app "$IOS_APP_ID" --platform IOS --version "$version" --limit 1 --output json > "$ios_path" && \
+                asc versions list --app "$SAFARI_APP_ID" --platform MAC_OS --version "$version" --limit 1 --output json > "$safari_path"; then
+                break
+              fi
+              if [ "$attempt" -eq 3 ]; then exit 1; fi
+              sleep $((attempt * 10))
+            done
+            ios_state="$(jq -r '.data[0].attributes.appVersionState // .data[0].attributes.appStoreState // "NOT_CREATED"' "$ios_path")"
+            safari_state="$(jq -r '.data[0].attributes.appVersionState // .data[0].attributes.appStoreState // "NOT_CREATED"' "$safari_path")"
+            ios_id="$(jq -r '.data[0].id // "n/a"' "$ios_path")"
+            safari_id="$(jq -r '.data[0].id // "n/a"' "$safari_path")"
+
+            ios_store="$(curl --fail --silent --show-error --retry 3 --retry-all-errors --connect-timeout 10 --max-time 30 \
+              "https://itunes.apple.com/lookup?id=$IOS_APP_ID&country=us" | jq -r '.results[0].version // "NOT_LIVE"')"
+            safari_store="$(curl --fail --silent --show-error --retry 3 --retry-all-errors --connect-timeout 10 --max-time 30 \
+              "https://itunes.apple.com/lookup?id=$SAFARI_APP_ID&country=us" | jq -r '.results[0].version // "NOT_LIVE"')"
+            {
+              echo "### Apple release v$version"
+              echo "- iOS: $ios_state ($ios_id); storefront $ios_store"
+              echo "- Safari macOS: $safari_state ($safari_id); storefront $safari_store"
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            if [ "$UPDATE_ISSUES" = "true" ]; then
+              node scripts/apple-release-issue.mjs status \
+                --version "$version" \
+                --ios-state "$ios_state" \
+                --ios-store-version "$ios_store" \
+                --safari-state "$safari_state" \
+                --safari-store-version "$safari_store" \
+                --workflow-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            fi
+          done < <(jq -r '.[]' <<< "$versions")

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Resolve version
         id: version
@@ -47,13 +47,13 @@ jobs:
 
       - name: Setup Bun
         if: steps.check.outputs.should_publish == 'true'
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.5"
 
       - name: Setup Node
         if: steps.check.outputs.should_publish == 'true'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Resolve version
         id: version
@@ -47,13 +47,13 @@ jobs:
 
       - name: Setup Bun
         if: steps.check.outputs.should_publish == 'true'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.5"
 
       - name: Setup Node
         if: steps.check.outputs.should_publish == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check if version already released
         id: check
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Bun
         if: steps.check.outputs.should_run == 'true'
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.5"
 

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Check if version already released
         id: check
@@ -46,7 +46,7 @@ jobs:
 
       - name: Setup Bun
         if: steps.check.outputs.should_run == 'true'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.5"
 

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Check if version already released
         id: check
@@ -39,7 +39,7 @@ jobs:
 
       - name: Setup Bun
         if: steps.check.outputs.should_run == 'true'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.5"
 
@@ -78,7 +78,7 @@ jobs:
           TAG_NAME: ${{ github.ref_name }}
         run: |
           version="${TAG_NAME#v}"
-          zip_path="$(ls .output/*-chrome.zip | head -n1)"
+          zip_path="$(find .output -maxdepth 1 -type f -name '*-chrome.zip' -print -quit)"
           if [ -z "$zip_path" ] || [ ! -f "$zip_path" ]; then
             echo "Could not find built Chrome zip under apps/extension/.output" >&2
             ls -la .output >&2 || true
@@ -86,9 +86,11 @@ jobs:
           fi
           release_zip="teak-extension-${version}-chrome.zip"
           cp "$zip_path" ".output/${release_zip}"
-          echo "zip_path=apps/extension/${zip_path}" >> "$GITHUB_OUTPUT"
-          echo "release_zip_path=apps/extension/.output/${release_zip}" >> "$GITHUB_OUTPUT"
-          echo "release_zip_name=${release_zip}" >> "$GITHUB_OUTPUT"
+          {
+            echo "zip_path=apps/extension/${zip_path}"
+            echo "release_zip_path=apps/extension/.output/${release_zip}"
+            echo "release_zip_name=${release_zip}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Verify Chrome Web Store credentials
         if: steps.check.outputs.should_run == 'true'

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check if version already released
         id: check
@@ -39,7 +39,7 @@ jobs:
 
       - name: Setup Bun
         if: steps.check.outputs.should_run == 'true'
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.5"
 

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -47,20 +47,20 @@ jobs:
       target_state: ${{ steps.release_state.outputs.target_state }}
     steps:
       - name: Checkout release ref
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.5
       - name: Set up asc
         uses: rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d # v1.0.1
         with:
+          cache: "false"
           version: ${{ env.ASC_VERSION }}
       - name: Install dependencies
         run: bun install --frozen-lockfile
-
       - name: Prepare App Store Connect key
         env:
           APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
@@ -73,7 +73,6 @@ jobs:
           printf '%s' "$APPLE_API_KEY_P8" > "$key_path"
           chmod 600 "$key_path"
           echo "ASC_PRIVATE_KEY_PATH=$key_path" >> "$GITHUB_ENV"
-
       - name: Verify release identity and canonical version
         env:
           DRY_RUN: ${{ inputs.dry_run }}
@@ -115,7 +114,6 @@ jobs:
                 ;;
             esac
           fi
-
           expo_version="$(cd apps/mobile && bunx expo config --type public --json | jq -r '.version')"
           if [ "$expo_version" != "$VERSION" ]; then
             echo "Expo resolved $expo_version, expected root package version $VERSION." >&2
@@ -128,7 +126,6 @@ jobs:
           fi
           echo "$xcode_version"
           pod --version
-
           asc auth status --validate --output table
           asc_version="$(asc --version | awk '{print $1}')"
           if [ "$asc_version" != "$ASC_VERSION" ]; then
@@ -495,7 +492,7 @@ jobs:
 
       - name: Upload verified signed IPA handoff
         if: steps.release_state.outputs.mutate == 'true' && steps.build_state.outputs.reuse != 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: teak-ios-${{ env.VERSION }}-signed
           path: |
@@ -514,19 +511,20 @@ jobs:
 
     steps:
       - name: Checkout release ref
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Bun
         if: needs.build.outputs.mutate == 'true' && needs.build.outputs.reuse != 'true'
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.5
 
       - name: Set up asc
         uses: rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d # v1.0.1
         with:
+          cache: "false"
           version: ${{ env.ASC_VERSION }}
 
       - name: Prepare App Store Connect key
@@ -549,7 +547,7 @@ jobs:
 
       - name: Download verified signed IPA handoff
         if: needs.build.outputs.mutate == 'true' && needs.build.outputs.reuse != 'true'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: teak-ios-${{ env.VERSION }}-signed
           path: ${{ runner.temp }}/ios-handoff
@@ -970,10 +968,11 @@ jobs:
       group: apple-release-issue-${{ inputs.version }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up asc
         uses: rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d # v1.0.1
         with:
+          cache: "false"
           version: ${{ env.ASC_VERSION }}
       - name: Prepare App Store Connect key
         env:

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -1,5 +1,5 @@
 name: Mobile App Store Release
-
+run-name: iOS ${{ inputs.version }} (${{ inputs.dry_run && 'dry run' || 'release' }})
 on:
   workflow_dispatch:
     inputs:
@@ -12,17 +12,14 @@ on:
         required: true
         default: true
         type: boolean
-
 concurrency:
   # App Store build numbers are allocated from app-wide ASC history, so keep
   # allocation through upload atomic even when different patch versions queue.
   group: mobile-app-store-ios-${{ github.repository }}
   cancel-in-progress: false
-
 permissions:
   contents: read
   issues: write
-
 env:
   ASC_APP_ID: "6756574989"
   ASC_BYPASS_KEYCHAIN: "1"
@@ -36,28 +33,31 @@ env:
   PLATFORM: IOS
   RELEASE_NOTES: "Small fixes and polish to keep saving and organizing your ideas smooth and reliable."
   VERSION: ${{ inputs.version }}
-
 jobs:
-  release:
-    runs-on: macos-latest
-    timeout-minutes: 150
-
+  build:
+    runs-on: macos-26
+    timeout-minutes: 90
+    outputs:
+      build_id: ${{ steps.build_state.outputs.build_id }}
+      build_number: ${{ steps.build_state.outputs.build_number }}
+      mutate: ${{ steps.release_state.outputs.mutate }}
+      reuse: ${{ steps.build_state.outputs.reuse }}
+      source_version: ${{ steps.release_state.outputs.source_version }}
+      target_id: ${{ steps.release_state.outputs.target_id }}
+      target_state: ${{ steps.release_state.outputs.target_state }}
     steps:
       - name: Checkout release ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
-
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.5
-
       - name: Set up asc
         uses: rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d # v1.0.1
         with:
           version: ${{ env.ASC_VERSION }}
-
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
@@ -94,13 +94,26 @@ jobs:
               echo "A real release requires the existing $release_tag tag." >&2
               exit 1
             fi
-            if ! git merge-base --is-ancestor "$tag_commit" "$GITHUB_SHA"; then
-              echo "A real release must run from $release_tag or one of its descendant recovery commits." >&2
-              exit 1
-            fi
-            if [ "$tag_commit" != "$GITHUB_SHA" ]; then
-              echo "- Recovery source: $GITHUB_SHA (descends from $release_tag at $tag_commit)" >> "$GITHUB_STEP_SUMMARY"
-            fi
+            case "$GITHUB_REF" in
+              "refs/tags/$release_tag")
+                if [ "$tag_commit" != "$GITHUB_SHA" ]; then
+                  echo "$release_tag resolved to an unexpected commit." >&2
+                  exit 1
+                fi
+                ;;
+              refs/heads/main)
+                git fetch origin main
+                if [ "$GITHUB_SHA" != "$(git rev-parse origin/main)" ] || ! git merge-base --is-ancestor "$tag_commit" "$GITHUB_SHA"; then
+                  echo "A recovery release must run at the current origin/main commit descending from $release_tag." >&2
+                  exit 1
+                fi
+                echo "- Recovery source: current main $GITHUB_SHA (descends from $release_tag at $tag_commit)" >> "$GITHUB_STEP_SUMMARY"
+                ;;
+              *)
+                echo "A real release may run only from $release_tag or current main, not $GITHUB_REF." >&2
+                exit 1
+                ;;
+            esac
           fi
 
           expo_version="$(cd apps/mobile && bunx expo config --type public --json | jq -r '.version')"
@@ -108,7 +121,12 @@ jobs:
             echo "Expo resolved $expo_version, expected root package version $VERSION." >&2
             exit 1
           fi
-          xcodebuild -version
+          xcode_version="$(xcodebuild -version)"
+          if [[ "$xcode_version" != Xcode\ 26.* ]]; then
+            echo "The pinned macos-26 release image must provide Xcode 26.x." >&2
+            exit 1
+          fi
+          echo "$xcode_version"
           pod --version
 
           asc auth status --validate --output table
@@ -125,7 +143,7 @@ jobs:
         run: |
           versions_json="$RUNNER_TEMP/ios-versions.json"
           for attempt in 1 2 3; do
-            if asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --paginate > "$versions_json"; then
+            if asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --paginate --output json > "$versions_json"; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then exit 1; fi
@@ -191,7 +209,8 @@ jobs:
             --processing-state VALID \
             --exclude-expired \
             --sort=-uploadedDate \
-            --limit 1 > "$exact_builds"
+            --limit 1 \
+            --output json > "$exact_builds"
           build_id="$(jq -r '.data[0].id // empty' "$exact_builds")"
           build_number="$(jq -r '.data[0].attributes.version // empty' "$exact_builds")"
 
@@ -201,8 +220,14 @@ jobs:
           else
             reuse=false
             all_builds="$RUNNER_TEMP/apple-ios-all-builds.json"
-            asc builds list --app "$ASC_APP_ID" --platform "$PLATFORM" --paginate > "$all_builds"
+            asc builds list --app "$ASC_APP_ID" --platform "$PLATFORM" --paginate --output json > "$all_builds"
             build_number="$(node scripts/apple-build-number.mjs "$all_builds")"
+            asc builds next-build-number --app "$ASC_APP_ID" --platform "$PLATFORM" --output json > "$RUNNER_TEMP/ios-asc-next-build.json"
+            asc_build_number="$(jq -r '.nextBuildNumber // .buildNumber // .data.nextBuildNumber // empty' "$RUNNER_TEMP/ios-asc-next-build.json")"
+            if [ -z "$asc_build_number" ] || [ "$asc_build_number" != "$build_number" ]; then
+              echo "asc next-build-number returned ${asc_build_number:-nothing}; deterministic allocation expected $build_number." >&2
+              exit 1
+            fi
             if ! [[ "$build_number" =~ ^[1-9][0-9]*$ ]]; then
               echo "Could not allocate a positive integer iOS build number from App Store Connect." >&2
               exit 1
@@ -450,25 +475,122 @@ jobs:
           done
           echo "- Local IPA: verified $VERSION/$BUILD_NUMBER for app and share extension" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Upload local IPA to Sentry Size Analysis
+      - name: Prepare verified signed IPA handoff
+        id: handoff
         if: steps.release_state.outputs.mutate == 'true' && steps.build_state.outputs.reuse != 'true'
         env:
+          BUILD_NUMBER: ${{ steps.build_state.outputs.build_number }}
+          IPA_PATH: ${{ steps.ipa.outputs.path }}
+        run: |
+          sha256="$(shasum -a 256 "$IPA_PATH" | awk '{print $1}')"
+          descriptor="$RUNNER_TEMP/ios-handoff.json"
+          jq -n \
+            --arg version "$VERSION" \
+            --arg buildNumber "$BUILD_NUMBER" \
+            --arg sha256 "$sha256" \
+            --arg fileName "$(basename "$IPA_PATH")" \
+            '{version: $version, buildNumber: $buildNumber, sha256: $sha256, fileName: $fileName}' > "$descriptor"
+          echo "descriptor=$descriptor" >> "$GITHUB_OUTPUT"
+          echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Upload verified signed IPA handoff
+        if: steps.release_state.outputs.mutate == 'true' && steps.build_state.outputs.reuse != 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: teak-ios-${{ env.VERSION }}-signed
+          path: |
+            ${{ steps.ipa.outputs.path }}
+            ${{ steps.handoff.outputs.descriptor }}
+          if-no-files-found: error
+          retention-days: 1
+
+  submit:
+    if: inputs.dry_run == false
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout release ref
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Bun
+        if: needs.build.outputs.mutate == 'true' && needs.build.outputs.reuse != 'true'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.5
+
+      - name: Set up asc
+        uses: rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d # v1.0.1
+        with:
+          version: ${{ env.ASC_VERSION }}
+
+      - name: Prepare App Store Connect key
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          if [ -z "$ASC_KEY_ID" ] || [ -z "$ASC_ISSUER_ID" ] || [ -z "$APPLE_API_KEY_P8" ]; then
+            echo "Missing App Store Connect credentials." >&2
+            exit 1
+          fi
+          key_path="$RUNNER_TEMP/AuthKey_${ASC_KEY_ID}.p8"
+          printf '%s' "$APPLE_API_KEY_P8" > "$key_path"
+          chmod 600 "$key_path"
+          echo "ASC_PRIVATE_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+          asc auth status --validate --output table
+
+      - name: Install dependencies for mandatory Sentry analysis
+        if: needs.build.outputs.mutate == 'true' && needs.build.outputs.reuse != 'true'
+        run: bun install --frozen-lockfile
+
+      - name: Download verified signed IPA handoff
+        if: needs.build.outputs.mutate == 'true' && needs.build.outputs.reuse != 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: teak-ios-${{ env.VERSION }}-signed
+          path: ${{ runner.temp }}/ios-handoff
+
+      - name: Verify handoff and upload IPA to Sentry Size Analysis
+        id: handoff
+        if: needs.build.outputs.mutate == 'true' && needs.build.outputs.reuse != 'true'
+        env:
+          BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           if [ -z "$SENTRY_AUTH_TOKEN" ]; then
             echo "Sentry Size Analysis is mandatory and SENTRY_AUTH_TOKEN is missing." >&2
             exit 1
           fi
-          bun run --cwd apps/mobile build:sentry -- "${{ steps.ipa.outputs.path }}"
+          descriptor="$(find "$RUNNER_TEMP/ios-handoff" -maxdepth 1 -type f -name 'ios-handoff.json')"
+          ipa_path="$(find "$RUNNER_TEMP/ios-handoff" -maxdepth 1 -type f -name '*.ipa')"
+          if [ "$(find "$RUNNER_TEMP/ios-handoff" -maxdepth 1 -type f -name '*.ipa' | wc -l | tr -d ' ')" -ne 1 ] || [ ! -s "$descriptor" ]; then
+            echo "Expected one signed IPA and its handoff descriptor." >&2
+            exit 1
+          fi
+          jq -e --arg version "$VERSION" --arg build "$BUILD_NUMBER" \
+            '.version == $version and .buildNumber == $build' "$descriptor" > /dev/null
+          expected_sha="$(jq -r '.sha256' "$descriptor")"
+          actual_sha="$(sha256sum "$ipa_path" | awk '{print $1}')"
+          if [ "$actual_sha" != "$expected_sha" ]; then
+            echo "Signed IPA handoff digest mismatch." >&2
+            exit 1
+          fi
+          bun run --cwd apps/mobile build:sentry -- "$ipa_path"
+          echo "path=$ipa_path" >> "$GITHUB_OUTPUT"
+          echo "sha256=$actual_sha" >> "$GITHUB_OUTPUT"
 
       - name: Upload local IPA with asc or reuse the exact valid Apple build
         id: apple_build
-        if: steps.release_state.outputs.mutate == 'true'
+        if: needs.build.outputs.mutate == 'true'
         env:
-          BUILD_NUMBER: ${{ steps.build_state.outputs.build_number }}
-          EXISTING_BUILD_ID: ${{ steps.build_state.outputs.build_id }}
-          IPA_PATH: ${{ steps.ipa.outputs.path }}
-          REUSE: ${{ steps.build_state.outputs.reuse }}
+          BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
+          EXISTING_BUILD_ID: ${{ needs.build.outputs.build_id }}
+          IPA_PATH: ${{ steps.handoff.outputs.path }}
+          REUSE: ${{ needs.build.outputs.reuse }}
         run: |
           build_id="$EXISTING_BUILD_ID"
           builds_path="$RUNNER_TEMP/apple-ios-builds.json"
@@ -479,7 +601,8 @@ jobs:
               --version "$VERSION" \
               --build-number "$BUILD_NUMBER" \
               --checksum \
-              --wait > "$RUNNER_TEMP/ios-upload.json"
+              --wait \
+              --output json > "$RUNNER_TEMP/ios-upload.json"
           fi
           asc builds list \
             --app "$ASC_APP_ID" \
@@ -487,7 +610,8 @@ jobs:
             --version "$VERSION" \
             --build-number "$BUILD_NUMBER" \
             --processing-state VALID \
-            --exclude-expired > "$builds_path"
+            --exclude-expired \
+            --output json > "$builds_path"
           resolved_build_id="$(jq -r '.data[0].id // empty' "$builds_path")"
           if [ -z "$resolved_build_id" ] || [ "$(jq '.data | length' "$builds_path")" -ne 1 ]; then
             echo "Expected exactly one VALID iOS build for $VERSION/$BUILD_NUMBER." >&2
@@ -500,12 +624,51 @@ jobs:
           echo "id=$resolved_build_id" >> "$GITHUB_OUTPUT"
           echo "- App Store build: $resolved_build_id ($VERSION/$BUILD_NUMBER, VALID)" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Evaluate asc high-level release commands without mutation
+        id: asc_parity
+        if: needs.build.outputs.mutate == 'true'
+        env:
+          BUILD_ID: ${{ steps.apple_build.outputs.id }}
+          IPA_PATH: ${{ steps.handoff.outputs.path }}
+          REUSE: ${{ needs.build.outputs.reuse }}
+          SOURCE_VERSION: ${{ needs.build.outputs.source_version }}
+        run: |
+          stage_exit=0
+          asc release stage \
+            --app "$ASC_APP_ID" \
+            --version "$VERSION" \
+            --build "$BUILD_ID" \
+            --platform "$PLATFORM" \
+            --copy-metadata-from "$SOURCE_VERSION" \
+            --exclude-fields whatsNew \
+            --strict-validate \
+            --dry-run \
+            --output json > "$RUNNER_TEMP/ios-release-stage-dry-run.json" || stage_exit=$?
+          publish_exit="not_evaluated_on_reuse"
+          if [ "$REUSE" != "true" ]; then
+            publish_exit=0
+            asc publish appstore \
+              --app "$ASC_APP_ID" \
+              --ipa "$IPA_PATH" \
+              --version "$VERSION" \
+              --platform "$PLATFORM" \
+              --submit \
+              --dry-run \
+              --output json > "$RUNNER_TEMP/ios-publish-dry-run.json" || publish_exit=$?
+          fi
+          echo "stage_exit=$stage_exit" >> "$GITHUB_OUTPUT"
+          echo "publish_exit=$publish_exit" >> "$GITHUB_OUTPUT"
+          {
+            echo "- asc release stage dry-run exit: $stage_exit"
+            echo "- asc publish appstore dry-run exit: $publish_exit"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Find or create the iOS version and preserve release metadata
         id: apple_version
-        if: steps.release_state.outputs.mutate == 'true'
+        if: needs.build.outputs.mutate == 'true'
         env:
-          SOURCE_VERSION: ${{ steps.release_state.outputs.source_version }}
-          TARGET_ID: ${{ steps.release_state.outputs.target_id }}
+          SOURCE_VERSION: ${{ needs.build.outputs.source_version }}
+          TARGET_ID: ${{ needs.build.outputs.target_id }}
         run: |
           version_id="$TARGET_ID"
           if [ -z "$version_id" ]; then
@@ -519,19 +682,20 @@ jobs:
               --platform "$PLATFORM" \
               --release-type AFTER_APPROVAL \
               --copy-metadata-from "$SOURCE_VERSION" \
-              --exclude-fields whatsNew > "$RUNNER_TEMP/ios-version-create.json"
+              --exclude-fields whatsNew \
+              --output json > "$RUNNER_TEMP/ios-version-create.json"
             version_id="$(jq -r '.id // empty' "$RUNNER_TEMP/ios-version-create.json")"
           fi
           if [ -z "$version_id" ]; then
-            version_id="$(asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --version "$VERSION" --limit 1 | jq -r '.data[0].id // empty')"
+            version_id="$(asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --version "$VERSION" --limit 1 --output json | jq -r '.data[0].id // empty')"
           fi
           if [ -z "$version_id" ]; then
             echo "Could not resolve iOS App Store version $VERSION." >&2
             exit 1
           fi
-          asc versions update --version-id "$version_id" --release-type AFTER_APPROVAL > "$RUNNER_TEMP/ios-version-update.json"
+          asc versions update --version-id "$version_id" --release-type AFTER_APPROVAL --output json > "$RUNNER_TEMP/ios-version-update.json"
           localizations="$RUNNER_TEMP/ios-localizations.json"
-          asc localizations list --version "$version_id" --paginate > "$localizations"
+          asc localizations list --version "$version_id" --paginate --output json > "$localizations"
           if [ "$(jq '.data | length' "$localizations")" -eq 0 ]; then
             echo "Metadata carry-forward produced no version localizations." >&2
             exit 1
@@ -542,9 +706,9 @@ jobs:
               --locale "$locale" \
               --whats-new "$RELEASE_NOTES" > /dev/null
           done < <(jq -r '.data[].attributes.locale' "$localizations")
-          source_id="$(asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --version "$SOURCE_VERSION" --limit 1 | jq -r '.data[0].id // empty')"
-          if ! asc review details-for-version --version-id "$version_id" > "$RUNNER_TEMP/ios-review-target.json" 2>/dev/null; then
-            asc review details-for-version --version-id "$source_id" > "$RUNNER_TEMP/ios-review-source.json"
+          source_id="$(asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --version "$SOURCE_VERSION" --limit 1 --output json | jq -r '.data[0].id // empty')"
+          if ! asc review details-for-version --version-id "$version_id" --output json > "$RUNNER_TEMP/ios-review-target.json" 2>/dev/null; then
+            asc review details-for-version --version-id "$source_id" --output json > "$RUNNER_TEMP/ios-review-source.json"
             review="$RUNNER_TEMP/ios-review-source.json"
             args=(review details-create --version-id "$version_id")
             for field in contactFirstName contactLastName contactEmail contactPhone notes; do
@@ -569,7 +733,7 @@ jobs:
           echo "id=$version_id" >> "$GITHUB_OUTPUT"
           echo "- App Store version: $version_id (AFTER_APPROVAL)" >> "$GITHUB_STEP_SUMMARY"
       - name: Complete new Apple age-rating fields without changing the existing declaration
-        if: steps.release_state.outputs.mutate == 'true'
+        if: needs.build.outputs.mutate == 'true'
         env:
           VERSION_ID: ${{ steps.apple_version.outputs.id }}
         run: |
@@ -586,16 +750,16 @@ jobs:
           fi
       - name: Attach exact build, validate, run doctor, and submit
         id: submit
-        if: steps.release_state.outputs.mutate == 'true'
+        if: needs.build.outputs.mutate == 'true'
         env:
           BUILD_ID: ${{ steps.apple_build.outputs.id }}
-          CURRENT_STATE: ${{ steps.release_state.outputs.target_state }}
+          CURRENT_STATE: ${{ needs.build.outputs.target_state }}
           VERSION_ID: ${{ steps.apple_version.outputs.id }}
         run: |
           attach_exit=0
-          asc versions attach-build --version-id "$VERSION_ID" --build-id "$BUILD_ID" > "$RUNNER_TEMP/ios-attach.json" || attach_exit=$?
+          asc versions attach-build --version-id "$VERSION_ID" --build-id "$BUILD_ID" --output json > "$RUNNER_TEMP/ios-attach.json" || attach_exit=$?
           if [ "$attach_exit" -ne 0 ]; then
-            asc versions view --version-id "$VERSION_ID" --include-build > "$RUNNER_TEMP/ios-attached-version.json"
+            asc versions view --version-id "$VERSION_ID" --include-build --output json > "$RUNNER_TEMP/ios-attached-version.json"
             if [ "$CURRENT_STATE" != "READY_FOR_REVIEW" ] || ! jq -e --arg version "$VERSION_ID" --arg build "$BUILD_ID" '.id == $version and .state == "READY_FOR_REVIEW" and .buildId == $build' "$RUNNER_TEMP/ios-attached-version.json" > /dev/null; then
               echo "Could not attach the exact iOS build to the target version." >&2
               exit "$attach_exit"
@@ -603,7 +767,7 @@ jobs:
             echo "- Exact iOS build was already attached to the existing READY_FOR_REVIEW draft." >> "$GITHUB_STEP_SUMMARY"
           fi
           validate_exit=0
-          asc validate --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" --strict > "$RUNNER_TEMP/ios-validate.json" || validate_exit=$?
+          asc validate --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" --strict --output json > "$RUNNER_TEMP/ios-validate.json" || validate_exit=$?
           if [ "$validate_exit" -ne 0 ]; then
             if [ "$CURRENT_STATE" != "READY_FOR_REVIEW" ] || ! jq -e '
               .summary.errors == 1
@@ -616,7 +780,7 @@ jobs:
             echo "asc validate confirmed the only blocker is the expected existing READY_FOR_REVIEW draft." >> "$GITHUB_STEP_SUMMARY"
           fi
           doctor_exit=0
-          asc review doctor --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" > "$RUNNER_TEMP/ios-doctor.json" || doctor_exit=$?
+          asc review doctor --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" --output json > "$RUNNER_TEMP/ios-doctor.json" || doctor_exit=$?
           if [ "$doctor_exit" -ne 0 ]; then
             if [ "$CURRENT_STATE" != "READY_FOR_REVIEW" ] || ! jq -e '
               .summary.errors == 1
@@ -633,7 +797,8 @@ jobs:
             --app "$ASC_APP_ID" \
             --platform "$PLATFORM" \
             --state READY_FOR_REVIEW \
-            --paginate > "$ready_submissions"
+            --paginate \
+            --output json > "$ready_submissions"
           matching_submission=""
           empty_submission=""
           while IFS= read -r candidate_id; do
@@ -642,7 +807,8 @@ jobs:
               --submission "$candidate_id" \
               --fields appStoreVersion \
               --include appStoreVersion \
-              --paginate > "$candidate_items"
+              --paginate \
+              --output json > "$candidate_items"
             item_count="$(jq '.data | length' "$candidate_items")"
             target_count="$(jq --arg target "$VERSION_ID" '[.data[]? | select(.relationships.appStoreVersion.data.id == $target)] | length' "$candidate_items")"
             if [ "$target_count" -eq 1 ] && [ "$item_count" -eq 1 ]; then
@@ -659,7 +825,7 @@ jobs:
           if [ -z "$submission_id" ]; then
             submission_id="$empty_submission"
             if [ -z "$submission_id" ]; then
-              asc review submissions-create --app "$ASC_APP_ID" --platform "$PLATFORM" > "$RUNNER_TEMP/ios-submission-create.json"
+              asc review submissions-create --app "$ASC_APP_ID" --platform "$PLATFORM" --output json > "$RUNNER_TEMP/ios-submission-create.json"
               submission_id="$(jq -r '.data.id // .id // empty' "$RUNNER_TEMP/ios-submission-create.json")"
             fi
             if [ -z "$submission_id" ]; then
@@ -675,31 +841,55 @@ jobs:
             --submission "$submission_id" \
             --fields appStoreVersion \
             --include appStoreVersion \
-            --paginate > "$RUNNER_TEMP/ios-review-items-final.json"
+            --paginate \
+            --output json > "$RUNNER_TEMP/ios-review-items-final.json"
           if ! jq -e --arg target "$VERSION_ID" '.data | length == 1 and .[0].relationships.appStoreVersion.data.id == $target' "$RUNNER_TEMP/ios-review-items-final.json" > /dev/null; then
             echo "Refusing to submit an iOS review draft that is empty or contains unrelated items." >&2
             exit 1
           fi
-          asc review submissions-submit --id "$submission_id" --confirm > "$RUNNER_TEMP/ios-submit.json"
+          asc review submissions-submit --id "$submission_id" --confirm --output json > "$RUNNER_TEMP/ios-submit.json"
           echo "submission_id=$submission_id" >> "$GITHUB_OUTPUT"
-      - name: Prove iOS reached App Review
-        if: steps.release_state.outputs.mutate == 'true'
+
+      - name: Prove exact iOS release and publish manifest
+        id: proof
         env:
+          BUILD_ID: ${{ steps.apple_build.outputs.id }}
+          BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
+          MANIFEST_NAME: teak-ios-${{ env.VERSION }}-app-store.json
+          MUTATE: ${{ needs.build.outputs.mutate }}
+          PUBLISH_EXIT: ${{ steps.asc_parity.outputs.publish_exit || 'not_run' }}
+          STAGE_EXIT: ${{ steps.asc_parity.outputs.stage_exit || 'not_run' }}
+          TARGET_ID: ${{ needs.build.outputs.target_id }}
           VERSION_ID: ${{ steps.apple_version.outputs.id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          version_id="$VERSION_ID"
+          build_id="$BUILD_ID"
+          build_number="$BUILD_NUMBER"
+          submission_id="${{ steps.submit.outputs.submission_id }}"
+          prior_manifest="$RUNNER_TEMP/prior-ios-manifest.json"
+          if [ "$MUTATE" != "true" ]; then
+            version_id="$TARGET_ID"
+            if ! gh release download "v$VERSION" --pattern "$MANIFEST_NAME" --output "$prior_manifest"; then
+              echo "A read-only rerun requires the existing release manifest $MANIFEST_NAME." >&2
+              exit 1
+            fi
+            build_id="$(jq -r '.build.id' "$prior_manifest")"
+            build_number="$(jq -r '.build.number' "$prior_manifest")"
+            submission_id="$(jq -r '.submission.id' "$prior_manifest")"
+          elif [ "${{ needs.build.outputs.reuse }}" = "true" ]; then
+            if ! gh release download "v$VERSION" --pattern "$MANIFEST_NAME" --output "$prior_manifest"; then
+              echo "Reusing an existing Apple build requires its canonical release manifest." >&2
+              exit 1
+            fi
+          fi
           deadline=$((SECONDS + 1200))
           while [ "$SECONDS" -lt "$deadline" ]; do
-            asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --version "$VERSION" --limit 1 > "$RUNNER_TEMP/ios-final-version.json"
+            asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --version "$VERSION" --limit 1 --output json > "$RUNNER_TEMP/ios-final-version.json"
             final_state="$(jq -r '.data[0].attributes.appVersionState // .data[0].attributes.appStoreState // empty' "$RUNNER_TEMP/ios-final-version.json")"
             case "$final_state" in
               WAITING_FOR_REVIEW|IN_REVIEW|PENDING_APPLE_RELEASE|PROCESSING_FOR_DISTRIBUTION|READY_FOR_DISTRIBUTION|READY_FOR_SALE)
-                asc review status --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" > "$RUNNER_TEMP/ios-final-review.json"
-                {
-                  echo "- Review submission: ${{ steps.submit.outputs.submission_id }}"
-                  echo "- Final iOS state: $final_state"
-                  echo "- Release: automatic after approval"
-                } >> "$GITHUB_STEP_SUMMARY"
-                exit 0
+                break
                 ;;
               DEVELOPER_REJECTED|REJECTED|METADATA_REJECTED|INVALID_BINARY)
                 echo "iOS $VERSION entered terminal state $final_state." >&2
@@ -708,18 +898,79 @@ jobs:
             esac
             sleep 30
           done
-          echo "Timed out waiting for iOS $VERSION to reach WAITING_FOR_REVIEW." >&2
-          exit 1
+          if ! [[ "$final_state" =~ ^(WAITING_FOR_REVIEW|IN_REVIEW|PENDING_APPLE_RELEASE|PROCESSING_FOR_DISTRIBUTION|READY_FOR_DISTRIBUTION|READY_FOR_SALE)$ ]]; then
+            echo "Timed out waiting for iOS $VERSION to reach WAITING_FOR_REVIEW." >&2
+            exit 1
+          fi
+
+          asc versions view --version-id "$version_id" --include-build --include-submission --output json > "$RUNNER_TEMP/ios-final-view.json"
+          asc status --app "$ASC_APP_ID" --platform "$PLATFORM" --output json > "$RUNNER_TEMP/ios-final-status.json"
+          jq -n \
+            --arg version "$VERSION" \
+            --arg platform "$PLATFORM" \
+            --arg versionId "$version_id" \
+            --arg buildId "$build_id" \
+            --arg buildNumber "$build_number" \
+            --arg submissionId "$submission_id" \
+            '{version: $version, platform: $platform, versionId: $versionId, buildId: $buildId, buildNumber: $buildNumber, submissionId: $submissionId}' \
+            > "$RUNNER_TEMP/ios-expected.json"
+          node scripts/apple-release-proof.mjs verify \
+            --version-list "$RUNNER_TEMP/ios-final-version.json" \
+            --version-view "$RUNNER_TEMP/ios-final-view.json" \
+            --status "$RUNNER_TEMP/ios-final-status.json" \
+            --expected "$RUNNER_TEMP/ios-expected.json" \
+            --output "$RUNNER_TEMP/ios-proof.json"
+
+          artifact_sha="${{ steps.handoff.outputs.sha256 }}"
+          sentry="success"
+          prior_args=()
+          if [ "$MUTATE" != "true" ] || [ "${{ needs.build.outputs.reuse }}" = "true" ]; then
+            artifact_sha=""
+            sentry=""
+            prior_args=(--prior "$prior_manifest")
+          fi
+          node scripts/apple-release-manifest.mjs create \
+            --proof "$RUNNER_TEMP/ios-proof.json" \
+            --output "$RUNNER_TEMP/$MANIFEST_NAME" \
+            --tag "v$VERSION" \
+            --source-sha "$GITHUB_SHA" \
+            --app-id "$ASC_APP_ID" \
+            --artifact-name "Teak-$VERSION.ipa" \
+            --artifact-sha "$artifact_sha" \
+            --sentry "$sentry" \
+            --asc-version "$ASC_VERSION" \
+            --stage-exit "$STAGE_EXIT" \
+            --publish-exit "$PUBLISH_EXIT" \
+            --workflow "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            "${prior_args[@]}"
+
+          for attempt in 1 2 3 4 5 6; do
+            if gh release view "v$VERSION" > /dev/null 2>&1; then break; fi
+            gh release create "v$VERSION" --verify-tag --title "v$VERSION" --generate-notes > /dev/null 2>&1 || true
+            if [ "$attempt" -eq 6 ]; then
+              echo "Could not resolve GitHub Release v$VERSION." >&2
+              exit 1
+            fi
+            sleep 10
+          done
+          gh release upload "v$VERSION" "$RUNNER_TEMP/$MANIFEST_NAME" --clobber
+          {
+            echo "- Review submission: $submission_id"
+            echo "- Final iOS state: $final_state"
+            echo "- Release: automatic after approval"
+            echo "- Manifest: $MANIFEST_NAME"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   report-failure:
-    if: ${{ failure() && inputs.dry_run == false }}
-    needs: release
-    runs-on: ubuntu-latest
+    if: ${{ always() && inputs.dry_run == false && (needs.build.result == 'failure' || needs.submit.result == 'failure') }}
+    needs: [build, submit]
+    runs-on: ubuntu-24.04
     concurrency:
       group: apple-release-issue-${{ inputs.version }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Set up asc
         uses: rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d # v1.0.1
         with:

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -900,9 +900,9 @@ jobs:
             echo "Timed out waiting for iOS $VERSION to reach WAITING_FOR_REVIEW." >&2
             exit 1
           fi
-
-          asc versions view --version-id "$version_id" --include-build --include-submission --output json > "$RUNNER_TEMP/ios-final-view.json"
-          asc status --app "$ASC_APP_ID" --platform "$PLATFORM" --output json > "$RUNNER_TEMP/ios-final-status.json"
+          asc versions view --version-id "$version_id" --include-build --output json > "$RUNNER_TEMP/ios-final-view.json"
+          asc builds info --build-id "$build_id" --output json > "$RUNNER_TEMP/ios-final-build.json"
+          asc review submissions-get --id "$submission_id" --include appStoreVersionForReview --output json > "$RUNNER_TEMP/ios-final-submission.json"
           jq -n \
             --arg version "$VERSION" \
             --arg platform "$PLATFORM" \
@@ -915,10 +915,10 @@ jobs:
           node scripts/apple-release-proof.mjs verify \
             --version-list "$RUNNER_TEMP/ios-final-version.json" \
             --version-view "$RUNNER_TEMP/ios-final-view.json" \
-            --status "$RUNNER_TEMP/ios-final-status.json" \
+            --build "$RUNNER_TEMP/ios-final-build.json" \
+            --submission "$RUNNER_TEMP/ios-final-submission.json" \
             --expected "$RUNNER_TEMP/ios-expected.json" \
             --output "$RUNNER_TEMP/ios-proof.json"
-
           artifact_sha="${{ steps.handoff.outputs.sha256 }}"
           sentry="success"
           prior_args=()

--- a/.github/workflows/safari-extension-release.yml
+++ b/.github/workflows/safari-extension-release.yml
@@ -55,13 +55,14 @@ jobs:
 
     steps:
       - name: Checkout release ref
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up asc
         uses: rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d # v1.0.1
         with:
+          cache: "false"
           version: ${{ env.ASC_VERSION }}
 
       - name: Prepare App Store Connect key
@@ -443,7 +444,7 @@ jobs:
 
       - name: Upload verified signed PKG handoff
         if: steps.release_state.outputs.mutate == 'true' && steps.reuse.outputs.reuse != 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: teak-safari-${{ env.VERSION }}-signed
           path: |
@@ -462,13 +463,14 @@ jobs:
 
     steps:
       - name: Checkout release ref
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up asc
         uses: rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d # v1.0.1
         with:
+          cache: "false"
           version: ${{ env.ASC_VERSION }}
 
       - name: Prepare App Store Connect key
@@ -487,7 +489,7 @@ jobs:
 
       - name: Download verified signed PKG handoff
         if: needs.build.outputs.mutate == 'true' && needs.build.outputs.reuse != 'true'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: teak-safari-${{ env.VERSION }}-signed
           path: ${{ runner.temp }}/safari-handoff
@@ -874,10 +876,11 @@ jobs:
       group: apple-release-issue-${{ inputs.version }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up asc
         uses: rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d # v1.0.1
         with:
+          cache: "false"
           version: ${{ env.ASC_VERSION }}
       - name: Prepare App Store Connect key
         env:

--- a/.github/workflows/safari-extension-release.yml
+++ b/.github/workflows/safari-extension-release.yml
@@ -818,14 +818,16 @@ jobs:
             echo "Timed out waiting for Safari macOS $VERSION to reach WAITING_FOR_REVIEW." >&2
             exit 1
           fi
-          asc versions view --version-id "$version_id" --include-build --include-submission --output json > "$RUNNER_TEMP/safari-final-view.json"
-          asc status --app "$ASC_APP_ID" --platform "$PLATFORM" --output json > "$RUNNER_TEMP/safari-final-status.json"
+          asc versions view --version-id "$version_id" --include-build --output json > "$RUNNER_TEMP/safari-final-view.json"
+          asc builds info --build-id "$build_id" --output json > "$RUNNER_TEMP/safari-final-build.json"
+          asc review submissions-get --id "$submission_id" --include appStoreVersionForReview --output json > "$RUNNER_TEMP/safari-final-submission.json"
           jq -n --arg version "$VERSION" --arg platform "$PLATFORM" --arg versionId "$version_id" --arg buildId "$build_id" --arg buildNumber "$build_number" --arg submissionId "$submission_id" \
             '{version: $version, platform: $platform, versionId: $versionId, buildId: $buildId, buildNumber: $buildNumber, submissionId: $submissionId}' > "$RUNNER_TEMP/safari-expected.json"
           node scripts/apple-release-proof.mjs verify \
             --version-list "$RUNNER_TEMP/safari-final-version.json" \
             --version-view "$RUNNER_TEMP/safari-final-view.json" \
-            --status "$RUNNER_TEMP/safari-final-status.json" \
+            --build "$RUNNER_TEMP/safari-final-build.json" \
+            --submission "$RUNNER_TEMP/safari-final-submission.json" \
             --expected "$RUNNER_TEMP/safari-expected.json" \
             --output "$RUNNER_TEMP/safari-proof.json"
 

--- a/.github/workflows/safari-extension-release.yml
+++ b/.github/workflows/safari-extension-release.yml
@@ -1,4 +1,5 @@
 name: Safari Extension Release
+run-name: Safari macOS ${{ inputs.version }} (${{ inputs.dry_run && 'dry run' || 'release' }})
 
 on:
   workflow_dispatch:
@@ -40,13 +41,21 @@ env:
   VERSION: ${{ inputs.version }}
 
 jobs:
-  release:
-    runs-on: macos-latest
-    timeout-minutes: 120
+  build:
+    runs-on: macos-26
+    timeout-minutes: 90
+    outputs:
+      build_id: ${{ steps.reuse.outputs.build_id }}
+      build_number: ${{ steps.reuse.outputs.build_number }}
+      mutate: ${{ steps.release_state.outputs.mutate }}
+      reuse: ${{ steps.reuse.outputs.reuse }}
+      source_version: ${{ steps.release_state.outputs.source_version }}
+      target_id: ${{ steps.release_state.outputs.target_id }}
+      target_state: ${{ steps.release_state.outputs.target_state }}
 
     steps:
       - name: Checkout release ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -80,13 +89,26 @@ jobs:
               echo "A real release requires the existing $release_tag tag." >&2
               exit 1
             fi
-            if ! git merge-base --is-ancestor "$tag_commit" "$GITHUB_SHA"; then
-              echo "A real release must run from $release_tag or one of its descendant recovery commits." >&2
-              exit 1
-            fi
-            if [ "$tag_commit" != "$GITHUB_SHA" ]; then
-              echo "- Recovery source: $GITHUB_SHA (descends from $release_tag at $tag_commit)" >> "$GITHUB_STEP_SUMMARY"
-            fi
+            case "$GITHUB_REF" in
+              "refs/tags/$release_tag")
+                if [ "$tag_commit" != "$GITHUB_SHA" ]; then
+                  echo "$release_tag resolved to an unexpected commit." >&2
+                  exit 1
+                fi
+                ;;
+              refs/heads/main)
+                git fetch origin main
+                if [ "$GITHUB_SHA" != "$(git rev-parse origin/main)" ] || ! git merge-base --is-ancestor "$tag_commit" "$GITHUB_SHA"; then
+                  echo "A recovery release must run at the current origin/main commit descending from $release_tag." >&2
+                  exit 1
+                fi
+                echo "- Recovery source: current main $GITHUB_SHA (descends from $release_tag at $tag_commit)" >> "$GITHUB_STEP_SUMMARY"
+                ;;
+              *)
+                echo "A real release may run only from $release_tag or current main, not $GITHUB_REF." >&2
+                exit 1
+                ;;
+            esac
           fi
           asc auth status --validate --output table
           asc_version="$(asc --version | awk '{print $1}')"
@@ -94,6 +116,12 @@ jobs:
             echo "asc $ASC_VERSION is required; found $asc_version." >&2
             exit 1
           fi
+          xcode_version="$(xcodebuild -version)"
+          if [[ "$xcode_version" != Xcode\ 26.* ]]; then
+            echo "The pinned macos-26 release image must provide Xcode 26.x." >&2
+            exit 1
+          fi
+          echo "$xcode_version"
           xcodebuild -list -project "$PROJECT_PATH"
 
       - name: Resolve current Apple release state
@@ -103,7 +131,7 @@ jobs:
         run: |
           versions_json="$RUNNER_TEMP/safari-versions.json"
           for attempt in 1 2 3; do
-            if asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --paginate > "$versions_json"; then
+            if asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --paginate --output json > "$versions_json"; then
               break
             fi
             if [ "$attempt" -eq 3 ]; then exit 1; fi
@@ -157,95 +185,6 @@ jobs:
             echo "mutate=$mutate"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Find or create the macOS version and preserve release metadata
-        id: apple_version
-        if: steps.release_state.outputs.mutate == 'true'
-        env:
-          SOURCE_VERSION: ${{ steps.release_state.outputs.source_version }}
-          TARGET_ID: ${{ steps.release_state.outputs.target_id }}
-        run: |
-          version_id="$TARGET_ID"
-          if [ -z "$version_id" ]; then
-            if [ -z "$SOURCE_VERSION" ]; then
-              echo "No prior live macOS version is available for metadata carry-forward." >&2
-              exit 1
-            fi
-            asc versions create \
-              --app "$ASC_APP_ID" \
-              --version "$VERSION" \
-              --platform "$PLATFORM" \
-              --release-type AFTER_APPROVAL \
-              --copy-metadata-from "$SOURCE_VERSION" \
-              --exclude-fields whatsNew > "$RUNNER_TEMP/safari-version-create.json"
-            version_id="$(jq -r '.id // empty' "$RUNNER_TEMP/safari-version-create.json")"
-          fi
-          if [ -z "$version_id" ]; then
-            version_id="$(asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --version "$VERSION" --limit 1 | jq -r '.data[0].id // empty')"
-          fi
-          if [ -z "$version_id" ]; then
-            echo "Could not resolve Safari macOS App Store version $VERSION." >&2
-            exit 1
-          fi
-
-          asc versions update --version-id "$version_id" --release-type AFTER_APPROVAL > "$RUNNER_TEMP/safari-version-update.json"
-          localizations="$RUNNER_TEMP/safari-localizations.json"
-          asc localizations list --version "$version_id" --paginate > "$localizations"
-          if [ "$(jq '.data | length' "$localizations")" -eq 0 ]; then
-            echo "Metadata carry-forward produced no version localizations." >&2
-            exit 1
-          fi
-          while IFS= read -r locale; do
-            asc localizations update \
-              --version "$version_id" \
-              --locale "$locale" \
-              --whats-new "$RELEASE_NOTES" > /dev/null
-          done < <(jq -r '.data[].attributes.locale' "$localizations")
-
-          source_id="$(asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --version "$SOURCE_VERSION" --limit 1 | jq -r '.data[0].id // empty')"
-          if ! asc review details-for-version --version-id "$version_id" > "$RUNNER_TEMP/safari-review-target.json" 2>/dev/null; then
-            asc review details-for-version --version-id "$source_id" > "$RUNNER_TEMP/safari-review-source.json"
-            review="$RUNNER_TEMP/safari-review-source.json"
-            args=(review details-create --version-id "$version_id")
-            for field in contactFirstName contactLastName contactEmail contactPhone notes; do
-              value="$(jq -r --arg field "$field" '.data.attributes[$field] // .[$field] // empty' "$review")"
-              case "$field" in
-                contactFirstName) flag=--contact-first-name ;;
-                contactLastName) flag=--contact-last-name ;;
-                contactEmail) flag=--contact-email ;;
-                contactPhone) flag=--contact-phone ;;
-                notes) flag=--notes ;;
-              esac
-              if [ -n "$value" ]; then args+=("$flag" "$value"); fi
-            done
-            demo_required="$(jq -r '.data.attributes.demoAccountRequired // .demoAccountRequired // false' "$review")"
-            if [ "$demo_required" = "true" ]; then
-              echo "Source review details require sensitive demo credentials; refusing to expose or copy them." >&2
-              exit 1
-            fi
-            args+=(--demo-account-required=false)
-            asc "${args[@]}" > "$RUNNER_TEMP/safari-review-create.json"
-          fi
-
-          echo "id=$version_id" >> "$GITHUB_OUTPUT"
-          echo "- App Store version: $version_id (AFTER_APPROVAL)" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Complete new Apple age-rating fields without changing the existing declaration
-        if: steps.release_state.outputs.mutate == 'true'
-        env:
-          VERSION_ID: ${{ steps.apple_version.outputs.id }}
-        run: |
-          asc age-rating edit \
-            --version-id "$VERSION_ID" \
-            --social-media false \
-            --social-media-age-restricted false > "$RUNNER_TEMP/safari-age-rating-edit.json"
-          asc age-rating view \
-            --version-id "$VERSION_ID" \
-            --fields socialMedia,socialMediaAgeRestricted > "$RUNNER_TEMP/safari-age-rating-view.json"
-          if ! jq -e '.data.attributes.socialMedia == false and .data.attributes.socialMediaAgeRestricted == false' "$RUNNER_TEMP/safari-age-rating-view.json" > /dev/null; then
-            echo "App Store Connect did not retain the required Safari social-media age-rating declarations." >&2
-            exit 1
-          fi
-
       - name: Reuse an exact uploaded Safari build and PKG when available
         id: reuse
         if: steps.release_state.outputs.mutate == 'true'
@@ -260,7 +199,8 @@ jobs:
             --processing-state VALID \
             --exclude-expired \
             --sort=-uploadedDate \
-            --limit 1 > "$RUNNER_TEMP/safari-existing-build.json"
+            --limit 1 \
+            --output json > "$RUNNER_TEMP/safari-existing-build.json"
           build_id="$(jq -r '.data[0].id // empty' "$RUNNER_TEMP/safari-existing-build.json")"
           build_number="$(jq -r '.data[0].attributes.version // empty' "$RUNNER_TEMP/safari-existing-build.json")"
           asset_label="App Store build $build_number"
@@ -270,7 +210,12 @@ jobs:
             echo "Reusing VALID Safari build $build_id and its exact GitHub PKG asset."
           else
             reuse=false
-            build_number="${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+            asc builds next-build-number --app "$ASC_APP_ID" --platform "$PLATFORM" --output json > "$RUNNER_TEMP/safari-next-build.json"
+            build_number="$(jq -r '.nextBuildNumber // empty' "$RUNNER_TEMP/safari-next-build.json")"
+            if [ -z "$build_number" ]; then
+              echo "asc could not allocate the next Safari build number." >&2
+              exit 1
+            fi
           fi
           {
             echo "reuse=$reuse"
@@ -478,76 +423,262 @@ jobs:
           cp "$package_path" "$release_pkg"
           echo "path=$release_pkg" >> "$GITHUB_OUTPUT"
 
-      - name: Upload PKG with asc and resolve the exact VALID build
-        id: uploaded_build
+      - name: Prepare verified signed PKG handoff
+        id: handoff
         if: steps.release_state.outputs.mutate == 'true' && steps.reuse.outputs.reuse != 'true'
         env:
           BUILD_NUMBER: ${{ steps.reuse.outputs.build_number }}
           PACKAGE_PATH: ${{ steps.export.outputs.path }}
         run: |
-          asc builds upload \
-            --app "$ASC_APP_ID" \
-            --pkg "$PACKAGE_PATH" \
-            --version "$VERSION" \
-            --build-number "$BUILD_NUMBER" \
-            --checksum \
-            --wait > "$RUNNER_TEMP/safari-upload.json"
+          sha256="$(shasum -a 256 "$PACKAGE_PATH" | awk '{print $1}')"
+          descriptor="$RUNNER_TEMP/safari-handoff.json"
+          jq -n \
+            --arg version "$VERSION" \
+            --arg buildNumber "$BUILD_NUMBER" \
+            --arg sha256 "$sha256" \
+            --arg fileName "$(basename "$PACKAGE_PATH")" \
+            '{version: $version, buildNumber: $buildNumber, sha256: $sha256, fileName: $fileName}' > "$descriptor"
+          echo "descriptor=$descriptor" >> "$GITHUB_OUTPUT"
+          echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Upload verified signed PKG handoff
+        if: steps.release_state.outputs.mutate == 'true' && steps.reuse.outputs.reuse != 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: teak-safari-${{ env.VERSION }}-signed
+          path: |
+            ${{ steps.export.outputs.path }}
+            ${{ steps.handoff.outputs.descriptor }}
+          if-no-files-found: error
+          retention-days: 1
+
+  submit:
+    if: inputs.dry_run == false
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout release ref
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up asc
+        uses: rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d # v1.0.1
+        with:
+          version: ${{ env.ASC_VERSION }}
+
+      - name: Prepare App Store Connect key
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          if [ -z "$ASC_KEY_ID" ] || [ -z "$ASC_ISSUER_ID" ] || [ -z "$APPLE_API_KEY_P8" ]; then
+            echo "Missing App Store Connect credentials." >&2
+            exit 1
+          fi
+          key_path="$RUNNER_TEMP/AuthKey_${ASC_KEY_ID}.p8"
+          printf '%s' "$APPLE_API_KEY_P8" > "$key_path"
+          chmod 600 "$key_path"
+          echo "ASC_PRIVATE_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+          asc auth status --validate --output table
+
+      - name: Download verified signed PKG handoff
+        if: needs.build.outputs.mutate == 'true' && needs.build.outputs.reuse != 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: teak-safari-${{ env.VERSION }}-signed
+          path: ${{ runner.temp }}/safari-handoff
+
+      - name: Verify signed PKG handoff
+        id: handoff
+        if: needs.build.outputs.mutate == 'true' && needs.build.outputs.reuse != 'true'
+        env:
+          BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
+        run: |
+          descriptor="$(find "$RUNNER_TEMP/safari-handoff" -maxdepth 1 -type f -name 'safari-handoff.json')"
+          package_path="$(find "$RUNNER_TEMP/safari-handoff" -maxdepth 1 -type f -name '*.pkg')"
+          if [ "$(find "$RUNNER_TEMP/safari-handoff" -maxdepth 1 -type f -name '*.pkg' | wc -l | tr -d ' ')" -ne 1 ] || [ ! -s "$descriptor" ]; then
+            echo "Expected one signed PKG and its handoff descriptor." >&2
+            exit 1
+          fi
+          jq -e --arg version "$VERSION" --arg build "$BUILD_NUMBER" \
+            '.version == $version and .buildNumber == $build' "$descriptor" > /dev/null
+          expected_sha="$(jq -r '.sha256' "$descriptor")"
+          actual_sha="$(sha256sum "$package_path" | awk '{print $1}')"
+          if [ "$actual_sha" != "$expected_sha" ]; then
+            echo "Signed PKG handoff digest mismatch." >&2
+            exit 1
+          fi
+          echo "path=$package_path" >> "$GITHUB_OUTPUT"
+          echo "sha256=$actual_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Upload PKG with asc or reuse exact VALID build
+        id: apple_build
+        if: needs.build.outputs.mutate == 'true'
+        env:
+          BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
+          EXISTING_BUILD_ID: ${{ needs.build.outputs.build_id }}
+          PACKAGE_PATH: ${{ steps.handoff.outputs.path }}
+          REUSE: ${{ needs.build.outputs.reuse }}
+        run: |
+          build_id="$EXISTING_BUILD_ID"
+          if [ "$REUSE" != "true" ]; then
+            asc builds upload \
+              --app "$ASC_APP_ID" \
+              --pkg "$PACKAGE_PATH" \
+              --version "$VERSION" \
+              --build-number "$BUILD_NUMBER" \
+              --checksum \
+              --wait \
+              --output json > "$RUNNER_TEMP/safari-upload.json"
+          fi
           asc builds list \
             --app "$ASC_APP_ID" \
             --platform "$PLATFORM" \
             --version "$VERSION" \
             --build-number "$BUILD_NUMBER" \
             --processing-state VALID \
-            --exclude-expired > "$RUNNER_TEMP/safari-build.json"
-          build_id="$(jq -r '.data[0].id // empty' "$RUNNER_TEMP/safari-build.json")"
-          if [ -z "$build_id" ] || [ "$(jq '.data | length' "$RUNNER_TEMP/safari-build.json")" -ne 1 ]; then
+            --exclude-expired \
+            --output json > "$RUNNER_TEMP/safari-build.json"
+          resolved_build_id="$(jq -r '.data[0].id // empty' "$RUNNER_TEMP/safari-build.json")"
+          if [ -z "$resolved_build_id" ] || [ "$(jq '.data | length' "$RUNNER_TEMP/safari-build.json")" -ne 1 ]; then
             echo "Expected exactly one VALID macOS build for $VERSION/$BUILD_NUMBER." >&2
             exit 1
           fi
-          echo "id=$build_id" >> "$GITHUB_OUTPUT"
-          echo "- App Store build: $build_id ($VERSION/$BUILD_NUMBER, VALID)" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Publish GitHub Release PKG
-        if: steps.release_state.outputs.mutate == 'true' && steps.reuse.outputs.reuse != 'true'
-        env:
-          BUILD_NUMBER: ${{ steps.reuse.outputs.build_number }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PACKAGE_PATH: ${{ steps.export.outputs.path }}
-        run: |
-          labeled_package="$PACKAGE_PATH#App Store build $BUILD_NUMBER"
-          if gh release view "v$VERSION" >/dev/null 2>&1; then
-            gh release upload "v$VERSION" "$labeled_package" --clobber
-          else
-            gh release create "v$VERSION" "$labeled_package" --title "$VERSION" --verify-tag
+          if [ -n "$build_id" ] && [ "$resolved_build_id" != "$build_id" ]; then
+            echo "The exact reusable Safari build changed unexpectedly." >&2
+            exit 1
           fi
+          echo "id=$resolved_build_id" >> "$GITHUB_OUTPUT"
+          echo "- App Store build: $resolved_build_id ($VERSION/$BUILD_NUMBER, VALID)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Evaluate asc high-level release commands without mutation
+        id: asc_parity
+        if: needs.build.outputs.mutate == 'true'
+        env:
+          BUILD_ID: ${{ steps.apple_build.outputs.id }}
+          SOURCE_VERSION: ${{ needs.build.outputs.source_version }}
+        run: |
+          stage_exit=0
+          asc release stage \
+            --app "$ASC_APP_ID" \
+            --version "$VERSION" \
+            --build "$BUILD_ID" \
+            --platform "$PLATFORM" \
+            --copy-metadata-from "$SOURCE_VERSION" \
+            --exclude-fields whatsNew \
+            --strict-validate \
+            --dry-run \
+            --output json > "$RUNNER_TEMP/safari-release-stage-dry-run.json" || stage_exit=$?
+          echo "stage_exit=$stage_exit" >> "$GITHUB_OUTPUT"
+          echo "publish_exit=unsupported_pkg" >> "$GITHUB_OUTPUT"
+          {
+            echo "- asc release stage dry-run exit: $stage_exit"
+            echo "- asc publish appstore: not used because 3.6.1 has no PKG input"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Find or create the macOS version and preserve release metadata
+        id: apple_version
+        if: needs.build.outputs.mutate == 'true'
+        env:
+          SOURCE_VERSION: ${{ needs.build.outputs.source_version }}
+          TARGET_ID: ${{ needs.build.outputs.target_id }}
+        run: |
+          version_id="$TARGET_ID"
+          if [ -z "$version_id" ]; then
+            if [ -z "$SOURCE_VERSION" ]; then
+              echo "No prior live macOS version is available for metadata carry-forward." >&2
+              exit 1
+            fi
+            asc versions create \
+              --app "$ASC_APP_ID" \
+              --version "$VERSION" \
+              --platform "$PLATFORM" \
+              --release-type AFTER_APPROVAL \
+              --copy-metadata-from "$SOURCE_VERSION" \
+              --exclude-fields whatsNew \
+              --output json > "$RUNNER_TEMP/safari-version-create.json"
+            version_id="$(jq -r '.id // empty' "$RUNNER_TEMP/safari-version-create.json")"
+          fi
+          if [ -z "$version_id" ]; then
+            version_id="$(asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --version "$VERSION" --limit 1 --output json | jq -r '.data[0].id // empty')"
+          fi
+          if [ -z "$version_id" ]; then
+            echo "Could not resolve Safari macOS App Store version $VERSION." >&2
+            exit 1
+          fi
+          asc versions update --version-id "$version_id" --release-type AFTER_APPROVAL --output json > "$RUNNER_TEMP/safari-version-update.json"
+          localizations="$RUNNER_TEMP/safari-localizations.json"
+          asc localizations list --version "$version_id" --paginate --output json > "$localizations"
+          if [ "$(jq '.data | length' "$localizations")" -eq 0 ]; then
+            echo "Metadata carry-forward produced no version localizations." >&2
+            exit 1
+          fi
+          while IFS= read -r locale; do
+            asc localizations update --version "$version_id" --locale "$locale" --whats-new "$RELEASE_NOTES" --output json > /dev/null
+          done < <(jq -r '.data[].attributes.locale' "$localizations")
+          source_id="$(asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --version "$SOURCE_VERSION" --limit 1 --output json | jq -r '.data[0].id // empty')"
+          if ! asc review details-for-version --version-id "$version_id" --output json > "$RUNNER_TEMP/safari-review-target.json" 2>/dev/null; then
+            asc review details-for-version --version-id "$source_id" --output json > "$RUNNER_TEMP/safari-review-source.json"
+            review="$RUNNER_TEMP/safari-review-source.json"
+            args=(review details-create --version-id "$version_id")
+            for field in contactFirstName contactLastName contactEmail contactPhone notes; do
+              value="$(jq -r --arg field "$field" '.data.attributes[$field] // .[$field] // empty' "$review")"
+              case "$field" in
+                contactFirstName) flag=--contact-first-name ;;
+                contactLastName) flag=--contact-last-name ;;
+                contactEmail) flag=--contact-email ;;
+                contactPhone) flag=--contact-phone ;;
+                notes) flag=--notes ;;
+              esac
+              if [ -n "$value" ]; then args+=("$flag" "$value"); fi
+            done
+            demo_required="$(jq -r '.data.attributes.demoAccountRequired // .demoAccountRequired // false' "$review")"
+            if [ "$demo_required" = "true" ]; then
+              echo "Source review details require sensitive demo credentials; refusing to expose or copy them." >&2
+              exit 1
+            fi
+            args+=(--demo-account-required=false --output json)
+            asc "${args[@]}" > "$RUNNER_TEMP/safari-review-create.json"
+          fi
+          echo "id=$version_id" >> "$GITHUB_OUTPUT"
+
+      - name: Complete new Apple age-rating fields without changing the existing declaration
+        if: needs.build.outputs.mutate == 'true'
+        env:
+          VERSION_ID: ${{ steps.apple_version.outputs.id }}
+        run: |
+          asc age-rating edit --version-id "$VERSION_ID" --social-media false --social-media-age-restricted false --output json > "$RUNNER_TEMP/safari-age-rating-edit.json"
+          asc age-rating view --version-id "$VERSION_ID" --fields socialMedia,socialMediaAgeRestricted --output json > "$RUNNER_TEMP/safari-age-rating-view.json"
+          jq -e '.data.attributes.socialMedia == false and .data.attributes.socialMediaAgeRestricted == false' "$RUNNER_TEMP/safari-age-rating-view.json" > /dev/null
 
       - name: Attach exact build, validate, run doctor, and submit
         id: submit
-        if: steps.release_state.outputs.mutate == 'true'
+        if: needs.build.outputs.mutate == 'true'
         env:
-          CURRENT_STATE: ${{ steps.release_state.outputs.target_state }}
-          NEW_BUILD_ID: ${{ steps.uploaded_build.outputs.id }}
-          REUSED_BUILD_ID: ${{ steps.reuse.outputs.build_id }}
+          CURRENT_STATE: ${{ needs.build.outputs.target_state }}
+          BUILD_ID: ${{ steps.apple_build.outputs.id }}
           VERSION_ID: ${{ steps.apple_version.outputs.id }}
         run: |
-          build_id="$NEW_BUILD_ID"
-          if [ -z "$build_id" ]; then build_id="$REUSED_BUILD_ID"; fi
-          if [ -z "$build_id" ]; then
+          if [ -z "$BUILD_ID" ]; then
             echo "No exact VALID Safari build was resolved." >&2
             exit 1
           fi
           attach_exit=0
-          asc versions attach-build --version-id "$VERSION_ID" --build-id "$build_id" > "$RUNNER_TEMP/safari-attach.json" || attach_exit=$?
+          asc versions attach-build --version-id "$VERSION_ID" --build-id "$BUILD_ID" --output json > "$RUNNER_TEMP/safari-attach.json" || attach_exit=$?
           if [ "$attach_exit" -ne 0 ]; then
-            asc versions view --version-id "$VERSION_ID" --include-build > "$RUNNER_TEMP/safari-attached-version.json"
-            if [ "$CURRENT_STATE" != "READY_FOR_REVIEW" ] || ! jq -e --arg version "$VERSION_ID" --arg build "$build_id" '.id == $version and .state == "READY_FOR_REVIEW" and .buildId == $build' "$RUNNER_TEMP/safari-attached-version.json" > /dev/null; then
+            asc versions view --version-id "$VERSION_ID" --include-build --output json > "$RUNNER_TEMP/safari-attached-version.json"
+            if [ "$CURRENT_STATE" != "READY_FOR_REVIEW" ] || ! jq -e --arg version "$VERSION_ID" --arg build "$BUILD_ID" '.id == $version and .state == "READY_FOR_REVIEW" and .buildId == $build' "$RUNNER_TEMP/safari-attached-version.json" > /dev/null; then
               echo "Could not attach the exact Safari build to the target version." >&2
               exit "$attach_exit"
             fi
             echo "- Exact Safari build was already attached to the existing READY_FOR_REVIEW draft." >> "$GITHUB_STEP_SUMMARY"
           fi
           validate_exit=0
-          asc validate --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" --strict > "$RUNNER_TEMP/safari-validate.json" || validate_exit=$?
+          asc validate --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" --strict --output json > "$RUNNER_TEMP/safari-validate.json" || validate_exit=$?
           if [ "$validate_exit" -ne 0 ]; then
             if [ "$CURRENT_STATE" != "READY_FOR_REVIEW" ] || ! jq -e '
               .summary.errors == 1
@@ -560,7 +691,7 @@ jobs:
             echo "asc validate confirmed the only blocker is the expected existing READY_FOR_REVIEW draft." >> "$GITHUB_STEP_SUMMARY"
           fi
           doctor_exit=0
-          asc review doctor --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" > "$RUNNER_TEMP/safari-doctor.json" || doctor_exit=$?
+          asc review doctor --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" --output json > "$RUNNER_TEMP/safari-doctor.json" || doctor_exit=$?
           if [ "$doctor_exit" -ne 0 ]; then
             if [ "$CURRENT_STATE" != "READY_FOR_REVIEW" ] || ! jq -e '
               .summary.errors == 1
@@ -578,7 +709,8 @@ jobs:
             --app "$ASC_APP_ID" \
             --platform "$PLATFORM" \
             --state READY_FOR_REVIEW \
-            --paginate > "$ready_submissions"
+            --paginate \
+            --output json > "$ready_submissions"
           matching_submission=""
           empty_submission=""
           while IFS= read -r candidate_id; do
@@ -587,7 +719,8 @@ jobs:
               --submission "$candidate_id" \
               --fields appStoreVersion \
               --include appStoreVersion \
-              --paginate > "$candidate_items"
+              --paginate \
+              --output json > "$candidate_items"
             item_count="$(jq '.data | length' "$candidate_items")"
             target_count="$(jq --arg target "$VERSION_ID" '[.data[]? | select(.relationships.appStoreVersion.data.id == $target)] | length' "$candidate_items")"
             if [ "$target_count" -eq 1 ] && [ "$item_count" -eq 1 ]; then
@@ -605,7 +738,7 @@ jobs:
           if [ -z "$submission_id" ]; then
             submission_id="$empty_submission"
             if [ -z "$submission_id" ]; then
-              asc review submissions-create --app "$ASC_APP_ID" --platform "$PLATFORM" > "$RUNNER_TEMP/safari-submission-create.json"
+              asc review submissions-create --app "$ASC_APP_ID" --platform "$PLATFORM" --output json > "$RUNNER_TEMP/safari-submission-create.json"
               submission_id="$(jq -r '.data.id // .id // empty' "$RUNNER_TEMP/safari-submission-create.json")"
             fi
             if [ -z "$submission_id" ]; then
@@ -622,33 +755,55 @@ jobs:
             --submission "$submission_id" \
             --fields appStoreVersion \
             --include appStoreVersion \
-            --paginate > "$RUNNER_TEMP/safari-review-items-final.json"
+            --paginate \
+            --output json > "$RUNNER_TEMP/safari-review-items-final.json"
           if ! jq -e --arg target "$VERSION_ID" '.data | length == 1 and .[0].relationships.appStoreVersion.data.id == $target' "$RUNNER_TEMP/safari-review-items-final.json" > /dev/null; then
             echo "Refusing to submit a Safari review draft that is empty or contains unrelated items." >&2
             exit 1
           fi
-          asc review submissions-submit --id "$submission_id" --confirm > "$RUNNER_TEMP/safari-submit.json"
+          asc review submissions-submit --id "$submission_id" --confirm --output json > "$RUNNER_TEMP/safari-submit.json"
           echo "submission_id=$submission_id" >> "$GITHUB_OUTPUT"
 
-      - name: Prove Safari macOS reached App Review
-        if: steps.release_state.outputs.mutate == 'true'
+      - name: Prove exact Safari release and publish artifacts and manifest
         env:
+          BUILD_ID: ${{ steps.apple_build.outputs.id }}
+          BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MANIFEST_NAME: teak-safari-${{ env.VERSION }}-app-store.json
+          MUTATE: ${{ needs.build.outputs.mutate }}
+          PACKAGE_PATH: ${{ steps.handoff.outputs.path }}
+          PUBLISH_EXIT: ${{ steps.asc_parity.outputs.publish_exit || 'not_run' }}
+          STAGE_EXIT: ${{ steps.asc_parity.outputs.stage_exit || 'not_run' }}
+          TARGET_ID: ${{ needs.build.outputs.target_id }}
           VERSION_ID: ${{ steps.apple_version.outputs.id }}
         run: |
+          version_id="$VERSION_ID"
+          build_id="$BUILD_ID"
+          build_number="$BUILD_NUMBER"
+          submission_id="${{ steps.submit.outputs.submission_id }}"
+          prior_manifest="$RUNNER_TEMP/prior-safari-manifest.json"
+          if [ "$MUTATE" != "true" ]; then
+            version_id="$TARGET_ID"
+            if ! gh release download "v$VERSION" --pattern "$MANIFEST_NAME" --output "$prior_manifest"; then
+              echo "A read-only rerun requires the existing release manifest $MANIFEST_NAME." >&2
+              exit 1
+            fi
+            build_id="$(jq -r '.build.id' "$prior_manifest")"
+            build_number="$(jq -r '.build.number' "$prior_manifest")"
+            submission_id="$(jq -r '.submission.id' "$prior_manifest")"
+          elif [ "${{ needs.build.outputs.reuse }}" = "true" ]; then
+            if ! gh release download "v$VERSION" --pattern "$MANIFEST_NAME" --output "$prior_manifest"; then
+              echo "Reusing an existing Apple build requires its canonical release manifest." >&2
+              exit 1
+            fi
+          fi
           deadline=$((SECONDS + 1200))
           while [ "$SECONDS" -lt "$deadline" ]; do
-            asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --version "$VERSION" --limit 1 > "$RUNNER_TEMP/safari-final-version.json"
+            asc versions list --app "$ASC_APP_ID" --platform "$PLATFORM" --version "$VERSION" --limit 1 --output json > "$RUNNER_TEMP/safari-final-version.json"
             final_state="$(jq -r '.data[0].attributes.appVersionState // .data[0].attributes.appStoreState // empty' "$RUNNER_TEMP/safari-final-version.json")"
             case "$final_state" in
               WAITING_FOR_REVIEW|IN_REVIEW|PENDING_APPLE_RELEASE|PROCESSING_FOR_DISTRIBUTION|READY_FOR_DISTRIBUTION|READY_FOR_SALE)
-                asc review status --app "$ASC_APP_ID" --version-id "$VERSION_ID" --platform "$PLATFORM" > "$RUNNER_TEMP/safari-final-review.json"
-                {
-                  echo "- Review submission: ${{ steps.submit.outputs.submission_id }}"
-                  echo "- Final Safari macOS state: $final_state"
-                  echo "- Release: automatic after approval"
-                  echo "- GitHub asset: teak-safari-$VERSION-mac-app-store.pkg"
-                } >> "$GITHUB_STEP_SUMMARY"
-                exit 0
+                break
                 ;;
               DEVELOPER_REJECTED|REJECTED|METADATA_REJECTED|INVALID_BINARY)
                 echo "Safari macOS $VERSION entered terminal state $final_state." >&2
@@ -657,18 +812,69 @@ jobs:
             esac
             sleep 30
           done
-          echo "Timed out waiting for Safari macOS $VERSION to reach WAITING_FOR_REVIEW." >&2
-          exit 1
+          if ! [[ "$final_state" =~ ^(WAITING_FOR_REVIEW|IN_REVIEW|PENDING_APPLE_RELEASE|PROCESSING_FOR_DISTRIBUTION|READY_FOR_DISTRIBUTION|READY_FOR_SALE)$ ]]; then
+            echo "Timed out waiting for Safari macOS $VERSION to reach WAITING_FOR_REVIEW." >&2
+            exit 1
+          fi
+          asc versions view --version-id "$version_id" --include-build --include-submission --output json > "$RUNNER_TEMP/safari-final-view.json"
+          asc status --app "$ASC_APP_ID" --platform "$PLATFORM" --output json > "$RUNNER_TEMP/safari-final-status.json"
+          jq -n --arg version "$VERSION" --arg platform "$PLATFORM" --arg versionId "$version_id" --arg buildId "$build_id" --arg buildNumber "$build_number" --arg submissionId "$submission_id" \
+            '{version: $version, platform: $platform, versionId: $versionId, buildId: $buildId, buildNumber: $buildNumber, submissionId: $submissionId}' > "$RUNNER_TEMP/safari-expected.json"
+          node scripts/apple-release-proof.mjs verify \
+            --version-list "$RUNNER_TEMP/safari-final-version.json" \
+            --version-view "$RUNNER_TEMP/safari-final-view.json" \
+            --status "$RUNNER_TEMP/safari-final-status.json" \
+            --expected "$RUNNER_TEMP/safari-expected.json" \
+            --output "$RUNNER_TEMP/safari-proof.json"
+
+          artifact_sha="${{ steps.handoff.outputs.sha256 }}"
+          prior_args=()
+          if [ "$MUTATE" != "true" ] || [ "${{ needs.build.outputs.reuse }}" = "true" ]; then
+            artifact_sha=""
+            prior_args=(--prior "$prior_manifest")
+          fi
+          node scripts/apple-release-manifest.mjs create \
+            --proof "$RUNNER_TEMP/safari-proof.json" \
+            --output "$RUNNER_TEMP/$MANIFEST_NAME" \
+            --tag "v$VERSION" \
+            --source-sha "$GITHUB_SHA" \
+            --app-id "$ASC_APP_ID" \
+            --artifact-name "teak-safari-$VERSION-mac-app-store.pkg" \
+            --artifact-sha "$artifact_sha" \
+            --asc-version "$ASC_VERSION" \
+            --stage-exit "$STAGE_EXIT" \
+            --publish-exit "$PUBLISH_EXIT" \
+            --workflow "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --generated-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            "${prior_args[@]}"
+
+          for attempt in 1 2 3 4 5 6; do
+            if gh release view "v$VERSION" > /dev/null 2>&1; then break; fi
+            gh release create "v$VERSION" --verify-tag --title "v$VERSION" --generate-notes > /dev/null 2>&1 || true
+            if [ "$attempt" -eq 6 ]; then exit 1; fi
+            sleep 10
+          done
+          if [ "$MUTATE" = "true" ] && [ "${{ needs.build.outputs.reuse }}" != "true" ]; then
+            gh release upload "v$VERSION" "$PACKAGE_PATH#App Store build $build_number" --clobber
+          fi
+          gh release upload "v$VERSION" "$RUNNER_TEMP/$MANIFEST_NAME" --clobber
+          {
+            echo "- Review submission: $submission_id"
+            echo "- Final Safari macOS state: $final_state"
+            echo "- Release: automatic after approval"
+            echo "- GitHub asset: teak-safari-$VERSION-mac-app-store.pkg"
+            echo "- Manifest: $MANIFEST_NAME"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   report-failure:
-    if: ${{ failure() && inputs.dry_run == false }}
-    needs: release
-    runs-on: ubuntu-latest
+    if: ${{ always() && inputs.dry_run == false && (needs.build.result == 'failure' || needs.submit.result == 'failure') }}
+    needs: [build, submit]
+    runs-on: ubuntu-24.04
     concurrency:
       group: apple-release-issue-${{ inputs.version }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Set up asc
         uses: rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d # v1.0.1
         with:

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -19,12 +19,17 @@ permissions:
 
 jobs:
   tag-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
+    outputs:
+      release_ready: ${{ steps.tag.outputs.release_ready }}
+      tag: ${{ steps.version.outputs.tag }}
+      tag_commit: ${{ steps.tag.outputs.tag_commit }}
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -63,23 +68,117 @@ jobs:
           TAG_NAME: ${{ steps.version.outputs.tag }}
         run: |
           if git rev-parse "$TAG_NAME" >/dev/null 2>&1 || gh release view "$TAG_NAME" >/dev/null 2>&1; then
-            echo "$TAG_NAME already exists."
-            echo "created=false" >> "$GITHUB_OUTPUT"
+            tag_commit="$(git rev-list -n 1 "$TAG_NAME")"
+            if [ "$tag_commit" != "$GITHUB_SHA" ]; then
+              echo "$TAG_NAME points to $tag_commit, expected $GITHUB_SHA." >&2
+              exit 1
+            fi
+            echo "$TAG_NAME already exists at the expected commit."
+            {
+              echo "created=false"
+              echo "release_ready=true"
+              echo "tag_commit=$tag_commit"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git tag "$TAG_NAME"
           git push origin "$TAG_NAME"
-          echo "created=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "created=true"
+            echo "release_ready=true"
+            echo "tag_commit=$GITHUB_SHA"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Dispatch release workflows
-        if: steps.version-change.outputs.changed == 'true' && steps.tag.outputs.created == 'true'
+  release:
+    name: Release / ${{ matrix.name }}
+    needs: tag-version
+    if: needs.tag-version.outputs.release_ready == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: CLI
+            workflow: cli-release.yml
+            apple: false
+            title_prefix: ""
+          - name: Desktop
+            workflow: desktop-release.yml
+            apple: false
+            title_prefix: ""
+          - name: Extension
+            workflow: extension-release.yml
+            apple: false
+            title_prefix: ""
+          - name: iOS
+            workflow: mobile-release.yml
+            apple: true
+            title_prefix: iOS
+          - name: Safari macOS
+            workflow: safari-extension-release.yml
+            apple: true
+            title_prefix: Safari macOS
+
+    steps:
+      - name: Reuse or dispatch and wait for release workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ steps.version.outputs.tag }}
-          VERSION: ${{ steps.version.outputs.version }}
+          APPLE_WORKFLOW: ${{ matrix.apple }}
+          EXPECTED_TITLE: ${{ matrix.title_prefix && format('{0} {1} (release)', matrix.title_prefix, needs.tag-version.outputs.version) || '' }}
+          TAG_COMMIT: ${{ needs.tag-version.outputs.tag_commit }}
+          TAG_NAME: ${{ needs.tag-version.outputs.tag }}
+          VERSION: ${{ needs.tag-version.outputs.version }}
+          WORKFLOW: ${{ matrix.workflow }}
         run: |
-          gh workflow run cli-release.yml --ref "$TAG_NAME"
-          gh workflow run desktop-release.yml --ref "$TAG_NAME"
-          gh workflow run extension-release.yml --ref "$TAG_NAME"
-          gh workflow run mobile-release.yml --ref "$TAG_NAME" -f "version=${VERSION}" -f "dry_run=false"
-          gh workflow run safari-extension-release.yml --ref "$TAG_NAME" -f "version=${VERSION}" -f "dry_run=false"
+          runs="$(gh api \
+            "/repos/$GITHUB_REPOSITORY/actions/workflows/$WORKFLOW/runs?per_page=100" \
+            | jq --arg sha "$TAG_COMMIT" --arg apple "$APPLE_WORKFLOW" --arg title "$EXPECTED_TITLE" \
+              '[.workflow_runs[] | select(.head_sha == $sha) | select($apple != "true" or (.event == "workflow_dispatch" and .display_title == $title))]')"
+          if [ "$APPLE_WORKFLOW" != "true" ]; then
+            for _ in {1..10}; do
+              if [ "$(jq 'length' <<< "$runs")" -gt 0 ]; then break; fi
+              echo "Waiting briefly for the tag-triggered $WORKFLOW run to register."
+              sleep 2
+              runs="$(gh api \
+                "/repos/$GITHUB_REPOSITORY/actions/workflows/$WORKFLOW/runs?per_page=100" \
+                | jq --arg sha "$TAG_COMMIT" '[.workflow_runs[] | select(.head_sha == $sha)]')"
+            done
+          fi
+          successful="$(jq -r '[.[] | select(.status == "completed" and .conclusion == "success")][0].id // empty' <<< "$runs")"
+          if [ -n "$successful" ]; then
+            echo "Reusing successful $WORKFLOW run $successful for $TAG_NAME."
+            echo "- ${{ matrix.name }}: https://github.com/$GITHUB_REPOSITORY/actions/runs/$successful" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          active="$(jq -r '[.[] | select(.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "pending")][0].id // empty' <<< "$runs")"
+          if [ -n "$active" ]; then
+            echo "Waiting for existing $WORKFLOW run $active."
+            gh run watch "$active" --exit-status
+            echo "- ${{ matrix.name }}: https://github.com/$GITHUB_REPOSITORY/actions/runs/$active" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          if [ "$APPLE_WORKFLOW" = "true" ]; then
+            gh workflow run "$WORKFLOW" --ref "$TAG_NAME" -f "version=$VERSION" -f dry_run=false
+          else
+            gh workflow run "$WORKFLOW" --ref "$TAG_NAME"
+          fi
+
+          run_id=""
+          for _ in {1..30}; do
+            run_id="$(gh api \
+              "/repos/$GITHUB_REPOSITORY/actions/workflows/$WORKFLOW/runs?per_page=20" \
+              | jq -r --arg sha "$TAG_COMMIT" --arg created "$dispatched_at" --arg apple "$APPLE_WORKFLOW" --arg title "$EXPECTED_TITLE" \
+              '[.workflow_runs[] | select(.head_sha == $sha and .created_at >= $created) | select($apple != "true" or (.event == "workflow_dispatch" and .display_title == $title))][0].id // empty')"
+            if [ -n "$run_id" ]; then break; fi
+            sleep 2
+          done
+          if [ -z "$run_id" ]; then
+            echo "Could not resolve the dispatched $WORKFLOW run." >&2
+            exit 1
+          fi
+          gh run watch "$run_id" --exit-status
+          echo "- ${{ matrix.name }}: https://github.com/$GITHUB_REPOSITORY/actions/runs/$run_id" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ These rules govern everything that lands in `apps/docs/content/changelog/*.mdx`.
 
 ## Mobile Release Process
 
-When asked to release the mobile app (cut a new App Store version, publish to iOS, submit to TestFlight/App Store, or similar), follow `apps/mobile/release.md`. The canonical release trigger is one next-patch lockstep `package.json` bump merged to `main`. The Version Tag workflow creates the tag and dispatches the hosted EAS build, mandatory Sentry Size Analysis upload, asc upload/validation, and direct App Review submission. Do not use EAS Submit or manually edit Expo/App Store marketing versions.
+When asked to release the mobile app (cut a new App Store version, publish to iOS, submit to TestFlight/App Store, or similar), follow `apps/mobile/release.md`. The canonical release trigger is one next-patch lockstep `package.json` bump merged to `main`. The Version Tag workflow creates the tag and dispatches the GitHub Actions macOS build, mandatory Sentry Size Analysis upload, asc upload/validation, and direct App Review submission. Do not use hosted EAS Build, EAS Submit, or manually edit Expo/App Store marketing versions.
 
 Do not invent a release flow. Read `apps/mobile/release.md` and run the commands listed there in order.
 

--- a/apps/mobile/release.md
+++ b/apps/mobile/release.md
@@ -12,7 +12,8 @@ iOS build history.
 1. Patch-bump every tracked `package.json` to the same next version.
 2. Merge that scoped bump to `main`.
 3. `Version Tag` verifies that the change is exactly one patch, creates
-   `v<version>`, and dispatches `Mobile App Store Release` at that tag.
+   `v<version>`, and dispatches every product release at that tag. A rerun
+   reuses successful or active child runs and dispatches only missing work.
 4. The workflow verifies the tag, lockstep packages, dynamic Expo version, asc
    version, and credentials.
 5. It reuses an exact valid App Store Connect build for the target marketing
@@ -23,17 +24,23 @@ iOS build history.
    provisioning profiles for the Teak app and share extension. The workflow
    archives, exports, and verifies the signed IPA locally, including bundle IDs,
    marketing version, build number, embedded profiles, and signatures.
-7. The locally exported IPA is uploaded to Sentry Size Analysis. A failed or
+7. The macOS job publishes the signed IPA and a SHA-256 handoff descriptor as a
+   one-day private Actions artifact. An Ubuntu job verifies the digest before
+   any external upload.
+8. The Ubuntu job uploads the exact IPA to Sentry Size Analysis. A failed or
    missing Sentry upload stops the release before App Store Connect upload.
-8. asc uploads the exact IPA directly to App Store Connect and waits for a
+9. asc uploads the exact IPA directly to App Store Connect and waits for a
    `VALID` build.
-9. asc finds or creates the iOS App Store version, copies localization metadata
+10. asc finds or creates the iOS App Store version, copies localization metadata
    from the prior live iOS version without copying What's New, applies the
    generic release note, preserves review details, sets `AFTER_APPROVAL`,
    sparsely completes Apple's social-media age-rating fields without changing
    the existing declaration, attaches the exact build, validates readiness,
    runs review doctor, and submits directly to App Review.
-10. The workflow succeeds only after iOS reaches `WAITING_FOR_REVIEW` or a later
+11. A separate read-only proof pass verifies the exact version, platform,
+   attached `VALID` build, submission, `AFTER_APPROVAL`, and review state. It
+   writes `teak-ios-<version>-app-store.json` to the GitHub Release.
+12. The workflow succeeds only after iOS reaches `WAITING_FOR_REVIEW` or a later
    valid state.
 
 The release note is:
@@ -52,16 +59,20 @@ gh workflow run mobile-release.yml --ref main -f "version=$version" -f dry_run=t
 
 ## Reliability and recovery
 
-- Concurrency is scoped by iOS version. Reruns reuse the exact valid Apple build
-  after its locally exported IPA has already passed mandatory Sentry Size
-  Analysis and App Store upload in the canonical workflow.
+- App-wide concurrency keeps build-number allocation through upload atomic.
+  Reruns reuse an exact valid Apple build only when its release manifest proves
+  the artifact, Sentry analysis, build, submission, and prior workflow.
 - In-review or already-live versions are read-only and return success.
 - Rejected versions are never resubmitted or modified automatically.
 - A terminal workflow failure opens or updates the single
   `Apple release v<version>` GitHub issue with the workflow link, redacted asc
   status, doctor remediation, and the exact rerun command.
-- `.github/workflows/apple-release-status.yml` checks iOS and Safari every six
-  hours and closes that issue only after both versions are live.
+- `.github/workflows/apple-release-status.yml` checks every open Apple release
+  issue every six hours. It closes an issue only when both ASC states are live
+  and both public storefronts report that exact version.
+- `asc release stage --dry-run` and `asc publish appstore --dry-run` are recorded
+  in the manifest for parity evaluation. The explicit lower-level asc sequence
+  remains canonical until a real patch proves the higher-level path equivalent.
 
 App Store Connect app: `6756574989`
 

--- a/apps/safari-extension/release.md
+++ b/apps/safari-extension/release.md
@@ -10,7 +10,8 @@ patch bump merged to `main` is the only normal manual release action. Root
 1. Patch-bump every tracked `package.json` to the same next version and merge
    the scoped bump to `main`.
 2. `Version Tag` verifies the next-patch and lockstep invariants, creates
-   `v<version>`, and dispatches `Safari Extension Release` at that tag.
+   `v<version>`, and dispatches every product release at that tag. A rerun
+   reuses successful or active child runs and dispatches only missing work.
 3. The workflow verifies the tag, Xcode project, asc version, and App Store
    Connect credentials.
 4. asc finds or creates the `MAC_OS` App Store version, copies localization
@@ -26,14 +27,20 @@ patch bump merged to `main` is the only normal manual release action. Root
 6. Xcode archives and exports
    `teak-safari-<version>-mac-app-store.pkg` without changing the stable app,
    extension, App Group, native-messaging, or keychain identifiers.
-7. `asc builds upload --pkg --wait` uploads the PKG. The workflow resolves the
+7. The macOS job publishes the signed PKG and a SHA-256 handoff descriptor as a
+   one-day private Actions artifact. An Ubuntu job verifies the digest before
+   continuing.
+8. `asc builds upload --pkg --wait` uploads the PKG from Ubuntu. The workflow resolves the
    exact returned marketing-version/build-number pair and requires one `VALID`
    `MAC_OS` build.
-8. The PKG is attached to the matching GitHub Release. asc attaches the exact
+9. The PKG is attached to the matching GitHub Release. asc attaches the exact
    Apple build, validates readiness, runs review doctor, and submits it directly
    to App Review.
-9. The workflow succeeds only after Safari macOS reaches `WAITING_FOR_REVIEW`
-   or a later valid state.
+10. A separate read-only proof pass verifies the exact version, platform,
+    attached `VALID` build, submission, `AFTER_APPROVAL`, and review state. It
+    writes `teak-safari-<version>-app-store.json` to the GitHub Release.
+11. The workflow succeeds only after Safari macOS reaches `WAITING_FOR_REVIEW`
+    or a later valid state.
 
 The release note is:
 
@@ -49,14 +56,18 @@ gh workflow run safari-extension-release.yml --ref main -f "version=$version" -f
 ## Reliability and recovery
 
 - Concurrency is scoped by Safari version. Reruns reuse an exact valid Apple
-  build when the matching GitHub PKG already exists.
+  build only when the matching labeled GitHub PKG and release manifest exist.
 - The workflow addresses only `MAC_OS`; unrelated iOS version records are
   ignored.
 - In-review or already-live versions are read-only. Rejected versions are never
   resubmitted or modified automatically.
 - A terminal failure opens or updates the same version-scoped Apple release
-  issue used by iOS. The scheduled status workflow closes it only after both
-  platforms are live.
+  issue used by iOS. The scheduled status workflow checks every open release
+  issue and closes it only when both ASC states are live and both public
+  storefronts report that exact version.
+- `asc release stage --dry-run` is recorded in the release manifest for parity
+  evaluation. asc 3.6.1 does not accept a PKG in `publish appstore`, so the
+  explicit lower-level asc sequence remains canonical for Safari.
 
 App Store Connect app: `6770003409`
 

--- a/scripts/apple-release-issue.mjs
+++ b/scripts/apple-release-issue.mjs
@@ -4,11 +4,10 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { parseVersion } from "./release-version.mjs";
 
-const liveStates = new Set([
-  "READY_FOR_DISTRIBUTION",
-  "READY_FOR_SALE",
-  "PROCESSING_FOR_DISTRIBUTION",
-]);
+const liveStates = new Set(["READY_FOR_DISTRIBUTION", "READY_FOR_SALE"]);
+
+const dashboardStart = "<!-- apple-release-dashboard:start -->";
+const dashboardEnd = "<!-- apple-release-dashboard:end -->";
 
 export function issueTitle(version) {
   parseVersion(version);
@@ -22,6 +21,59 @@ export function exactIssue(issues, version) {
 
 export function isLiveState(state) {
   return liveStates.has(String(state).trim().toUpperCase());
+}
+
+export function isStorefrontLive(state, storefrontVersion, targetVersion) {
+  return (
+    isLiveState(state) &&
+    String(storefrontVersion).trim() === String(targetVersion).trim()
+  );
+}
+
+export function openReleaseVersions(issues) {
+  return issues
+    .filter((issue) => issue.state === "OPEN")
+    .map((issue) => /^Apple release v(\d+\.\d+\.\d+)$/.exec(issue.title)?.[1])
+    .filter(Boolean)
+    .sort((left, right) =>
+      left.localeCompare(right, undefined, { numeric: true })
+    );
+}
+
+export function releaseDashboard(body, values) {
+  const stateKey = [
+    values["ios-state"],
+    values["ios-store-version"],
+    values["safari-state"],
+    values["safari-store-version"],
+  ]
+    .map((value) =>
+      String(value || "UNKNOWN")
+        .trim()
+        .toUpperCase()
+    )
+    .join("|");
+  const block = `${dashboardStart}
+<!-- apple-release-state:${stateKey} -->
+## Current release status
+
+| Platform | App Store Connect | Public storefront |
+| --- | --- | --- |
+| iOS | ${values["ios-state"]} | ${values["ios-store-version"] || "not live"} |
+| Safari macOS | ${values["safari-state"]} | ${values["safari-store-version"] || "not live"} |
+
+Last check: [GitHub Actions](${values["workflow-url"]})
+${dashboardEnd}`;
+  const current = String(body || "").match(
+    /<!-- apple-release-state:([^>]+) -->/
+  )?.[1];
+  const expression = new RegExp(
+    `${dashboardStart.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}[\\s\\S]*?${dashboardEnd.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`
+  );
+  const nextBody = expression.test(String(body || ""))
+    ? String(body).replace(expression, block)
+    : `${String(body || "").trim()}${body ? "\n\n" : ""}${block}`;
+  return { body: nextBody, changed: current !== stateKey, stateKey };
 }
 
 export function sanitizeAscOutput(value) {
@@ -81,7 +133,7 @@ function listIssues(version) {
     "--limit",
     "100",
     "--json",
-    "number,title,state,url",
+    "number,title,state,url,body",
   ]);
   return JSON.parse(result.stdout || "[]");
 }
@@ -163,10 +215,26 @@ function reportStatus(values) {
 
   const iosState = values["ios-state"].trim().toUpperCase();
   const safariState = values["safari-state"].trim().toUpperCase();
-  const bothLive = isLiveState(iosState) && isLiveState(safariState);
-  const body = `Apple release status check: iOS ${iosState}; Safari macOS ${safariState}. [Workflow](${workflowUrl})`;
+  const iosStoreVersion = values["ios-store-version"]?.trim() || "NOT_LIVE";
+  const safariStoreVersion =
+    values["safari-store-version"]?.trim() || "NOT_LIVE";
+  const bothLive =
+    isStorefrontLive(iosState, iosStoreVersion, values.version) &&
+    isStorefrontLive(safariState, safariStoreVersion, values.version);
+  const dashboard = releaseDashboard(issue.body, {
+    ...values,
+    "ios-state": iosState,
+    "safari-state": safariState,
+    "ios-store-version": iosStoreVersion,
+    "safari-store-version": safariStoreVersion,
+    "workflow-url": workflowUrl,
+  });
+  const transition = `Apple release status changed: iOS ${iosState} (storefront ${iosStoreVersion}); Safari macOS ${safariState} (storefront ${safariStoreVersion}). [Workflow](${workflowUrl})`;
   if (issue.state === "OPEN") {
-    gh(["issue", "comment", String(issue.number), "--body", body]);
+    gh(["issue", "edit", String(issue.number), "--body", dashboard.body]);
+    if (dashboard.changed) {
+      gh(["issue", "comment", String(issue.number), "--body", transition]);
+    }
     if (bothLive) {
       gh([
         "issue",
@@ -180,6 +248,24 @@ function reportStatus(values) {
   console.log(issue.url);
 }
 
+function listOpenVersions() {
+  const result = gh([
+    "issue",
+    "list",
+    "--state",
+    "open",
+    "--search",
+    '"Apple release v" in:title',
+    "--limit",
+    "100",
+    "--json",
+    "title,state",
+  ]);
+  process.stdout.write(
+    `${JSON.stringify(openReleaseVersions(JSON.parse(result.stdout || "[]")))}\n`
+  );
+}
+
 function main() {
   const [command, ...args] = process.argv.slice(2);
   const values = parseArguments(args);
@@ -191,7 +277,11 @@ function main() {
     reportStatus(values);
     return;
   }
-  throw new Error("Expected failure or status command.");
+  if (command === "versions") {
+    listOpenVersions();
+    return;
+  }
+  throw new Error("Expected failure, status, or versions command.");
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/scripts/apple-release-issue.test.ts
+++ b/scripts/apple-release-issue.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 import {
   exactIssue,
   isLiveState,
+  isStorefrontLive,
   issueTitle,
+  openReleaseVersions,
+  releaseDashboard,
   sanitizeAscOutput,
 } from "./apple-release-issue.mjs";
 
@@ -20,9 +23,42 @@ describe("Apple release issue handling", () => {
   test("closes only after both platforms reach a live state", () => {
     expect(isLiveState("READY_FOR_DISTRIBUTION")).toBe(true);
     expect(isLiveState("READY_FOR_SALE")).toBe(true);
-    expect(isLiveState("PROCESSING_FOR_DISTRIBUTION")).toBe(true);
+    expect(isLiveState("PROCESSING_FOR_DISTRIBUTION")).toBe(false);
     expect(isLiveState("WAITING_FOR_REVIEW")).toBe(false);
     expect(isLiveState("REJECTED")).toBe(false);
+    expect(isStorefrontLive("READY_FOR_DISTRIBUTION", "1.0.61", "1.0.61")).toBe(
+      true
+    );
+    expect(isStorefrontLive("READY_FOR_DISTRIBUTION", "1.0.60", "1.0.61")).toBe(
+      false
+    );
+  });
+
+  test("enumerates every exact open release issue", () => {
+    expect(
+      openReleaseVersions([
+        { title: "Apple release v1.0.61", state: "OPEN" },
+        { title: "Apple release v1.0.59", state: "CLOSED" },
+        { title: "Apple release v1.0.60", state: "OPEN" },
+        { title: "Apple release v1.0.61 notes", state: "OPEN" },
+      ])
+    ).toEqual(["1.0.60", "1.0.61"]);
+  });
+
+  test("updates one dashboard and reports only state transitions", () => {
+    const values = {
+      "ios-state": "WAITING_FOR_REVIEW",
+      "ios-store-version": "1.0.58",
+      "safari-state": "WAITING_FOR_REVIEW",
+      "safari-store-version": "1.0.59",
+      "workflow-url": "https://github.com/praveenjuge/teak/actions/runs/1",
+    };
+    const first = releaseDashboard("Existing diagnostics.", values);
+    const second = releaseDashboard(first.body, values);
+    expect(first.changed).toBe(true);
+    expect(second.changed).toBe(false);
+    expect(second.body.match(/Current release status/g)).toHaveLength(1);
+    expect(second.body).toContain("Public storefront");
   });
 
   test("redacts credential-shaped asc output", () => {

--- a/scripts/apple-release-manifest.mjs
+++ b/scripts/apple-release-manifest.mjs
@@ -1,0 +1,143 @@
+import fs from "node:fs";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+function required(value, label) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) {
+    throw new Error(`Missing ${label}.`);
+  }
+  return normalized;
+}
+
+function parseArguments(args) {
+  const values = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!(flag?.startsWith("--") && value !== undefined)) {
+      throw new Error(`Invalid argument near ${flag ?? "end of command"}.`);
+    }
+    values[flag.slice(2)] = value;
+  }
+  return values;
+}
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(fs.readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(`Could not read ${label}: ${error.message}`);
+  }
+}
+
+function verifyPrior(prior, proof, context) {
+  const pairs = [
+    [prior.version, proof.version, "version"],
+    [prior.platform, proof.platform, "platform"],
+    [prior.tag, context.tag, "tag"],
+    [prior.appId, context.appId, "app ID"],
+    [prior.build?.id, proof.buildId, "build ID"],
+    [prior.build?.number, proof.buildNumber, "build number"],
+    [prior.submission?.id, proof.submissionId, "submission ID"],
+  ];
+  for (const [actual, expected, label] of pairs) {
+    if (
+      required(actual, `prior ${label}`) !==
+      required(expected, `current ${label}`)
+    ) {
+      throw new Error(`Prior manifest ${label} does not match current proof.`);
+    }
+  }
+}
+
+export function createReleaseManifest({ proof, prior, context }) {
+  const now = required(context.generatedAt, "verification time");
+  const tag = required(context.tag, "tag");
+  const appId = required(context.appId, "app ID");
+  if (prior) {
+    verifyPrior(prior, proof, { tag, appId });
+  }
+
+  const artifact = prior?.artifact ?? {
+    name: required(context.artifactName, "artifact name"),
+    sha256: required(context.artifactSha, "artifact SHA-256"),
+  };
+  const sourceWorkflow =
+    prior?.sourceWorkflow ??
+    prior?.workflow ??
+    required(context.workflow, "workflow URL");
+  const stageExit =
+    context.stageExit === "not_run"
+      ? (prior?.highLevelEvaluation?.releaseStageDryRunExit ?? "not_run")
+      : required(context.stageExit, "asc release stage result");
+  const publishExit =
+    context.publishExit === "not_run"
+      ? (prior?.highLevelEvaluation?.publishAppStoreDryRunExit ?? "not_run")
+      : required(context.publishExit, "asc publish appstore result");
+
+  const {
+    buildId,
+    buildNumber,
+    submissionId,
+    submissionState,
+    ...proofFields
+  } = proof;
+  const manifest = {
+    ...proofFields,
+    tag,
+    sourceSha: prior?.sourceSha ?? required(context.sourceSha, "source SHA"),
+    sourceWorkflow,
+    appId,
+    artifact,
+    ascVersion:
+      prior?.ascVersion ?? required(context.ascVersion, "asc version"),
+    highLevelEvaluation: {
+      releaseStageDryRunExit: stageExit,
+      publishAppStoreDryRunExit: publishExit,
+    },
+    workflow: required(context.workflow, "workflow URL"),
+    generatedAt: prior?.generatedAt ?? now,
+    verifiedAt: now,
+    build: { id: buildId, number: buildNumber },
+    submission: { id: submissionId, state: submissionState },
+  };
+  if (prior?.sentrySizeAnalysis || context.sentrySizeAnalysis) {
+    manifest.sentrySizeAnalysis =
+      prior?.sentrySizeAnalysis ??
+      required(context.sentrySizeAnalysis, "Sentry result");
+  }
+  return manifest;
+}
+
+function main() {
+  const [command, ...args] = process.argv.slice(2);
+  if (command !== "create") {
+    throw new Error("Expected create command.");
+  }
+  const values = parseArguments(args);
+  const manifest = createReleaseManifest({
+    proof: readJson(values.proof, "release proof"),
+    prior: values.prior ? readJson(values.prior, "prior manifest") : undefined,
+    context: {
+      tag: values.tag,
+      sourceSha: values["source-sha"],
+      appId: values["app-id"],
+      artifactName: values["artifact-name"],
+      artifactSha: values["artifact-sha"],
+      sentrySizeAnalysis: values.sentry,
+      ascVersion: values["asc-version"],
+      stageExit: values["stage-exit"],
+      publishExit: values["publish-exit"],
+      workflow: values.workflow,
+      generatedAt: values["generated-at"],
+    },
+  });
+  fs.writeFileSync(values.output, `${JSON.stringify(manifest, null, 2)}\n`, {
+    mode: 0o600,
+  });
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/apple-release-manifest.test.ts
+++ b/scripts/apple-release-manifest.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { createReleaseManifest } from "./apple-release-manifest.mjs";
+
+const proof = {
+  version: "1.0.61",
+  platform: "IOS",
+  versionId: "ios-version-61",
+  state: "WAITING_FOR_REVIEW",
+  releaseType: "AFTER_APPROVAL",
+  buildId: "ios-build-65",
+  buildNumber: "65",
+  processingState: "VALID",
+  submissionId: "ios-submission-61",
+  submissionState: "WAITING_FOR_REVIEW",
+};
+
+const context = {
+  tag: "v1.0.61",
+  sourceSha: "a".repeat(40),
+  appId: "6756574989",
+  artifactName: "Teak-1.0.61.ipa",
+  artifactSha: "b".repeat(64),
+  sentrySizeAnalysis: "success",
+  ascVersion: "3.6.1",
+  stageExit: "0",
+  publishExit: "0",
+  workflow: "https://github.com/praveenjuge/teak/actions/runs/100",
+  generatedAt: "2026-08-09T00:00:00Z",
+};
+
+describe("Apple release manifest", () => {
+  test("records immutable artifact provenance and exact proof", () => {
+    const manifest = createReleaseManifest({ proof, context });
+    expect(manifest.artifact.sha256).toBe(context.artifactSha);
+    expect(manifest.build).toEqual({ id: "ios-build-65", number: "65" });
+    expect(manifest.submission.id).toBe("ios-submission-61");
+    expect(manifest.sentrySizeAnalysis).toBe("success");
+    expect(manifest.sourceWorkflow).toBe(context.workflow);
+    expect(manifest.verifiedAt).toBe(context.generatedAt);
+  });
+
+  test("preserves provenance while refreshing read-only proof", () => {
+    const prior = createReleaseManifest({ proof, context });
+    const replay = createReleaseManifest({
+      proof: { ...proof, state: "IN_REVIEW", submissionState: "IN_REVIEW" },
+      prior,
+      context: {
+        ...context,
+        sourceSha: "c".repeat(40),
+        artifactName: "",
+        artifactSha: "",
+        stageExit: "not_run",
+        publishExit: "not_run",
+        workflow: "https://github.com/praveenjuge/teak/actions/runs/101",
+        generatedAt: "2026-08-09T01:00:00Z",
+      },
+    });
+    expect(replay.sourceSha).toBe(prior.sourceSha);
+    expect(replay.sourceWorkflow).toBe(prior.sourceWorkflow);
+    expect(replay.artifact).toEqual(prior.artifact);
+    expect(replay.highLevelEvaluation).toEqual(prior.highLevelEvaluation);
+    expect(replay.generatedAt).toBe(prior.generatedAt);
+    expect(replay.verifiedAt).toBe("2026-08-09T01:00:00Z");
+    expect(replay.state).toBe("IN_REVIEW");
+  });
+
+  test("rejects a prior manifest for another build", () => {
+    const prior = createReleaseManifest({ proof, context });
+    prior.build.id = "unrelated-build";
+    expect(() => createReleaseManifest({ proof, prior, context })).toThrow(
+      "Prior manifest build ID does not match current proof"
+    );
+  });
+});

--- a/scripts/apple-release-proof.mjs
+++ b/scripts/apple-release-proof.mjs
@@ -57,26 +57,34 @@ function versionRecord(payload) {
       attributes.buildId ??
       row?.relationships?.build?.data?.id ??
       payload?.included?.find?.((item) => item.type === "builds")?.id,
-    buildNumber: attributes.buildNumber,
+    buildNumber: attributes.buildNumber ?? attributes.buildVersion,
     submissionId:
       attributes.submissionId ??
       row?.relationships?.appStoreVersionSubmission?.data?.id,
   };
 }
 
-function statusRecord(payload) {
+function buildRecord(payload) {
+  const row = payload?.data ?? payload;
+  const preReleaseVersion = payload?.included?.find?.(
+    (item) => item.type === "preReleaseVersions"
+  );
   return {
-    versionId: payload?.appstore?.versionId,
-    version: payload?.appstore?.version,
-    platform: payload?.appstore?.platform,
-    state: payload?.appstore?.state,
-    buildId: payload?.builds?.latest?.id,
-    buildVersion: payload?.builds?.latest?.version,
-    buildNumber: payload?.builds?.latest?.buildNumber,
-    processingState: payload?.builds?.latest?.processingState,
-    submissionId: payload?.review?.latestSubmissionId,
-    submissionState: payload?.review?.state,
-    inFlight: payload?.submission?.inFlight,
+    id: row?.id,
+    buildNumber: row?.attributes?.version,
+    processingState: row?.attributes?.processingState,
+    version: preReleaseVersion?.attributes?.version,
+    platform: preReleaseVersion?.attributes?.platform,
+  };
+}
+
+function submissionRecord(payload) {
+  const row = payload?.data ?? payload;
+  return {
+    id: row?.id,
+    state: row?.attributes?.state,
+    platform: row?.attributes?.platform,
+    versionId: row?.relationships?.appStoreVersionForReview?.data?.id,
   };
 }
 
@@ -91,7 +99,8 @@ function same(actual, expected, label) {
 export function verifyReleaseProof({
   versionList,
   versionView,
-  status,
+  build,
+  submission,
   expected,
 }) {
   const version = required(expected.version, "expected version");
@@ -106,7 +115,8 @@ export function verifyReleaseProof({
 
   const listed = versionRecord(versionList);
   const viewed = versionRecord(versionView);
-  const dashboard = statusRecord(status);
+  const exactBuild = buildRecord(build);
+  const exactSubmission = submissionRecord(submission);
   const versionId = required(
     expected.versionId ?? listed.id ?? viewed.id,
     "version ID"
@@ -116,29 +126,17 @@ export function verifyReleaseProof({
 
   same(listed.id, versionId, "listed version ID");
   same(viewed.id, versionId, "viewed version ID");
-  same(dashboard.versionId, versionId, "status version ID");
-  for (const [actual, label] of [
-    [listed.version, "listed version"],
-    [dashboard.version, "status version"],
-    [dashboard.buildVersion, "build marketing version"],
-  ]) {
-    same(actual, version, label);
-  }
+  same(listed.version, version, "listed version");
   if (viewed.version) {
     same(viewed.version, version, "viewed version");
   }
-  for (const [actual, label] of [
-    [listed.platform, "listed platform"],
-    [dashboard.platform, "status platform"],
-  ]) {
-    same(String(actual).toUpperCase(), platform, label);
-  }
+  same(String(listed.platform).toUpperCase(), platform, "listed platform");
   if (viewed.platform) {
     same(String(viewed.platform).toUpperCase(), platform, "viewed platform");
   }
 
   const state = required(
-    dashboard.state ?? listed.state ?? viewed.state,
+    listed.state ?? viewed.state,
     "release state"
   ).toUpperCase();
   if (!reviewStates.has(state)) {
@@ -146,9 +144,7 @@ export function verifyReleaseProof({
       `Release state ${state} is not waiting for review or later.`
     );
   }
-  for (const candidate of [listed.state, viewed.state, dashboard.state].filter(
-    Boolean
-  )) {
+  for (const candidate of [listed.state, viewed.state].filter(Boolean)) {
     same(String(candidate).toUpperCase(), state, "release state");
   }
 
@@ -157,27 +153,33 @@ export function verifyReleaseProof({
     same(viewed.releaseType, "AFTER_APPROVAL", "viewed release type");
   }
   same(viewed.buildId, buildId, "attached build ID");
-  same(dashboard.buildId, buildId, "status build ID");
   if (viewed.buildNumber) {
     same(viewed.buildNumber, buildNumber, "attached build number");
   }
-  same(dashboard.buildNumber, buildNumber, "status build number");
-  same(dashboard.processingState, "VALID", "build processing state");
-
-  const submissionId = required(
-    expected.submissionId ?? viewed.submissionId ?? dashboard.submissionId,
-    "submission ID"
+  same(exactBuild.id, buildId, "exact build ID");
+  same(exactBuild.buildNumber, buildNumber, "exact build number");
+  same(exactBuild.version, version, "exact build marketing version");
+  same(
+    String(exactBuild.platform).toUpperCase(),
+    platform,
+    "exact build platform"
   );
-  same(dashboard.submissionId, submissionId, "status submission ID");
+  same(exactBuild.processingState, "VALID", "build processing state");
+
+  const submissionId = required(expected.submissionId, "submission ID");
+  same(exactSubmission.id, submissionId, "exact submission ID");
+  same(exactSubmission.versionId, versionId, "submission version ID");
+  same(
+    String(exactSubmission.platform).toUpperCase(),
+    platform,
+    "submission platform"
+  );
   const submissionState = required(
-    dashboard.submissionState,
+    exactSubmission.state,
     "submission state"
   ).toUpperCase();
-  if (
-    ["WAITING_FOR_REVIEW", "IN_REVIEW"].includes(state) &&
-    dashboard.inFlight !== true
-  ) {
-    throw new Error(`${state} must have an in-flight review submission.`);
+  if (["WAITING_FOR_REVIEW", "IN_REVIEW"].includes(state)) {
+    same(submissionState, state, "in-flight submission state");
   }
 
   return {
@@ -203,7 +205,8 @@ function main() {
   const proof = verifyReleaseProof({
     versionList: readJson(values["version-list"], "version list"),
     versionView: readJson(values["version-view"], "version view"),
-    status: readJson(values.status, "release status"),
+    build: readJson(values.build, "exact build"),
+    submission: readJson(values.submission, "exact submission"),
     expected: readJson(values.expected, "expected release"),
   });
   const output = `${JSON.stringify(proof, null, 2)}\n`;

--- a/scripts/apple-release-proof.mjs
+++ b/scripts/apple-release-proof.mjs
@@ -1,0 +1,219 @@
+import fs from "node:fs";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { parseVersion } from "./release-version.mjs";
+
+export const reviewStates = new Set([
+  "WAITING_FOR_REVIEW",
+  "IN_REVIEW",
+  "PENDING_APPLE_RELEASE",
+  "PROCESSING_FOR_DISTRIBUTION",
+  "READY_FOR_DISTRIBUTION",
+  "READY_FOR_SALE",
+]);
+
+function required(value, label) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) {
+    throw new Error(`Missing ${label}.`);
+  }
+  return normalized;
+}
+
+function parseArguments(args) {
+  const values = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!(flag?.startsWith("--") && value !== undefined)) {
+      throw new Error(`Invalid argument near ${flag ?? "end of command"}.`);
+    }
+    values[flag.slice(2)] = value;
+  }
+  return values;
+}
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(fs.readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(`Could not read ${label}: ${error.message}`);
+  }
+}
+
+function versionRecord(payload) {
+  const row = payload?.data?.[0] ?? payload?.data ?? payload;
+  const attributes = row?.attributes ?? row ?? {};
+  return {
+    id: row?.id ?? attributes.id,
+    version: attributes.versionString ?? attributes.version,
+    platform: attributes.platform,
+    state:
+      attributes.appVersionState ??
+      attributes.appStoreState ??
+      attributes.state,
+    releaseType: attributes.releaseType,
+    buildId:
+      attributes.buildId ??
+      row?.relationships?.build?.data?.id ??
+      payload?.included?.find?.((item) => item.type === "builds")?.id,
+    buildNumber: attributes.buildNumber,
+    submissionId:
+      attributes.submissionId ??
+      row?.relationships?.appStoreVersionSubmission?.data?.id,
+  };
+}
+
+function statusRecord(payload) {
+  return {
+    versionId: payload?.appstore?.versionId,
+    version: payload?.appstore?.version,
+    platform: payload?.appstore?.platform,
+    state: payload?.appstore?.state,
+    buildId: payload?.builds?.latest?.id,
+    buildVersion: payload?.builds?.latest?.version,
+    buildNumber: payload?.builds?.latest?.buildNumber,
+    processingState: payload?.builds?.latest?.processingState,
+    submissionId: payload?.review?.latestSubmissionId,
+    submissionState: payload?.review?.state,
+    inFlight: payload?.submission?.inFlight,
+  };
+}
+
+function same(actual, expected, label) {
+  if (required(actual, label) !== required(expected, `expected ${label}`)) {
+    throw new Error(
+      `${label} mismatch: received ${actual}, expected ${expected}.`
+    );
+  }
+}
+
+export function verifyReleaseProof({
+  versionList,
+  versionView,
+  status,
+  expected,
+}) {
+  const version = required(expected.version, "expected version");
+  parseVersion(version);
+  const platform = required(
+    expected.platform,
+    "expected platform"
+  ).toUpperCase();
+  if (!new Set(["IOS", "MAC_OS"]).has(platform)) {
+    throw new Error(`Unsupported platform: ${platform}.`);
+  }
+
+  const listed = versionRecord(versionList);
+  const viewed = versionRecord(versionView);
+  const dashboard = statusRecord(status);
+  const versionId = required(
+    expected.versionId ?? listed.id ?? viewed.id,
+    "version ID"
+  );
+  const buildId = required(expected.buildId, "expected build ID");
+  const buildNumber = required(expected.buildNumber, "expected build number");
+
+  same(listed.id, versionId, "listed version ID");
+  same(viewed.id, versionId, "viewed version ID");
+  same(dashboard.versionId, versionId, "status version ID");
+  for (const [actual, label] of [
+    [listed.version, "listed version"],
+    [dashboard.version, "status version"],
+    [dashboard.buildVersion, "build marketing version"],
+  ]) {
+    same(actual, version, label);
+  }
+  if (viewed.version) {
+    same(viewed.version, version, "viewed version");
+  }
+  for (const [actual, label] of [
+    [listed.platform, "listed platform"],
+    [dashboard.platform, "status platform"],
+  ]) {
+    same(String(actual).toUpperCase(), platform, label);
+  }
+  if (viewed.platform) {
+    same(String(viewed.platform).toUpperCase(), platform, "viewed platform");
+  }
+
+  const state = required(
+    dashboard.state ?? listed.state ?? viewed.state,
+    "release state"
+  ).toUpperCase();
+  if (!reviewStates.has(state)) {
+    throw new Error(
+      `Release state ${state} is not waiting for review or later.`
+    );
+  }
+  for (const candidate of [listed.state, viewed.state, dashboard.state].filter(
+    Boolean
+  )) {
+    same(String(candidate).toUpperCase(), state, "release state");
+  }
+
+  same(listed.releaseType, "AFTER_APPROVAL", "release type");
+  if (viewed.releaseType) {
+    same(viewed.releaseType, "AFTER_APPROVAL", "viewed release type");
+  }
+  same(viewed.buildId, buildId, "attached build ID");
+  same(dashboard.buildId, buildId, "status build ID");
+  if (viewed.buildNumber) {
+    same(viewed.buildNumber, buildNumber, "attached build number");
+  }
+  same(dashboard.buildNumber, buildNumber, "status build number");
+  same(dashboard.processingState, "VALID", "build processing state");
+
+  const submissionId = required(
+    expected.submissionId ?? viewed.submissionId ?? dashboard.submissionId,
+    "submission ID"
+  );
+  same(dashboard.submissionId, submissionId, "status submission ID");
+  const submissionState = required(
+    dashboard.submissionState,
+    "submission state"
+  ).toUpperCase();
+  if (
+    ["WAITING_FOR_REVIEW", "IN_REVIEW"].includes(state) &&
+    dashboard.inFlight !== true
+  ) {
+    throw new Error(`${state} must have an in-flight review submission.`);
+  }
+
+  return {
+    version,
+    platform,
+    versionId,
+    state,
+    releaseType: "AFTER_APPROVAL",
+    buildId,
+    buildNumber,
+    processingState: "VALID",
+    submissionId,
+    submissionState,
+  };
+}
+
+function main() {
+  const [command, ...args] = process.argv.slice(2);
+  if (command !== "verify") {
+    throw new Error("Expected verify command.");
+  }
+  const values = parseArguments(args);
+  const proof = verifyReleaseProof({
+    versionList: readJson(values["version-list"], "version list"),
+    versionView: readJson(values["version-view"], "version view"),
+    status: readJson(values.status, "release status"),
+    expected: readJson(values.expected, "expected release"),
+  });
+  const output = `${JSON.stringify(proof, null, 2)}\n`;
+  if (values.output) {
+    fs.writeFileSync(values.output, output, { mode: 0o600 });
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/apple-release-proof.test.ts
+++ b/scripts/apple-release-proof.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { verifyReleaseProof } from "./apple-release-proof.mjs";
+
+const fixtureRoot = path.join(import.meta.dir, "fixtures/apple-release");
+const fixture = (name: string) =>
+  JSON.parse(fs.readFileSync(path.join(fixtureRoot, name), "utf8"));
+
+const waiting = () => ({
+  versionList: fixture("waiting-ios-version-list.json"),
+  versionView: fixture("waiting-ios-version-view.json"),
+  status: fixture("waiting-ios-status.json"),
+  expected: fixture("waiting-ios-expected.json"),
+});
+
+describe("Apple release proof", () => {
+  test("accepts an exact valid build waiting for review with automatic release", () => {
+    expect(verifyReleaseProof(waiting())).toEqual({
+      version: "1.0.61",
+      platform: "IOS",
+      versionId: "ios-version-61",
+      state: "WAITING_FOR_REVIEW",
+      releaseType: "AFTER_APPROVAL",
+      buildId: "ios-build-65",
+      buildNumber: "65",
+      processingState: "VALID",
+      submissionId: "ios-submission-61",
+      submissionState: "WAITING_FOR_REVIEW",
+    });
+  });
+
+  test("rejects the wrong attached build", () => {
+    const input = waiting();
+    input.expected.buildId = "unrelated-build";
+    expect(() => verifyReleaseProof(input)).toThrow(
+      "attached build ID mismatch"
+    );
+  });
+
+  test("rejects manual release configuration", () => {
+    const input = waiting();
+    input.versionList.data[0].attributes.releaseType = "MANUAL";
+    expect(() => verifyReleaseProof(input)).toThrow("release type mismatch");
+  });
+
+  test("rejects a non-valid build", () => {
+    const input = waiting();
+    input.status.builds.latest.processingState = "PROCESSING";
+    expect(() => verifyReleaseProof(input)).toThrow(
+      "build processing state mismatch"
+    );
+  });
+
+  test("rejects a waiting version without an in-flight submission", () => {
+    const input = waiting();
+    input.status.submission.inFlight = false;
+    expect(() => verifyReleaseProof(input)).toThrow(
+      "must have an in-flight review submission"
+    );
+  });
+});

--- a/scripts/apple-release-proof.test.ts
+++ b/scripts/apple-release-proof.test.ts
@@ -10,7 +10,8 @@ const fixture = (name: string) =>
 const waiting = () => ({
   versionList: fixture("waiting-ios-version-list.json"),
   versionView: fixture("waiting-ios-version-view.json"),
-  status: fixture("waiting-ios-status.json"),
+  build: fixture("waiting-ios-build.json"),
+  submission: fixture("waiting-ios-submission.json"),
   expected: fixture("waiting-ios-expected.json"),
 });
 
@@ -46,7 +47,7 @@ describe("Apple release proof", () => {
 
   test("rejects a non-valid build", () => {
     const input = waiting();
-    input.status.builds.latest.processingState = "PROCESSING";
+    input.build.data.attributes.processingState = "PROCESSING";
     expect(() => verifyReleaseProof(input)).toThrow(
       "build processing state mismatch"
     );
@@ -54,9 +55,25 @@ describe("Apple release proof", () => {
 
   test("rejects a waiting version without an in-flight submission", () => {
     const input = waiting();
-    input.status.submission.inFlight = false;
+    input.submission.data.attributes.state = "READY_FOR_REVIEW";
     expect(() => verifyReleaseProof(input)).toThrow(
-      "must have an in-flight review submission"
+      "in-flight submission state mismatch"
     );
+  });
+
+  test("ignores newer app-wide latest records when replaying an older release", () => {
+    const input = {
+      ...waiting(),
+      status: fixture("waiting-ios-status.json"),
+    };
+    input.status.appstore.version = "1.0.62";
+    input.status.builds.latest = {
+      ...input.status.builds.latest,
+      id: "ios-build-66",
+      version: "1.0.62",
+      buildNumber: "66",
+    };
+    input.status.review.latestSubmissionId = "ios-submission-62";
+    expect(verifyReleaseProof(input).buildId).toBe("ios-build-65");
   });
 });

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 const repoRoot = path.resolve(import.meta.dir, "..");
 const read = (relative: string) =>
   fs.readFileSync(path.join(repoRoot, relative), "utf8");
+const expression = (value: string) => `\${{ ${value} }}`;
 
 describe("Apple release workflows", () => {
   const mobile = read(".github/workflows/mobile-release.yml");
@@ -12,6 +13,11 @@ describe("Apple release workflows", () => {
   const status = read(".github/workflows/apple-release-status.yml");
   const issueHelper = read("scripts/apple-release-issue.mjs");
   const versionTag = read(".github/workflows/version-tag.yml");
+  const productReleases = [
+    read(".github/workflows/cli-release.yml"),
+    read(".github/workflows/desktop-release.yml"),
+    read(".github/workflows/extension-release.yml"),
+  ];
   const setupAscPin =
     "rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d";
 
@@ -23,13 +29,21 @@ describe("Apple release workflows", () => {
     }
   });
 
-  test("keeps iOS on a runner-local Xcode build plus asc upload and review", () => {
+  test("hands a runner-local iOS build to an isolated Ubuntu submission job", () => {
+    expect(mobile).toContain("build:\n    runs-on: macos-26");
+    expect(mobile).toContain("submit:\n    if: inputs.dry_run == false");
+    expect(mobile).toContain("runs-on: ubuntu-24.04");
     expect(mobile).toContain("bunx expo prebuild --platform ios");
     expect(mobile).toContain("xcodebuild");
     expect(mobile).toContain("IOS_APP_STORE");
     expect(mobile).toContain("--certificate-type IOS_DISTRIBUTION");
     expect(mobile).not.toContain("--certificate-type DISTRIBUTION");
-    expect(mobile).toContain("Upload local IPA to Sentry Size Analysis");
+    expect(mobile).toContain("Upload verified signed IPA handoff");
+    expect(mobile).toContain("Download verified signed IPA handoff");
+    expect(mobile).toContain(
+      "Verify handoff and upload IPA to Sentry Size Analysis"
+    );
+    expect(mobile).toContain("Signed IPA handoff digest mismatch");
     expect(mobile).toContain("asc builds upload");
     expect(mobile).toContain("asc validate");
     expect(mobile).toContain("asc review doctor");
@@ -45,17 +59,25 @@ describe("Apple release workflows", () => {
     expect(mobile).toContain("secrets.SENTRY_MOBILE_DSN");
     expect(mobile).toContain("asc age-rating edit");
     expect(mobile).toContain("--social-media-age-restricted false");
+    expect(mobile.indexOf("build:sentry")).toBeLessThan(
+      mobile.indexOf("asc builds upload")
+    );
   });
 
   test("serializes app-wide iOS build-number allocation through upload", () => {
     expect(mobile).toContain(
-      "group: mobile-app-store-ios-${{ github.repository }}"
+      `group: mobile-app-store-ios-${expression("github.repository")}`
     );
-    expect(mobile).not.toContain("group: mobile-app-store-${{ inputs.version }}");
+    expect(mobile).not.toContain(
+      `group: mobile-app-store-${expression("inputs.version")}`
+    );
     expect(mobile).toContain("cancel-in-progress: false");
   });
 
-  test("keeps Safari PKG artifacts while using asc for every Apple operation", () => {
+  test("hands a signed Safari PKG to an isolated Ubuntu submission job", () => {
+    expect(safari).toContain("build:\n    runs-on: macos-26");
+    expect(safari).toContain("submit:\n    if: inputs.dry_run == false");
+    expect(safari).toContain("runs-on: ubuntu-24.04");
     expect(safari).toContain("xcodebuild archive");
     expect(safari).toContain("asc certificates");
     expect(safari).toContain("asc profiles");
@@ -70,15 +92,22 @@ describe("Apple release workflows", () => {
     expect(safari).not.toContain("EXPECTED_SIGNING_IDENTITY");
     expect(safari).toContain("asc age-rating edit");
     expect(safari).toContain("--social-media-age-restricted false");
+    expect(safari).toContain("Upload verified signed PKG handoff");
+    expect(safari).toContain("Download verified signed PKG handoff");
+    expect(safari).toContain("Signed PKG handoff digest mismatch");
   });
 
-  test("permits real recovery only from a tagged release descendant", () => {
+  test("permits mutation only from the exact tag or current main", () => {
     for (const workflow of [mobile, safari]) {
       expect(workflow).toContain('release_tag="v$VERSION"');
+      expect(workflow).toContain('"refs/tags/$release_tag")');
+      expect(workflow).toContain("refs/heads/main)");
       expect(workflow).toContain(
-        'git merge-base --is-ancestor "$tag_commit" "$GITHUB_SHA"'
+        'if [ "$GITHUB_SHA" != "$(git rev-parse origin/main)" ] || ! git merge-base --is-ancestor "$tag_commit" "$GITHUB_SHA"; then'
       );
-      expect(workflow).toContain("descendant recovery commits");
+      expect(workflow).toContain(
+        "A real release may run only from $release_tag or current main, not $GITHUB_REF."
+      );
     }
   });
 
@@ -90,11 +119,11 @@ describe("Apple release workflows", () => {
     expect(safari).toContain('asset_label="App Store build $build_number"');
     expect(safari).toContain('[ "$existing_label" = "$asset_label" ]');
     expect(safari).toContain(
-      'labeled_package="$PACKAGE_PATH#App Store build $BUILD_NUMBER"'
+      'gh release upload "v$VERSION" "$PACKAGE_PATH#App Store build $build_number" --clobber'
     );
   });
 
-  test("dispatches every release from the one version tag", () => {
+  test("replays or dispatches every release from the one version tag", () => {
     for (const workflow of [
       "cli-release.yml",
       "desktop-release.yml",
@@ -102,8 +131,21 @@ describe("Apple release workflows", () => {
       "mobile-release.yml",
       "safari-extension-release.yml",
     ]) {
-      expect(versionTag).toContain(`gh workflow run ${workflow}`);
+      expect(versionTag).toContain(`workflow: ${workflow}`);
     }
+    expect(versionTag).toContain('gh workflow run "$WORKFLOW"');
+    expect(versionTag).toContain(".display_title == $title");
+    expect(versionTag).toContain('.event == "workflow_dispatch"');
+    expect(versionTag).toContain("Reusing successful $WORKFLOW run");
+    expect(versionTag).toContain("Waiting for existing $WORKFLOW run");
+    expect(versionTag).toContain(
+      "Waiting briefly for the tag-triggered $WORKFLOW run"
+    );
+    expect(versionTag).toContain("fail-fast: false");
+    expect(mobile).toContain(`run-name: iOS ${expression("inputs.version")}`);
+    expect(safari).toContain(
+      `run-name: Safari macOS ${expression("inputs.version")}`
+    );
     expect(versionTag).toContain("release-version.mjs patch");
     expect(versionTag).toContain(
       'if [ "$previous_version" = "$VERSION" ]; then'
@@ -118,6 +160,38 @@ describe("Apple release workflows", () => {
     expect(status).toContain("--platform IOS");
     expect(status).toContain("--platform MAC_OS");
     expect(status).toContain("apple-release-issue.mjs status");
+    expect(status).toContain("apple-release-issue.mjs versions");
+    expect(status).toContain("itunes.apple.com/lookup?id=$IOS_APP_ID");
+    expect(status).toContain("itunes.apple.com/lookup?id=$SAFARI_APP_ID");
+    expect(status).toContain('--ios-store-version "$ios_store"');
+    expect(status).toContain('--safari-store-version "$safari_store"');
+  });
+
+  test("publishes replayable proof manifests after exact read-only verification", () => {
+    for (const workflow of [mobile, safari]) {
+      expect(workflow).toContain("apple-release-proof.mjs verify");
+      expect(workflow).toContain("apple-release-manifest.mjs create");
+      expect(workflow).toContain("app-store.json");
+      expect(workflow).toContain("gh release upload");
+      expect(workflow).toContain("asc release stage");
+    }
+    expect(mobile).toContain("asc publish appstore");
+    expect(safari).toContain(
+      "asc publish appstore: not used because 3.6.1 has no PKG input"
+    );
+  });
+
+  test("pins every third-party action in the Apple release workflows", () => {
+    const mutableAction = /^\s*uses:\s*[^./\s][^\s]*@(v\d+|main|master)\s*$/m;
+    for (const workflow of [
+      mobile,
+      safari,
+      status,
+      versionTag,
+      ...productReleases,
+    ]) {
+      expect(workflow).not.toMatch(mutableAction);
+    }
   });
 
   test("continues an exact version already attached to a review draft", () => {
@@ -137,9 +211,7 @@ describe("Apple release workflows", () => {
             '`;
 
     for (const workflow of [mobile, safari]) {
-      expect(workflow).toContain(
-        '""|PREPARE_FOR_SUBMISSION|READY_FOR_REVIEW)'
-      );
+      expect(workflow).toContain('""|PREPARE_FOR_SUBMISSION|READY_FOR_REVIEW)');
       expect(workflow).not.toContain(
         "WAITING_FOR_REVIEW|READY_FOR_REVIEW|IN_REVIEW"
       );

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -170,6 +170,10 @@ describe("Apple release workflows", () => {
   test("publishes replayable proof manifests after exact read-only verification", () => {
     for (const workflow of [mobile, safari]) {
       expect(workflow).toContain("apple-release-proof.mjs verify");
+      expect(workflow).toContain('asc builds info --build-id "$build_id"');
+      expect(workflow).toContain(
+        'asc review submissions-get --id "$submission_id" --include appStoreVersionForReview'
+      );
       expect(workflow).toContain("apple-release-manifest.mjs create");
       expect(workflow).toContain("app-store.json");
       expect(workflow).toContain("gh release upload");

--- a/scripts/fixtures/apple-release/waiting-ios-build.json
+++ b/scripts/fixtures/apple-release/waiting-ios-build.json
@@ -1,0 +1,20 @@
+{
+  "data": {
+    "type": "builds",
+    "id": "ios-build-65",
+    "attributes": {
+      "version": "65",
+      "processingState": "VALID"
+    }
+  },
+  "included": [
+    {
+      "type": "preReleaseVersions",
+      "id": "ios-pre-release-61",
+      "attributes": {
+        "version": "1.0.61",
+        "platform": "IOS"
+      }
+    }
+  ]
+}

--- a/scripts/fixtures/apple-release/waiting-ios-expected.json
+++ b/scripts/fixtures/apple-release/waiting-ios-expected.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.61",
+  "platform": "IOS",
+  "versionId": "ios-version-61",
+  "buildId": "ios-build-65",
+  "buildNumber": "65",
+  "submissionId": "ios-submission-61"
+}

--- a/scripts/fixtures/apple-release/waiting-ios-status.json
+++ b/scripts/fixtures/apple-release/waiting-ios-status.json
@@ -1,0 +1,26 @@
+{
+  "builds": {
+    "latest": {
+      "id": "ios-build-65",
+      "version": "1.0.61",
+      "buildNumber": "65",
+      "processingState": "VALID",
+      "platform": "IOS"
+    }
+  },
+  "appstore": {
+    "versionId": "ios-version-61",
+    "version": "1.0.61",
+    "state": "WAITING_FOR_REVIEW",
+    "platform": "IOS"
+  },
+  "submission": {
+    "inFlight": true,
+    "blockingIssues": []
+  },
+  "review": {
+    "latestSubmissionId": "ios-submission-61",
+    "state": "WAITING_FOR_REVIEW",
+    "platform": "IOS"
+  }
+}

--- a/scripts/fixtures/apple-release/waiting-ios-submission.json
+++ b/scripts/fixtures/apple-release/waiting-ios-submission.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "type": "reviewSubmissions",
+    "id": "ios-submission-61",
+    "attributes": {
+      "platform": "IOS",
+      "state": "WAITING_FOR_REVIEW"
+    },
+    "relationships": {
+      "appStoreVersionForReview": {
+        "data": {
+          "type": "appStoreVersions",
+          "id": "ios-version-61"
+        }
+      }
+    }
+  }
+}

--- a/scripts/fixtures/apple-release/waiting-ios-version-list.json
+++ b/scripts/fixtures/apple-release/waiting-ios-version-list.json
@@ -1,0 +1,14 @@
+{
+  "data": [
+    {
+      "id": "ios-version-61",
+      "type": "appStoreVersions",
+      "attributes": {
+        "versionString": "1.0.61",
+        "platform": "IOS",
+        "appVersionState": "WAITING_FOR_REVIEW",
+        "releaseType": "AFTER_APPROVAL"
+      }
+    }
+  ]
+}

--- a/scripts/fixtures/apple-release/waiting-ios-version-view.json
+++ b/scripts/fixtures/apple-release/waiting-ios-version-view.json
@@ -5,6 +5,5 @@
   "state": "WAITING_FOR_REVIEW",
   "releaseType": "AFTER_APPROVAL",
   "buildId": "ios-build-65",
-  "buildNumber": "65",
-  "submissionId": "ios-submission-61"
+  "buildNumber": "65"
 }

--- a/scripts/fixtures/apple-release/waiting-ios-version-view.json
+++ b/scripts/fixtures/apple-release/waiting-ios-version-view.json
@@ -1,0 +1,10 @@
+{
+  "id": "ios-version-61",
+  "version": "1.0.61",
+  "platform": "IOS",
+  "state": "WAITING_FOR_REVIEW",
+  "releaseType": "AFTER_APPROVAL",
+  "buildId": "ios-build-65",
+  "buildNumber": "65",
+  "submissionId": "ios-submission-61"
+}


### PR DESCRIPTION
## Summary
- gate real Apple mutations to the exact release tag or current `main`, pin release actions, and make Version Tag replay/reuse all child releases without confusing Apple dry runs for submissions
- build/sign iOS and Safari artifacts on `macos-26`, verify a private SHA-256 handoff, and perform Sentry/ASC submission from Ubuntu
- add exact read-only Apple proof, replay-safe GitHub Release manifests, multi-version storefront-aware monitoring, and deterministic fixtures/tests
- record dry-run parity for asc 3.6.1 high-level release commands while retaining the proven lower-level path

## Validation
- actionlint 1.7.12 + shellcheck on all changed release workflows
- 31 release/version/build-number tests
- 166 mobile tests; mobile lint, typecheck, and Expo web export
- Safari Xcode project listing and Release build-settings resolution with Xcode 26.6
- `bun run pre-commit` (affected packages)
- credentialed workflow dry runs in progress for iOS, Safari macOS, and Apple status

No App Store state is mutated by this PR's dry runs. Existing iOS and Safari macOS 1.0.60 submissions remain untouched.
