### PR TITLE
Keep the latest Apple version in review

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -147,52 +147,23 @@ jobs:
             sleep $((attempt * 10))
           done
 
-          target="$(jq -c --arg version "$VERSION" '.data[]? | select(.attributes.versionString == $version)' "$versions_json" | head -1)"
-          target_id="$(jq -r '.id // empty' <<< "$target")"
-          target_state="$(jq -r '.attributes.appVersionState // .attributes.appStoreState // empty' <<< "$target")"
-          source_version="$(jq -r --arg target "$VERSION" '
-            .data[]?
-            | select((.attributes.appVersionState // .attributes.appStoreState) as $state
-              | ["READY_FOR_DISTRIBUTION", "READY_FOR_SALE", "PROCESSING_FOR_DISTRIBUTION"]
-              | index($state))
-            | .attributes.versionString
-            | select(. != $target)
-          ' "$versions_json" | sort -V | tail -1)"
-
-          if [ "$DRY_RUN" = "true" ]; then
-            mutate=false
-            {
-              echo "### iOS dry run"
-              echo "- App: $ASC_APP_ID"
-              echo "- Target: $VERSION (${target_state:-not created})"
-              echo "- Metadata source: ${source_version:-not found}"
-              echo "- Native build: GitHub Actions macOS runner"
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            case "$target_state" in
-              ""|PREPARE_FOR_SUBMISSION|READY_FOR_REVIEW)
-                mutate=true
-                ;;
-              WAITING_FOR_REVIEW|IN_REVIEW|PENDING_APPLE_RELEASE|PROCESSING_FOR_DISTRIBUTION|READY_FOR_DISTRIBUTION|READY_FOR_SALE)
-                mutate=false
-                echo "iOS $VERSION is already $target_state; no mutation will run." >> "$GITHUB_STEP_SUMMARY"
-                ;;
-              DEVELOPER_REJECTED|REJECTED|METADATA_REJECTED|INVALID_BINARY)
-                echo "iOS $VERSION is $target_state. Rejections are never resubmitted automatically." >&2
-                exit 1
-                ;;
-              *)
-                echo "Refusing to mutate iOS $VERSION in unknown state: $target_state" >&2
-                exit 1
-                ;;
-            esac
-          fi
+          result="$(node scripts/apple-latest-review.mjs apply "$versions_json" "$VERSION" "$ASC_APP_ID" "$PLATFORM" "$DRY_RUN")"
+          target_id="$(jq -r '.targetId' <<< "$result")"
+          target_state="$(jq -r '.targetState' <<< "$result")"
+          source_version="$(jq -r '.sourceVersion' <<< "$result")"
+          mutate="$(jq -r '.mutate' <<< "$result")"
           {
             echo "target_id=$target_id"
             echo "target_state=$target_state"
             echo "source_version=$source_version"
             echo "mutate=$mutate"
           } >> "$GITHUB_OUTPUT"
+          {
+            echo "### iOS $([ "$DRY_RUN" = "true" ] && echo 'dry run' || echo 'latest-review release')"
+            echo "- Target: $VERSION (${target_state:-not created})"
+            echo "- Superseded: $(jq -r 'if .supersededId == "" then "none" else "\(.supersededVersion) (\(.supersededState)); cancel=\(.cancelSuperseded), promote=\(.promoteSuperseded)" end' <<< "$result")"
+            echo "- Metadata source: ${source_version:-not found}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Reuse an exact valid build or allocate the next Apple build number
         id: build_state

--- a/.github/workflows/safari-extension-release.yml
+++ b/.github/workflows/safari-extension-release.yml
@@ -19,7 +19,8 @@ on:
         type: boolean
 
 concurrency:
-  group: safari-app-store-${{ inputs.version }}
+  # Serialize every mutation for this App Store app, including cross-version promotion.
+  group: safari-app-store-${{ github.repository }}
   cancel-in-progress: false
 
 permissions:
@@ -139,52 +140,23 @@ jobs:
             sleep $((attempt * 10))
           done
 
-          target="$(jq -c --arg version "$VERSION" '.data[]? | select(.attributes.versionString == $version)' "$versions_json" | head -1)"
-          target_id="$(jq -r '.id // empty' <<< "$target")"
-          target_state="$(jq -r '.attributes.appVersionState // .attributes.appStoreState // empty' <<< "$target")"
-          source_version="$(jq -r --arg target "$VERSION" '
-            .data[]?
-            | select((.attributes.appVersionState // .attributes.appStoreState) as $state
-              | ["READY_FOR_DISTRIBUTION", "READY_FOR_SALE", "PROCESSING_FOR_DISTRIBUTION"]
-              | index($state))
-            | .attributes.versionString
-            | select(. != $target)
-          ' "$versions_json" | sort -V | tail -1)"
-
-          if [ "$DRY_RUN" = "true" ]; then
-            mutate=false
-            {
-              echo "### Safari macOS dry run"
-              echo "- App: $ASC_APP_ID"
-              echo "- Target: $VERSION (${target_state:-not created})"
-              echo "- Metadata source: ${source_version:-not found}"
-              echo "- Xcode project and asc authentication: valid"
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            case "$target_state" in
-              ""|PREPARE_FOR_SUBMISSION|READY_FOR_REVIEW)
-                mutate=true
-                ;;
-              WAITING_FOR_REVIEW|IN_REVIEW|PENDING_APPLE_RELEASE|PROCESSING_FOR_DISTRIBUTION|READY_FOR_DISTRIBUTION|READY_FOR_SALE)
-                mutate=false
-                echo "Safari macOS $VERSION is already $target_state; no mutation will run." >> "$GITHUB_STEP_SUMMARY"
-                ;;
-              DEVELOPER_REJECTED|REJECTED|METADATA_REJECTED|INVALID_BINARY)
-                echo "Safari macOS $VERSION is $target_state. Rejections are never resubmitted automatically." >&2
-                exit 1
-                ;;
-              *)
-                echo "Refusing to mutate Safari macOS $VERSION in unknown state: $target_state" >&2
-                exit 1
-                ;;
-            esac
-          fi
+          result="$(node scripts/apple-latest-review.mjs apply "$versions_json" "$VERSION" "$ASC_APP_ID" "$PLATFORM" "$DRY_RUN")"
+          target_id="$(jq -r '.targetId' <<< "$result")"
+          target_state="$(jq -r '.targetState' <<< "$result")"
+          source_version="$(jq -r '.sourceVersion' <<< "$result")"
+          mutate="$(jq -r '.mutate' <<< "$result")"
           {
             echo "target_id=$target_id"
             echo "target_state=$target_state"
             echo "source_version=$source_version"
             echo "mutate=$mutate"
           } >> "$GITHUB_OUTPUT"
