### PR TITLE
fix(release): run iOS size analysis on Apple Silicon

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -472,6 +472,22 @@ jobs:
           done
           echo "- Local IPA: verified $VERSION/$BUILD_NUMBER for app and share extension" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Upload IPA to mandatory Sentry Size Analysis on Apple Silicon
+        if: steps.release_state.outputs.mutate == 'true' && steps.build_state.outputs.reuse != 'true'
+        env:
+          IPA_PATH: ${{ steps.ipa.outputs.path }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ]; then
+            echo "Sentry Size Analysis is mandatory and SENTRY_AUTH_TOKEN is missing." >&2
+            exit 1
+          fi
+          if [ ! -s "$IPA_PATH" ]; then
+            echo "Sentry Size Analysis requires the verified signed IPA." >&2
+            exit 1
+          fi
+          bun run --cwd apps/mobile build:sentry -- "$IPA_PATH"
+
       - name: Prepare verified signed IPA handoff
         id: handoff
         if: steps.release_state.outputs.mutate == 'true' && steps.build_state.outputs.reuse != 'true'
@@ -518,12 +534,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Bun
-        if: needs.build.outputs.mutate == 'true' && needs.build.outputs.reuse != 'true'
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: 1.3.5
-
       - name: Set up asc
         uses: rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d # v1.0.1
         with:
@@ -544,10 +554,6 @@ jobs:
           echo "ASC_PRIVATE_KEY_PATH=$key_path" >> "$GITHUB_ENV"
           asc auth status --validate --output table
 
-      - name: Install dependencies for mandatory Sentry analysis
-        if: needs.build.outputs.mutate == 'true' && needs.build.outputs.reuse != 'true'
-        run: bun install --frozen-lockfile
-
       - name: Download verified signed IPA handoff
         if: needs.build.outputs.mutate == 'true' && needs.build.outputs.reuse != 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -555,17 +561,12 @@ jobs:
           name: teak-ios-${{ env.VERSION }}-signed
           path: ${{ runner.temp }}/ios-handoff
 
-      - name: Verify handoff and upload IPA to Sentry Size Analysis
+      - name: Verify signed IPA handoff
         id: handoff
         if: needs.build.outputs.mutate == 'true' && needs.build.outputs.reuse != 'true'
         env:
           BUILD_NUMBER: ${{ needs.build.outputs.build_number }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          if [ -z "$SENTRY_AUTH_TOKEN" ]; then
-            echo "Sentry Size Analysis is mandatory and SENTRY_AUTH_TOKEN is missing." >&2
-            exit 1
-          fi
           descriptor_count="$(find "$RUNNER_TEMP/ios-handoff" -maxdepth 1 -type f -name 'ios-handoff.json' | wc -l | tr -d ' ')"
           ipa_count="$(find "$RUNNER_TEMP/ios-handoff" -maxdepth 1 -type f -name '*.ipa' | wc -l | tr -d ' ')"
           descriptor="$(find "$RUNNER_TEMP/ios-handoff" -maxdepth 1 -type f -name 'ios-handoff.json')"
@@ -582,7 +583,6 @@ jobs:
             echo "Signed IPA handoff digest mismatch." >&2
             exit 1
           fi
-          bun run --cwd apps/mobile build:sentry -- "$ipa_path"
           echo "path=$ipa_path" >> "$GITHUB_OUTPUT"
           echo "sha256=$actual_sha" >> "$GITHUB_OUTPUT"
 

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -63,7 +63,11 @@ describe("Apple release workflows", () => {
     );
     const verifyHandoff = workflowStep(
       mobile,
-      "Verify handoff and upload IPA to Sentry Size Analysis"
+      "Verify signed IPA handoff"
+    );
+    const sentryAnalysis = workflowStep(
+      mobile,
+      "Upload IPA to mandatory Sentry Size Analysis on Apple Silicon"
     );
     expect(prepareHandoff).toContain(
       'handoff_directory="$RUNNER_TEMP/ios-handoff"'
@@ -85,6 +89,19 @@ describe("Apple release workflows", () => {
     );
     expect(verifyHandoff).toContain(
       'if [ "$descriptor_count" -ne 1 ] || [ "$ipa_count" -ne 1 ]'
+    );
+    expect(sentryAnalysis).toContain(
+      `IPA_PATH: ${expression("steps.ipa.outputs.path")}`
+    );
+    expect(sentryAnalysis).toContain(
+      'bun run --cwd apps/mobile build:sentry -- "$IPA_PATH"'
+    );
+    expect(mobile.indexOf(sentryAnalysis)).toBeLessThan(
+      mobile.indexOf("  submit:")
+    );
+    expect(verifyHandoff).not.toContain("build:sentry");
+    expect(mobile).not.toContain(
+      "Install dependencies for mandatory Sentry analysis"
     );
     expect(mobile).toContain("Signed IPA handoff digest mismatch");
     expect(mobile).toContain("asc builds upload");


### PR DESCRIPTION
## Summary
- run mandatory Sentry IPA size analysis in the Apple Silicon build job
- keep the isolated Ubuntu submission job responsible for handoff verification and App Store upload
- add regression coverage binding the Sentry uploader to the macOS side of the workflow

## Live release evidence
Run 31303709973 produced and verified the signed 1.0.61 IPA and passed the flattened artifact handoff. Sentry then rejected the IPA on Ubuntu with: `Uploading XCArchive and IPA files requires an Apple Silicon Mac`.

## Verification
- `bun test scripts/apple-workflows.test.ts` (12 pass, 163 assertions)
- `git diff --check`
- pre-commit hook passed