### PR TITLE
Require provenance before Apple build reuse

### DIFF
--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -168,6 +168,8 @@ jobs:
       - name: Reuse an exact valid build or allocate the next Apple build number
         id: build_state
         if: steps.release_state.outputs.mutate == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           exact_builds="$RUNNER_TEMP/apple-ios-exact-builds.json"
           asc builds list \
@@ -181,12 +183,20 @@ jobs:
             --output json > "$exact_builds"
           build_id="$(jq -r '.data[0].id // empty' "$exact_builds")"
           build_number="$(jq -r '.data[0].attributes.version // empty' "$exact_builds")"
+          manifest="$RUNNER_TEMP/ios-reuse-manifest.json"
+          manifest_name="teak-ios-$VERSION-app-store.json"
 
-          if [ -n "$build_id" ]; then
+          if [ -n "$build_id" ] && gh release download "v$VERSION" --pattern "$manifest_name" --output "$manifest" 2>/dev/null; then
+            if ! jq -e --arg id "$build_id" --arg number "$build_number" \
+              '.build.id == $id and .build.number == $number and .artifact.sha256 != "" and .sentrySizeAnalysis == "success"' "$manifest" > /dev/null; then
+              echo "The canonical iOS manifest does not prove the exact reusable build." >&2
+              exit 1
+            fi
             reuse=true
-            echo "Reusing VALID App Store Connect build $build_id ($VERSION/$build_number)."
+            echo "Reusing manifest-proven VALID App Store Connect build $build_id ($VERSION/$build_number)."
           else
             reuse=false
+            build_id=""
             all_builds="$RUNNER_TEMP/apple-ios-all-builds.json"
             asc builds list --app "$ASC_APP_ID" --platform "$PLATFORM" --paginate --output json > "$all_builds"
             build_number="$(node scripts/apple-build-number.mjs "$all_builds")"

--- a/.github/workflows/safari-extension-release.yml
+++ b/.github/workflows/safari-extension-release.yml
@@ -179,10 +179,16 @@ jobs:
           asset_label="App Store build $build_number"
           manifest="$RUNNER_TEMP/safari-reuse-manifest.json"
           manifest_name="teak-safari-$VERSION-app-store.json"
+          reusable_pkg="$RUNNER_TEMP/safari-reuse.pkg"
           existing_label="$(gh release view "v$VERSION" --json assets --jq ".assets[] | select(.name == \"$asset\") | .label" 2>/dev/null || true)"
-          if [ -n "$build_id" ] && [ "$existing_label" = "$asset_label" ] && gh release download "v$VERSION" --pattern "$manifest_name" --output "$manifest" 2>/dev/null; then
+          if [ -n "$build_id" ] && [ "$existing_label" = "$asset_label" ] && \
+            gh release download "v$VERSION" --pattern "$manifest_name" --output "$manifest" 2>/dev/null && \
+            gh release download "v$VERSION" --pattern "$asset" --output "$reusable_pkg" 2>/dev/null; then
+            expected_sha="$(jq -r '.artifact.sha256 // empty' "$manifest")"
+            actual_sha="$(shasum -a 256 "$reusable_pkg" | awk '{print $1}')"
             if ! jq -e --arg id "$build_id" --arg number "$build_number" \
-              '.build.id == $id and .build.number == $number and .artifact.sha256 != ""' "$manifest" > /dev/null; then
+              '.build.id == $id and .build.number == $number' "$manifest" > /dev/null || \
+              [ -z "$expected_sha" ] || [ "$actual_sha" != "$expected_sha" ]; then
               echo "The canonical Safari manifest does not prove the exact reusable build." >&2
               exit 1
             fi

--- a/.github/workflows/safari-extension-release.yml
+++ b/.github/workflows/safari-extension-release.yml
@@ -177,12 +177,20 @@ jobs:
           build_id="$(jq -r '.data[0].id // empty' "$RUNNER_TEMP/safari-existing-build.json")"
           build_number="$(jq -r '.data[0].attributes.version // empty' "$RUNNER_TEMP/safari-existing-build.json")"
           asset_label="App Store build $build_number"