+          {
+            echo "### Safari macOS $([ "$DRY_RUN" = "true" ] && echo 'dry run' || echo 'latest-review release')"
+            echo "- Target: $VERSION (${target_state:-not created})"
+            echo "- Superseded: $(jq -r 'if .supersededId == "" then "none" else "\(.supersededVersion) (\(.supersededState)); cancel=\(.cancelSuperseded), promote=\(.promoteSuperseded)" end' <<< "$result")"
+            echo "- Metadata source: ${source_version:-not found}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Reuse an exact uploaded Safari build and PKG when available
         id: reuse

--- a/apps/mobile/release.md
+++ b/apps/mobile/release.md
@@ -16,19 +16,23 @@ iOS build history.
    reuses successful or active child runs and dispatches only missing work.
 4. The workflow verifies the tag, lockstep packages, dynamic Expo version, asc
    version, and credentials.
-5. It reuses an exact valid App Store Connect build for the target marketing
+5. The package version is authoritative. If an older version is waiting for or
+   currently in App Review, asc cancels that superseded submission, waits for
+   Apple to make the version editable, updates the same version record to the
+   new package version, and preserves its metadata. Dry runs report this plan
+   without changing App Store Connect.
+6. It reuses an exact valid App Store Connect build for the target marketing
    version when one exists. Otherwise it allocates the next build number from
    App Store Connect, generates the native iOS project with Expo Prebuild, and
    uses CocoaPods plus Xcode directly on the GitHub Actions macOS runner.
-6. asc finds or creates the exact iOS distribution certificate and App Store
+7. asc finds or creates the exact iOS distribution certificate and App Store
    provisioning profiles for the Teak app and share extension. The workflow
    archives, exports, and verifies the signed IPA locally, including bundle IDs,
    marketing version, build number, embedded profiles, and signatures.
-7. The macOS job publishes the signed IPA and a SHA-256 handoff descriptor as a
+8. The macOS job uploads the verified IPA to mandatory Sentry Size Analysis,
+   then publishes the signed IPA and a SHA-256 handoff descriptor as a
    one-day private Actions artifact. An Ubuntu job verifies the digest before
    any external upload.
-8. The Ubuntu job uploads the exact IPA to Sentry Size Analysis. A failed or
-   missing Sentry upload stops the release before App Store Connect upload.
 9. asc uploads the exact IPA directly to App Store Connect and waits for a
    `VALID` build.
 10. asc finds or creates the iOS App Store version, copies localization metadata
@@ -62,8 +66,12 @@ gh workflow run mobile-release.yml --ref main -f "version=$version" -f dry_run=t
 - App-wide concurrency keeps build-number allocation through upload atomic.
   Reruns reuse an exact valid Apple build only when its release manifest proves
   the artifact, Sentry analysis, build, submission, and prior workflow.
-- In-review or already-live versions are read-only and return success.
-- Rejected versions are never resubmitted or modified automatically.
+- The newest lockstep package version wins. A different version in an active
+  review is cancelled and promoted to the new version before submission. The
+  workflow fails closed if multiple active reviews or a newer App Store version
+  make that choice ambiguous.
+- An exact target version already in review or live remains read-only and
+  returns success. Terminal Apple rejections remain manual recovery states.
 - A terminal workflow failure opens or updates the single
   `Apple release v<version>` GitHub issue with the workflow link, redacted asc
   status, doctor remediation, and the exact rerun command.

--- a/apps/safari-extension/release.md
+++ b/apps/safari-extension/release.md
@@ -14,32 +14,36 @@ patch bump merged to `main` is the only normal manual release action. Root
    reuses successful or active child runs and dispatches only missing work.
 3. The workflow verifies the tag, Xcode project, asc version, and App Store
    Connect credentials.
-4. asc finds or creates the `MAC_OS` App Store version, copies localization
+4. The package version is authoritative. If an older Safari version is waiting
+   for or currently in App Review, asc cancels that superseded submission,
+   waits for Apple to make it editable, and updates the same version record to
+   the new package version. Dry runs only report the replacement plan.
+5. asc finds or creates the `MAC_OS` App Store version, copies localization
    metadata from the prior live macOS version without copying What's New,
    applies the generic note, preserves review details and the existing age
    rating declaration, sparsely completes Apple's new social-media age-rating
    fields, and sets `AFTER_APPROVAL`.
-5. For a new build, asc resolves or creates the Mac App Distribution and Mac
+6. For a new build, asc resolves or creates the Mac App Distribution and Mac
    Installer Distribution certificates that match the repository's private key,
    then resolves, creates, and downloads the two Mac App Store provisioning
    profiles. The private key and certificates live only in the runner's secure
    temporary keychain.
-6. Xcode archives and exports
+7. Xcode archives and exports
    `teak-safari-<version>-mac-app-store.pkg` without changing the stable app,
    extension, App Group, native-messaging, or keychain identifiers.
-7. The macOS job publishes the signed PKG and a SHA-256 handoff descriptor as a
+8. The macOS job publishes the signed PKG and a SHA-256 handoff descriptor as a
    one-day private Actions artifact. An Ubuntu job verifies the digest before
    continuing.
-8. `asc builds upload --pkg --wait` uploads the PKG from Ubuntu. The workflow resolves the
+9. `asc builds upload --pkg --wait` uploads the PKG from Ubuntu. The workflow resolves the
    exact returned marketing-version/build-number pair and requires one `VALID`
    `MAC_OS` build.
-9. The PKG is attached to the matching GitHub Release. asc attaches the exact
+10. The PKG is attached to the matching GitHub Release. asc attaches the exact
    Apple build, validates readiness, runs review doctor, and submits it directly
    to App Review.
-10. A separate read-only proof pass verifies the exact version, platform,
+11. A separate read-only proof pass verifies the exact version, platform,
     attached `VALID` build, submission, `AFTER_APPROVAL`, and review state. It
     writes `teak-safari-<version>-app-store.json` to the GitHub Release.
-11. The workflow succeeds only after Safari macOS reaches `WAITING_FOR_REVIEW`
+12. The workflow succeeds only after Safari macOS reaches `WAITING_FOR_REVIEW`
     or a later valid state.
 
 The release note is:
@@ -59,8 +63,12 @@ gh workflow run safari-extension-release.yml --ref main -f "version=$version" -f
   build only when the matching labeled GitHub PKG and release manifest exist.
 - The workflow addresses only `MAC_OS`; unrelated iOS version records are
   ignored.
-- In-review or already-live versions are read-only. Rejected versions are never
-  resubmitted or modified automatically.
+- The newest lockstep package version wins. All Safari App Store mutations are
+  serialized across versions. A different Safari version in an active review is
+  cancelled and promoted to the new version. Ambiguous active reviews or a newer
+  App Store version fail closed.
+- An exact target version already in review or live remains read-only. Terminal
+  Apple rejections remain manual recovery states.
 - A terminal failure opens or updates the same version-scoped Apple release
   issue used by iOS. The scheduled status workflow checks every open release
   issue and closes it only when both ASC states are live and both public

--- a/scripts/apple-latest-review.mjs
+++ b/scripts/apple-latest-review.mjs
@@ -113,8 +113,9 @@ export function planLatestReviewVersion(response, targetVersion) {
     (candidate) =>
       candidate.version !== targetVersion && reusableStates.has(candidate.state)
   );
-  const superseded =
-    activeOlder[0] ?? (target ? undefined : newest(reusableOlder));
+  const superseded = completedStates.has(target?.state)
+    ? undefined
+    : (activeOlder[0] ?? (target ? undefined : newest(reusableOlder)));
   const source = newest(
     versions.filter(
       (candidate) =>

--- a/scripts/apple-latest-review.mjs
+++ b/scripts/apple-latest-review.mjs
@@ -1,0 +1,294 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { parseVersion } from "./release-version.mjs";
+
+const cancellableStates = new Set([
+  "IN_REVIEW",
+  "PENDING_APPLE_RELEASE",
+  "PENDING_DEVELOPER_RELEASE",
+  "WAITING_FOR_EXPORT_COMPLIANCE",
+  "WAITING_FOR_REVIEW",
+]);
+const reusableStates = new Set([
+  "DEVELOPER_REJECTED",
+  "PREPARE_FOR_SUBMISSION",
+  "READY_FOR_REVIEW",
+]);
+const releasedStates = new Set([
+  "PROCESSING_FOR_DISTRIBUTION",
+  "READY_FOR_DISTRIBUTION",
+  "READY_FOR_SALE",
+]);
+const completedStates = new Set([
+  "IN_REVIEW",
+  "PENDING_APPLE_RELEASE",
+  "PENDING_DEVELOPER_RELEASE",
+  "PROCESSING_FOR_DISTRIBUTION",
+  "READY_FOR_DISTRIBUTION",
+  "READY_FOR_SALE",
+  "WAITING_FOR_EXPORT_COMPLIANCE",
+  "WAITING_FOR_REVIEW",
+]);
+const mutableStates = new Set([
+  "",
+  "DEVELOPER_REJECTED",
+  "PREPARE_FOR_SUBMISSION",
+  "READY_FOR_REVIEW",
+]);
+
+function compareVersions(left, right) {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] !== b[index]) {
+      return a[index] - b[index];
+    }
+  }
+  return 0;
+}
+
+function normalizeVersion(resource) {
+  const attributes = resource?.attributes ?? {};
+  const version = attributes.versionString;
+  if (typeof resource?.id !== "string" || typeof version !== "string") {
+    throw new Error(
+      "Every App Store version must have an id and versionString."
+    );
+  }
+  parseVersion(version);
+  return {
+    id: resource.id,
+    state: attributes.appVersionState ?? attributes.appStoreState ?? "",
+    version,
+  };
+}
+
+function newest(versions) {
+  return versions.toSorted((left, right) =>
+    compareVersions(right.version, left.version)
+  )[0];
+}
+
+export function planLatestReviewVersion(response, targetVersion) {
+  parseVersion(targetVersion);
+  if (!Array.isArray(response?.data)) {
+    throw new Error(
+      "Expected an App Store versions response with a data array."
+    );
+  }
+  const versions = response.data.map(normalizeVersion);
+  const newer = versions.find(
+    (candidate) => compareVersions(candidate.version, targetVersion) > 0
+  );
+  if (newer) {
+    throw new Error(
+      `App Store version ${newer.version} is newer than requested ${targetVersion}.`
+    );
+  }
+
+  const targets = versions.filter(
+    (candidate) => candidate.version === targetVersion
+  );
+  if (targets.length > 1) {
+    throw new Error(`Multiple App Store versions match ${targetVersion}.`);
+  }
+  const target = targets[0];
+  const activeOlder = versions.filter(
+    (candidate) =>
+      candidate.version !== targetVersion &&
+      cancellableStates.has(candidate.state)
+  );
+  if (activeOlder.length > 1) {
+    throw new Error(
+      `Multiple older App Store versions have active reviews: ${activeOlder
+        .map((candidate) => `${candidate.version}/${candidate.state}`)
+        .join(", ")}.`
+    );
+  }
+
+  const reusableOlder = versions.filter(
+    (candidate) =>
+      candidate.version !== targetVersion && reusableStates.has(candidate.state)
+  );
+  const superseded =
+    activeOlder[0] ?? (target ? undefined : newest(reusableOlder));
+  const source = newest(
+    versions.filter(
+      (candidate) =>
+        candidate.version !== targetVersion &&
+        releasedStates.has(candidate.state)
+    )
+  );
+
+  return {
+    cancelSuperseded: Boolean(
+      superseded && cancellableStates.has(superseded.state)
+    ),
+    promoteSuperseded: Boolean(superseded && !target),
+    sourceVersion: source?.version ?? "",
+    supersededId: superseded?.id ?? "",
+    supersededState: superseded?.state ?? "",
+    supersededVersion: superseded?.version ?? "",
+    targetId: target?.id ?? "",
+    targetState: target?.state ?? "",
+  };
+}
+
+function runAsc(args) {
+  const result = spawnSync("asc", [...args, "--output", "json"], {
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `asc ${args.join(" ")} failed: ${(result.stderr || result.stdout).trim()}`
+    );
+  }
+  return result.stdout.trim() ? JSON.parse(result.stdout) : {};
+}
+
+const wait = (milliseconds) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+async function waitForCancellation(versionId, runCommand, waitCommand) {
+  const deadline = Date.now() + 10 * 60 * 1000;
+  while (Date.now() < deadline) {
+    const version = runCommand(["versions", "view", "--version-id", versionId]);
+    if (reusableStates.has(version.state)) {
+      return version;
+    }
+    await waitCommand(15_000);
+  }
+  throw new Error(
+    `Timed out waiting for App Store version ${versionId} cancellation.`
+  );
+}
+
+function mutationForState(state) {
+  if (mutableStates.has(state)) {
+    return true;
+  }
+  if (completedStates.has(state)) {
+    return false;
+  }
+  throw new Error(`Refusing to mutate App Store version in state: ${state}`);
+}
+
+export async function applyLatestReviewVersion({
+  appId,
+  dryRun,
+  platform,
+  response,
+  runCommand = runAsc,
+  targetVersion,
+  waitCommand = wait,
+}) {
+  const plan = planLatestReviewVersion(response, targetVersion);
+  if (dryRun) {
+    return { ...plan, mutate: false };
+  }
+
+  if (plan.cancelSuperseded) {
+    runCommand([
+      "submit",
+      "cancel",
+      "--version-id",
+      plan.supersededId,
+      "--app",
+      appId,
+      "--confirm",
+    ]);
+    await waitForCancellation(plan.supersededId, runCommand, waitCommand);
+  }
+
+  let targetId = plan.targetId;
+  let targetState = plan.targetState;
+  if (plan.promoteSuperseded) {
+    runCommand([
+      "versions",
+      "update",
+      "--version-id",
+      plan.supersededId,
+      "--version",
+      targetVersion,
+      "--release-type",
+      "AFTER_APPROVAL",
+    ]);
+    const exact = runCommand([
+      "versions",
+      "list",
+      "--app",
+      appId,
+      "--platform",
+      platform,
+      "--version",
+      targetVersion,
+      "--limit",
+      "2",
+    ]).data;
+    if (exact?.length !== 1 || exact[0].id !== plan.supersededId) {
+      throw new Error(
+        `App Store did not promote exactly one version to ${targetVersion}.`
+      );
+    }
+    targetId = exact[0].id;
+    targetState =
+      exact[0].attributes?.appVersionState ??
+      exact[0].attributes?.appStoreState ??
+      "";
+  }
+
+  return {
+    ...plan,
+    mutate: mutationForState(targetState),
+    targetId,
+    targetState,
+  };
+}
+
+function usage() {
+  throw new Error(
+    "Usage: node scripts/apple-latest-review.mjs plan <versions-json> <target-version> | apply <versions-json> <target-version> <app-id> <platform> <dry-run>"
+  );
+}
+
+async function main() {
+  const [command, inputPath, targetVersion, appId, platform, dryRun] =
+    process.argv.slice(2);
+  if (!(inputPath && targetVersion)) {
+    usage();
+  }
+  const response = JSON.parse(fs.readFileSync(inputPath, "utf8"));
+  if (command === "plan" && !appId) {
+    process.stdout.write(
+      `${JSON.stringify(planLatestReviewVersion(response, targetVersion))}\n`
+    );
+    return;
+  }
+  if (
+    command !== "apply" ||
+    !appId ||
+    !platform ||
+    !["true", "false"].includes(dryRun)
+  ) {
+    usage();
+  }
+  const result = await applyLatestReviewVersion({
+    appId,
+    dryRun: dryRun === "true",
+    platform,
+    response,
+    targetVersion,
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/apple-latest-review.mjs
+++ b/scripts/apple-latest-review.mjs
@@ -113,9 +113,10 @@ export function planLatestReviewVersion(response, targetVersion) {
     (candidate) =>
       candidate.version !== targetVersion && reusableStates.has(candidate.state)
   );
-  const superseded = completedStates.has(target?.state)
-    ? undefined
-    : (activeOlder[0] ?? (target ? undefined : newest(reusableOlder)));
+  const superseded =
+    target && !mutableStates.has(target.state)
+      ? undefined
+      : (activeOlder[0] ?? (target ? undefined : newest(reusableOlder)));
   const source = newest(
     versions.filter(
       (candidate) =>
@@ -194,12 +195,11 @@ export async function applyLatestReviewVersion({
   waitCommand = wait,
 }) {
   const plan = planLatestReviewVersion(response, targetVersion);
-  if (dryRun) {
-    return { ...plan, mutate: false };
-  }
-
   if (plan.targetId) {
     mutationForState(plan.targetState, false);
+  }
+  if (dryRun) {
+    return { ...plan, mutate: false };
   }
 
   if (plan.cancelSuperseded) {

--- a/scripts/apple-latest-review.mjs
+++ b/scripts/apple-latest-review.mjs
@@ -12,11 +12,12 @@ const cancellableStates = new Set([
   "WAITING_FOR_EXPORT_COMPLIANCE",
   "WAITING_FOR_REVIEW",
 ]);
-const reusableStates = new Set([
+const cancellationReadyStates = new Set([
   "DEVELOPER_REJECTED",
   "PREPARE_FOR_SUBMISSION",
   "READY_FOR_REVIEW",
 ]);
+const reusableStates = new Set(["PREPARE_FOR_SUBMISSION", "READY_FOR_REVIEW"]);
 const releasedStates = new Set([
   "PROCESSING_FOR_DISTRIBUTION",
   "READY_FOR_DISTRIBUTION",
@@ -34,7 +35,6 @@ const completedStates = new Set([
 ]);
 const mutableStates = new Set([
   "",
-  "DEVELOPER_REJECTED",
   "PREPARE_FOR_SUBMISSION",
   "READY_FOR_REVIEW",
 ]);
@@ -160,7 +160,7 @@ async function waitForCancellation(versionId, runCommand, waitCommand) {
   const deadline = Date.now() + 10 * 60 * 1000;
   while (Date.now() < deadline) {
     const version = runCommand(["versions", "view", "--version-id", versionId]);
-    if (reusableStates.has(version.state)) {
+    if (cancellationReadyStates.has(version.state)) {
       return version;
     }
     await waitCommand(15_000);
@@ -170,8 +170,11 @@ async function waitForCancellation(versionId, runCommand, waitCommand) {
   );
 }
 
-function mutationForState(state) {
+function mutationForState(state, allowCancelledDeveloperRejection) {
   if (mutableStates.has(state)) {
+    return true;
+  }
+  if (state === "DEVELOPER_REJECTED" && allowCancelledDeveloperRejection) {
     return true;
   }
   if (completedStates.has(state)) {
@@ -246,7 +249,10 @@ export async function applyLatestReviewVersion({
 
   return {
     ...plan,
-    mutate: mutationForState(targetState),
+    mutate: mutationForState(
+      targetState,
+      plan.cancelSuperseded && plan.promoteSuperseded
+    ),
     targetId,
     targetState,
   };

--- a/scripts/apple-latest-review.mjs
+++ b/scripts/apple-latest-review.mjs
@@ -197,6 +197,10 @@ export async function applyLatestReviewVersion({
     return { ...plan, mutate: false };
   }
 
+  if (plan.targetId) {
+    mutationForState(plan.targetState, false);
+  }
+
   if (plan.cancelSuperseded) {
     runCommand([
       "submit",

--- a/scripts/apple-latest-review.test.ts
+++ b/scripts/apple-latest-review.test.ts
@@ -74,21 +74,28 @@ describe("latest Apple review planning", () => {
   });
 
   test("refuses to resubmit an exact developer-rejected target", async () => {
+    let called = false;
     await expect(
       applyLatestReviewVersion({
         appId: "app-id",
         dryRun: false,
         platform: "IOS",
         response: response([
+          { id: "old", state: "IN_REVIEW", version: "1.0.60" },
           {
             id: "rejected",
             state: "DEVELOPER_REJECTED",
             version: "1.0.61",
           },
         ]),
+        runCommand: () => {
+          called = true;
+          return {};
+        },
         targetVersion: "1.0.61",
       })
     ).rejects.toThrow("Refusing to mutate App Store version");
+    expect(called).toBe(false);
   });
 
   test("leaves the requested version alone when it is already in review", () => {

--- a/scripts/apple-latest-review.test.ts
+++ b/scripts/apple-latest-review.test.ts
@@ -98,6 +98,25 @@ describe("latest Apple review planning", () => {
     expect(called).toBe(false);
   });
 
+  test("does not report a rejected target as a valid dry run", async () => {
+    await expect(
+      applyLatestReviewVersion({
+        appId: "app-id",
+        dryRun: true,
+        platform: "IOS",
+        response: response([
+          { id: "old", state: "IN_REVIEW", version: "1.0.60" },
+          {
+            id: "rejected",
+            state: "DEVELOPER_REJECTED",
+            version: "1.0.61",
+          },
+        ]),
+        targetVersion: "1.0.61",
+      })
+    ).rejects.toThrow("Refusing to mutate App Store version");
+  });
+
   test("leaves the requested version alone when it is already in review", () => {
     const plan = planLatestReviewVersion(
       response([

--- a/scripts/apple-latest-review.test.ts
+++ b/scripts/apple-latest-review.test.ts
@@ -110,6 +110,33 @@ describe("latest Apple review planning", () => {
     expect(plan.targetState).toBe("WAITING_FOR_REVIEW");
   });
 
+  test("does not cancel another review when the exact target is active", async () => {
+    for (const state of ["WAITING_FOR_REVIEW", "IN_REVIEW"]) {
+      let called = false;
+      const result = await applyLatestReviewVersion({
+        appId: "app-id",
+        dryRun: false,
+        platform: "IOS",
+        response: response([
+          { id: "old", state: "IN_REVIEW", version: "1.0.60" },
+          { id: "target", state, version: "1.0.61" },
+        ]),
+        runCommand: () => {
+          called = true;
+          return {};
+        },
+        targetVersion: "1.0.61",
+      });
+      expect(called).toBe(false);
+      expect(result).toMatchObject({
+        cancelSuperseded: false,
+        mutate: false,
+        supersededId: "",
+        targetState: state,
+      });
+    }
+  });
+
   test("fails closed for ambiguous or non-latest requests", () => {
     expect(() =>
       planLatestReviewVersion(

--- a/scripts/apple-latest-review.test.ts
+++ b/scripts/apple-latest-review.test.ts
@@ -62,6 +62,35 @@ describe("latest Apple review planning", () => {
     expect(plan.supersededId).toBe("newer");
   });
 
+  test("does not promote a pre-existing developer-rejected version", () => {
+    const plan = planLatestReviewVersion(
+      response([
+        { id: "rejected", state: "DEVELOPER_REJECTED", version: "1.0.60" },
+      ]),
+      "1.0.61"
+    );
+    expect(plan.promoteSuperseded).toBe(false);
+    expect(plan.supersededId).toBe("");
+  });
+
+  test("refuses to resubmit an exact developer-rejected target", async () => {
+    await expect(
+      applyLatestReviewVersion({
+        appId: "app-id",
+        dryRun: false,
+        platform: "IOS",
+        response: response([
+          {
+            id: "rejected",
+            state: "DEVELOPER_REJECTED",
+            version: "1.0.61",
+          },
+        ]),
+        targetVersion: "1.0.61",
+      })
+    ).rejects.toThrow("Refusing to mutate App Store version");
+  });
+
   test("leaves the requested version alone when it is already in review", () => {
     const plan = planLatestReviewVersion(
       response([

--- a/scripts/apple-latest-review.test.ts
+++ b/scripts/apple-latest-review.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  applyLatestReviewVersion,
+  planLatestReviewVersion,
+} from "./apple-latest-review.mjs";
+
+const response = (
+  versions: Array<{ id: string; state: string; version: string }>
+) => ({
+  data: versions.map(({ id, state, version }) => ({
+    attributes: { appVersionState: state, versionString: version },
+    id,
+  })),
+});
+
+describe("latest Apple review planning", () => {
+  test("cancels and promotes the one older in-flight version", () => {
+    expect(
+      planLatestReviewVersion(
+        response([
+          { id: "live", state: "READY_FOR_SALE", version: "1.0.58" },
+          { id: "old", state: "WAITING_FOR_REVIEW", version: "1.0.60" },
+        ]),
+        "1.0.61"
+      )
+    ).toEqual({
+      cancelSuperseded: true,
+      promoteSuperseded: true,
+      sourceVersion: "1.0.58",
+      supersededId: "old",
+      supersededState: "WAITING_FOR_REVIEW",
+      supersededVersion: "1.0.60",
+      targetId: "",
+      targetState: "",
+    });
+  });
+
+  test("cancels an older review without replacing an existing target", () => {
+    const plan = planLatestReviewVersion(
+      response([
+        { id: "old", state: "IN_REVIEW", version: "1.0.60" },
+        { id: "target", state: "PREPARE_FOR_SUBMISSION", version: "1.0.61" },
+      ]),
+      "1.0.61"
+    );
+    expect(plan.cancelSuperseded).toBe(true);
+    expect(plan.promoteSuperseded).toBe(false);
+    expect(plan.targetId).toBe("target");
+  });
+
+  test("reuses the newest editable version when no review is active", () => {
+    const plan = planLatestReviewVersion(
+      response([
+        { id: "older", state: "DEVELOPER_REJECTED", version: "1.0.59" },
+        { id: "newer", state: "READY_FOR_REVIEW", version: "1.0.60" },
+      ]),
+      "1.0.61"
+    );
+    expect(plan.cancelSuperseded).toBe(false);
+    expect(plan.promoteSuperseded).toBe(true);
+    expect(plan.supersededId).toBe("newer");
+  });
+
+  test("leaves the requested version alone when it is already in review", () => {
+    const plan = planLatestReviewVersion(
+      response([
+        { id: "target", state: "WAITING_FOR_REVIEW", version: "1.0.61" },
+      ]),
+      "1.0.61"
+    );
+    expect(plan.cancelSuperseded).toBe(false);
+    expect(plan.promoteSuperseded).toBe(false);
+    expect(plan.targetState).toBe("WAITING_FOR_REVIEW");
+  });
+
+  test("fails closed for ambiguous or non-latest requests", () => {
+    expect(() =>
+      planLatestReviewVersion(
+        response([
+          { id: "one", state: "WAITING_FOR_REVIEW", version: "1.0.59" },
+          { id: "two", state: "IN_REVIEW", version: "1.0.60" },
+        ]),
+        "1.0.61"
+      )
+    ).toThrow("Multiple older App Store versions");
+    expect(() =>
+      planLatestReviewVersion(
+        response([{ id: "newer", state: "READY_FOR_SALE", version: "1.0.62" }]),
+        "1.0.61"
+      )
+    ).toThrow("newer than requested");
+  });
+
+  test("cancels, waits, renames, and verifies before returning mutation state", async () => {
+    const commands: string[][] = [];
+    let viewCount = 0;
+    const result = await applyLatestReviewVersion({
+      appId: "app-id",
+      dryRun: false,
+      platform: "IOS",
+      response: response([
+        { id: "old", state: "WAITING_FOR_REVIEW", version: "1.0.60" },
+      ]),
+      runCommand: (command: string[]) => {
+        commands.push(command);
+        if (command[0] === "submit") {
+          return { cancelled: true, id: "submission-id" };
+        }
+        if (command[1] === "view") {
+          viewCount += 1;
+          return {
+            id: "old",
+            state: viewCount === 1 ? "CANCELING" : "DEVELOPER_REJECTED",
+            versionString: "1.0.60",
+          };
+        }
+        if (command[1] === "update") {
+          return { id: "old", state: "DEVELOPER_REJECTED" };
+        }
+        return response([
+          { id: "old", state: "DEVELOPER_REJECTED", version: "1.0.61" },
+        ]);
+      },
+      targetVersion: "1.0.61",
+      waitCommand: () => Promise.resolve(),
+    });
+
+    expect(commands[0]).toEqual([
+      "submit",
+      "cancel",
+      "--version-id",
+      "old",
+      "--app",
+      "app-id",
+      "--confirm",
+    ]);
+    expect(commands.some((command) => command[1] === "update")).toBe(true);
+    expect(result).toMatchObject({
+      mutate: true,
+      targetId: "old",
+      targetState: "DEVELOPER_REJECTED",
+    });
+  });
+
+  test("dry runs report replacement without calling App Store Connect", async () => {
+    let called = false;
+    const result = await applyLatestReviewVersion({
+      appId: "app-id",
+      dryRun: true,
+      platform: "MAC_OS",
+      response: response([
+        { id: "old", state: "IN_REVIEW", version: "1.0.60" },
+      ]),
+      runCommand: () => {
+        called = true;
+        return {};
+      },
+      targetVersion: "1.0.61",
+    });
+    expect(called).toBe(false);
+    expect(result).toMatchObject({
+      cancelSuperseded: true,
+      mutate: false,
+      promoteSuperseded: true,
+    });
+  });
+});

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -21,6 +21,7 @@ describe("Apple release workflows", () => {
   const safari = read(".github/workflows/safari-extension-release.yml");
   const status = read(".github/workflows/apple-release-status.yml");
   const issueHelper = read("scripts/apple-release-issue.mjs");
+  const latestReview = read("scripts/apple-latest-review.mjs");
   const versionTag = read(".github/workflows/version-tag.yml");
   const productReleases = [
     read(".github/workflows/cli-release.yml"),
@@ -61,10 +62,7 @@ describe("Apple release workflows", () => {
       mobile,
       "Download verified signed IPA handoff"
     );
-    const verifyHandoff = workflowStep(
-      mobile,
-      "Verify signed IPA handoff"
-    );
+    const verifyHandoff = workflowStep(mobile, "Verify signed IPA handoff");
     const sentryAnalysis = workflowStep(
       mobile,
       "Upload IPA to mandatory Sentry Size Analysis on Apple Silicon"
@@ -124,14 +122,21 @@ describe("Apple release workflows", () => {
     );
   });
 
-  test("serializes app-wide iOS build-number allocation through upload", () => {
+  test("serializes app-wide Apple mutations across versions", () => {
     expect(mobile).toContain(
       `group: mobile-app-store-ios-${expression("github.repository")}`
     );
     expect(mobile).not.toContain(
       `group: mobile-app-store-${expression("inputs.version")}`
     );
+    expect(safari).toContain(
+      `group: safari-app-store-${expression("github.repository")}`
+    );
+    expect(safari).not.toContain(
+      `group: safari-app-store-${expression("inputs.version")}`
+    );
     expect(mobile).toContain("cancel-in-progress: false");
+    expect(safari).toContain("cancel-in-progress: false");
   });
 
   test("hands a signed Safari PKG to an isolated Ubuntu submission job", () => {
@@ -235,6 +240,25 @@ describe("Apple release workflows", () => {
     expect(status).toContain('--safari-store-version "$safari_store"');
   });
 
+  test("makes the newest package version replace an older Apple review", () => {
+    for (const workflow of [mobile, safari]) {
+      const releaseState = workflowStep(
+        workflow,
+        "Resolve current Apple release state"
+      );
+      expect(releaseState).toContain(
+        'node scripts/apple-latest-review.mjs apply "$versions_json" "$VERSION" "$ASC_APP_ID" "$PLATFORM" "$DRY_RUN"'
+      );
+      expect(releaseState).toContain('echo "target_id=$target_id"');
+      expect(releaseState).toContain('echo "mutate=$mutate"');
+    }
+    expect(latestReview).toContain('"submit",\n      "cancel"');
+    expect(latestReview).toContain('"versions",\n      "update"');
+    expect(latestReview).toContain('"--version",\n      targetVersion');
+    expect(latestReview).toContain("Multiple older App Store versions");
+    expect(latestReview).toContain("newer than requested");
+  });
+
   test("publishes replayable proof manifests after exact read-only verification", () => {
     for (const workflow of [mobile, safari]) {
       expect(workflow).toContain("apple-release-proof.mjs verify");
@@ -283,10 +307,6 @@ describe("Apple release workflows", () => {
             '`;
 
     for (const workflow of [mobile, safari]) {
-      expect(workflow).toContain('""|PREPARE_FOR_SUBMISSION|READY_FOR_REVIEW)');
-      expect(workflow).not.toContain(
-        "WAITING_FOR_REVIEW|READY_FOR_REVIEW|IN_REVIEW"
-      );
       expect(workflow.split(exactAttachRecovery)).toHaveLength(2);
       expect(workflow).toContain(
         'asc versions view --version-id "$VERSION_ID" --include-build'


### PR DESCRIPTION
## Summary
- make the lockstep package version authoritative for iOS and Safari App Store review
- cancel one superseded active review, wait for Apple to unlock it, promote that version record, and resume submission
- serialize Apple mutations across versions and fail closed for ambiguous or newer App Store state
- document and test the latest-version-wins recovery path

## Verification
- `bun test scripts/apple-*.test.ts` (37 pass)
- pre-commit: affected typecheck, lint, and mobile build
- `bun x ultracite check scripts/apple-latest-review.mjs scripts/apple-latest-review.test.ts scripts/apple-workflows.test.ts`
- `git diff --check`