### PR TITLE
Fix release parent repository context

### DIFF
--- a/.github/workflows/version-tag.yml
+++ b/.github/workflows/version-tag.yml
@@ -155,16 +155,16 @@ jobs:
           active="$(jq -r '[.[] | select(.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "pending")][0].id // empty' <<< "$runs")"
           if [ -n "$active" ]; then
             echo "Waiting for existing $WORKFLOW run $active."
-            gh run watch "$active" --exit-status
+            gh run watch "$active" --repo "$GITHUB_REPOSITORY" --exit-status
             echo "- ${{ matrix.name }}: https://github.com/$GITHUB_REPOSITORY/actions/runs/$active" >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
           dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           if [ "$APPLE_WORKFLOW" = "true" ]; then
-            gh workflow run "$WORKFLOW" --ref "$TAG_NAME" -f "version=$VERSION" -f dry_run=false
+            gh workflow run "$WORKFLOW" --repo "$GITHUB_REPOSITORY" --ref "$TAG_NAME" -f "version=$VERSION" -f dry_run=false
           else
-            gh workflow run "$WORKFLOW" --ref "$TAG_NAME"
+            gh workflow run "$WORKFLOW" --repo "$GITHUB_REPOSITORY" --ref "$TAG_NAME"
           fi
 
           run_id=""
@@ -180,5 +180,5 @@ jobs:
             echo "Could not resolve the dispatched $WORKFLOW run." >&2
             exit 1
           fi
-          gh run watch "$run_id" --exit-status
+          gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --exit-status
           echo "- ${{ matrix.name }}: https://github.com/$GITHUB_REPOSITORY/actions/runs/$run_id" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -133,7 +133,15 @@ describe("Apple release workflows", () => {
     ]) {
       expect(versionTag).toContain(`workflow: ${workflow}`);
     }
-    expect(versionTag).toContain('gh workflow run "$WORKFLOW"');
+    expect(versionTag).toContain(
+      'gh workflow run "$WORKFLOW" --repo "$GITHUB_REPOSITORY"'
+    );
+    expect(versionTag).toContain(
+      'gh run watch "$run_id" --repo "$GITHUB_REPOSITORY"'
+    );
+    expect(versionTag).toContain(
+      'gh run watch "$active" --repo "$GITHUB_REPOSITORY"'
+    );
     expect(versionTag).toContain(".display_title == $title");
     expect(versionTag).toContain('.event == "workflow_dispatch"');
     expect(versionTag).toContain("Reusing successful $WORKFLOW run");


### PR DESCRIPTION
The first live 1.0.61 release proved that the checkout-free Version Tag matrix cannot use gh workflow run or gh run watch without an explicit repository. Every parent matrix leg failed with fatal: not a git repository, even though tag-triggered child releases continued.\n\nThis binds all dispatch and watch commands to GITHUB_REPOSITORY and adds regression assertions for the checkout-free path.\n\nValidation:\n- bun test scripts/apple-workflows.test.ts scripts/release-version.test.ts (15 pass, 0 fail)\n- git diff --check\n- pre-commit passed