+          manifest="$RUNNER_TEMP/safari-reuse-manifest.json"
+          manifest_name="teak-safari-$VERSION-app-store.json"
           existing_label="$(gh release view "v$VERSION" --json assets --jq ".assets[] | select(.name == \"$asset\") | .label" 2>/dev/null || true)"
-          if [ -n "$build_id" ] && [ "$existing_label" = "$asset_label" ]; then
+          if [ -n "$build_id" ] && [ "$existing_label" = "$asset_label" ] && gh release download "v$VERSION" --pattern "$manifest_name" --output "$manifest" 2>/dev/null; then
+            if ! jq -e --arg id "$build_id" --arg number "$build_number" \
+              '.build.id == $id and .build.number == $number and .artifact.sha256 != ""' "$manifest" > /dev/null; then
+              echo "The canonical Safari manifest does not prove the exact reusable build." >&2
+              exit 1
+            fi
             reuse=true
-            echo "Reusing VALID Safari build $build_id and its exact GitHub PKG asset."
+            echo "Reusing manifest-proven VALID Safari build $build_id and its exact GitHub PKG asset."
           else
             reuse=false
+            build_id=""
             asc builds next-build-number --app "$ASC_APP_ID" --platform "$PLATFORM" --output json > "$RUNNER_TEMP/safari-next-build.json"
             build_number="$(jq -r '.nextBuildNumber // empty' "$RUNNER_TEMP/safari-next-build.json")"
             if [ -z "$build_number" ]; then

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -287,9 +287,8 @@ describe("Apple release workflows", () => {
     expect(safari).toContain(
       'manifest_name="teak-safari-$VERSION-app-store.json"'
     );
-    expect(safari).toContain(
-      '.build.id == $id and .build.number == $number and .artifact.sha256 != ""'
-    );
+    expect(safari).toContain('actual_sha="$(shasum -a 256 "$reusable_pkg"');
+    expect(safari).toContain('[ "$actual_sha" != "$expected_sha" ]');
     for (const workflow of [mobile, safari]) {
       expect(workflow).toContain('reuse=false\n            build_id=""');
     }

--- a/scripts/apple-workflows.test.ts
+++ b/scripts/apple-workflows.test.ts
@@ -277,6 +277,24 @@ describe("Apple release workflows", () => {
     );
   });
 
+  test("reuses Apple builds only with exact canonical provenance", () => {
+    expect(mobile).toContain(
+      'manifest_name="teak-ios-$VERSION-app-store.json"'
+    );
+    expect(mobile).toContain(
+      '.build.id == $id and .build.number == $number and .artifact.sha256 != "" and .sentrySizeAnalysis == "success"'
+    );
+    expect(safari).toContain(
+      'manifest_name="teak-safari-$VERSION-app-store.json"'
+    );
+    expect(safari).toContain(
+      '.build.id == $id and .build.number == $number and .artifact.sha256 != ""'
+    );
+    for (const workflow of [mobile, safari]) {
+      expect(workflow).toContain('reuse=false\n            build_id=""');
+    }
+  });
+
   test("pins every third-party action in the Apple release workflows", () => {
     const mutableAction = /^\s*uses:\s*[^./\s][^\s]*@(v\d+|main|master)\s*$/m;
     for (const workflow of [


### PR DESCRIPTION
## Summary
- reuse iOS and Safari App Store builds only when the canonical manifest proves the exact build and artifact
- require successful iOS Sentry analysis in reused-build provenance
- clear stale Apple build IDs before allocating and uploading a replacement build
- add workflow regression coverage for both release paths

## Verification
- `bun test scripts/apple-*.test.ts` (42 pass)
- pre-commit affected typecheck, lint, and mobile build
- Ultracite check and `git diff --check`