### PR TITLE
Fix iOS signed handoff artifact layout

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -480,13 +480,18 @@ jobs:
           IPA_PATH: ${{ steps.ipa.outputs.path }}
         run: |
           sha256="$(shasum -a 256 "$IPA_PATH" | awk '{print $1}')"
-          descriptor="$RUNNER_TEMP/ios-handoff.json"
+          handoff_directory="$RUNNER_TEMP/ios-handoff"
+          mkdir -p "$handoff_directory"
+          handoff_ipa="$handoff_directory/$(basename "$IPA_PATH")"
+          descriptor="$handoff_directory/ios-handoff.json"
+          cp "$IPA_PATH" "$handoff_ipa"
           jq -n \
             --arg version "$VERSION" \
             --arg buildNumber "$BUILD_NUMBER" \
             --arg sha256 "$sha256" \
-            --arg fileName "$(basename "$IPA_PATH")" \
+            --arg fileName "$(basename "$handoff_ipa")" \
             '{version: $version, buildNumber: $buildNumber, sha256: $sha256, fileName: $fileName}' > "$descriptor"
+          echo "directory=$handoff_directory" >> "$GITHUB_OUTPUT"
           echo "descriptor=$descriptor" >> "$GITHUB_OUTPUT"
           echo "sha256=$sha256" >> "$GITHUB_OUTPUT"
 
@@ -495,9 +500,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: teak-ios-${{ env.VERSION }}-signed
-          path: |
-            ${{ steps.ipa.outputs.path }}
-            ${{ steps.handoff.outputs.descriptor }}
+          path: ${{ steps.handoff.outputs.directory }}
           if-no-files-found: error
           retention-days: 1
 
@@ -563,9 +566,11 @@ jobs:
             echo "Sentry Size Analysis is mandatory and SENTRY_AUTH_TOKEN is missing." >&2
             exit 1
           fi
+          descriptor_count="$(find "$RUNNER_TEMP/ios-handoff" -maxdepth 1 -type f -name 'ios-handoff.json' | wc -l | tr -d ' ')"
+          ipa_count="$(find "$RUNNER_TEMP/ios-handoff" -maxdepth 1 -type f -name '*.ipa' | wc -l | tr -d ' ')"
           descriptor="$(find "$RUNNER_TEMP/ios-handoff" -maxdepth 1 -type f -name 'ios-handoff.json')"
           ipa_path="$(find "$RUNNER_TEMP/ios-handoff" -maxdepth 1 -type f -name '*.ipa')"
-          if [ "$(find "$RUNNER_TEMP/ios-handoff" -maxdepth 1 -type f -name '*.ipa' | wc -l | tr -d ' ')" -ne 1 ] || [ ! -s "$descriptor" ]; then
+          if [ "$descriptor_count" -ne 1 ] || [ "$ipa_count" -ne 1 ] || [ ! -s "$descriptor" ] || [ ! -s "$ipa_path" ]; then
             echo "Expected one signed IPA and its handoff descriptor." >&2
             exit 1
           fi

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -6,6 +6,15 @@ const repoRoot = path.resolve(import.meta.dir, "..");
 const read = (relative: string) =>
   fs.readFileSync(path.join(repoRoot, relative), "utf8");
 const expression = (value: string) => `\${{ ${value} }}`;
+const workflowStep = (workflow: string, name: string) => {
+  const marker = `      - name: ${name}\n`;
+  const start = workflow.indexOf(marker);
+  if (start === -1) {
+    throw new Error(`Missing workflow step: ${name}`);
+  }
+  const end = workflow.indexOf("\n      - name:", start + marker.length);
+  return workflow.slice(start, end === -1 ? undefined : end);
+};
 
 describe("Apple release workflows", () => {
   const mobile = read(".github/workflows/mobile-release.yml");
@@ -40,8 +49,42 @@ describe("Apple release workflows", () => {
     expect(mobile).not.toContain("--certificate-type DISTRIBUTION");
     expect(mobile).toContain("Upload verified signed IPA handoff");
     expect(mobile).toContain("Download verified signed IPA handoff");
-    expect(mobile).toContain(
+    const prepareHandoff = workflowStep(
+      mobile,
+      "Prepare verified signed IPA handoff"
+    );
+    const uploadHandoff = workflowStep(
+      mobile,
+      "Upload verified signed IPA handoff"
+    );
+    const downloadHandoff = workflowStep(
+      mobile,
+      "Download verified signed IPA handoff"
+    );
+    const verifyHandoff = workflowStep(
+      mobile,
       "Verify handoff and upload IPA to Sentry Size Analysis"
+    );
+    expect(prepareHandoff).toContain(
+      'handoff_directory="$RUNNER_TEMP/ios-handoff"'
+    );
+    expect(prepareHandoff).toContain(
+      'echo "directory=$handoff_directory" >> "$GITHUB_OUTPUT"'
+    );
+    expect(uploadHandoff).toContain(
+      `path: ${expression("steps.handoff.outputs.directory")}`
+    );
+    expect(downloadHandoff).toContain(
+      `path: ${expression("runner.temp")}/ios-handoff`
+    );
+    expect(verifyHandoff).toContain(
+      'descriptor_count="$(find "$RUNNER_TEMP/ios-handoff" -maxdepth 1'
+    );
+    expect(verifyHandoff).toContain(
+      'ipa_count="$(find "$RUNNER_TEMP/ios-handoff" -maxdepth 1'
+    );
+    expect(verifyHandoff).toContain(
+      'if [ "$descriptor_count" -ne 1 ] || [ "$ipa_count" -ne 1 ]'
     );
     expect(mobile).toContain("Signed IPA handoff digest mismatch");
     expect(mobile).toContain("asc builds upload");


### PR DESCRIPTION
The first live 1.0.61 iOS run produced and verified a signed IPA, but actions/upload-artifact preserved two separate absolute source roots. The isolated Ubuntu submit job therefore found neither file at its strict handoff root and stopped before Sentry Size Analysis or App Store upload.\n\nThis stages the IPA and descriptor in one flat, verified directory before upload, keeps exact one-file checks on download, and adds regression assertions for the handoff contract.\n\nValidation:\n- bun test scripts/apple-workflows.test.ts scripts/release-version.test.ts (15 pass, 0 fail)\n- git diff --check\n- pre-commit passed