### PR TITLE
fix: restore PDF thumbnails and center toast icons

### DIFF
--- a/apps/docs/content/changelog/august-2026.mdx
+++ b/apps/docs/content/changelog/august-2026.mdx
@@ -10,3 +10,5 @@ changelog:
 - Saved-card links, page reloads, and Markdown file uploads now finish reliably across the web app and browser extension.
 - The iPhone and iPad apps no longer close immediately on launch, and search, refresh, card opening, and image-heavy libraries load more quickly.
 - Continue with Apple now completes sign-in reliably on the web and in Teak for Safari.
+- Uploaded PDFs show their first page as the card preview in the grid again.
+- Notification banners now keep their icon, message, and close button centered together.

--- a/packages/convex/__tests__/workflows/steps/renderables/generatePdfThumbnail.test.ts
+++ b/packages/convex/__tests__/workflows/steps/renderables/generatePdfThumbnail.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { beforeAll, describe, expect, mock, test } from "bun:test";
+import { crc32, deflateSync, inflateSync } from "node:zlib";
 
 // Captured across the mocked Kernel + storage layer so the assertions can
 // inspect exactly how the PDF thumbnail was produced.
@@ -9,6 +10,226 @@ let storedThumbnail: { key: string; type?: string } | null = null;
 let generatePdfThumbnail: any;
 
 const THUMB_PNG_BASE64 = Buffer.from("fake-png").toString("base64");
+
+// Minimal valid one-page A4 PDF (qpdf-checked) used as the fixture bytes that
+// flow through the generated browser code.
+const FIXTURE_PDF_BASE64 =
+  "JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCA1OTUuMjggODQxLjg5XSAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA0IDAgUiA+PiA+PiAvQ29udGVudHMgNSAwIFIgPj4KZW5kb2JqCjQgMCBvYmoKPDwgL1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1R5cGUxIC9CYXNlRm9udCAvSGVsdmV0aWNhID4+CmVuZG9iago1IDAgb2JqCjw8IC9MZW5ndGggNDkgPj4Kc3RyZWFtCkJUIC9GMSAyNCBUZiA3MiA3MjAgVGQgKFBERiBUSFVNQk5BSUwgVEVTVCkgVGogRVQKZW5kc3RyZWFtCmVuZG9iagp4cmVmCjAgNgowMDAwMDAwMDAwIDY1NTM1IGYgCjAwMDAwMDAwMDkgMDAwMDAgbiAKMDAwMDAwMDA1OCAwMDAwMCBuIAowMDAwMDAwMTE1IDAwMDAwIG4gCjAwMDAwMDAyNDcgMDAwMDAgbiAKMDAwMDAwMDMxNyAwMDAwMCBuIAp0cmFpbGVyCjw8IC9TaXplIDYgL1Jvb3QgMSAwIFIgPj4Kc3RhcnR4cmVmCjQxNgolJUVPRgo=";
+
+// Functional pdf.js stand-in with the same API surface the generated code uses.
+// It validates that the fixture PDF bytes reached pdf.js, computes viewports
+// like pdf.js (A4 at 72dpi), and draws the page so the canvas is not blank.
+const STUB_PDFJS_SOURCE = `
+(function () {
+  var W = 595.28, H = 841.89;
+  window.pdfjsLib = {
+    GlobalWorkerOptions: { workerSrc: '' },
+    getDocument: function (params) {
+      var data = params.data;
+      var isPdf = data && data.length >= 4 &&
+        data[0] === 0x25 && data[1] === 0x50 &&
+        data[2] === 0x44 && data[3] === 0x46;
+      if (!isPdf) {
+        return { promise: Promise.reject(new Error('fixture is not a PDF')) };
+      }
+      return {
+        promise: Promise.resolve({
+          numPages: 1,
+          getPage: function () {
+            return Promise.resolve({
+              getViewport: function (opts) {
+                var scale = opts.scale;
+                return { width: W * scale, height: H * scale };
+              },
+              render: function (opts) {
+                opts.canvasContext.fillStyle = '#3366cc';
+                opts.canvasContext.fillRect(0, 0, opts.viewport.width, opts.viewport.height);
+                return { promise: Promise.resolve() };
+              }
+            });
+          }
+        })
+      };
+    }
+  };
+})();
+`;
+
+const PNG_SIGNATURE = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+const encodePng = (width: number, height: number, pixels: Buffer): Buffer => {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 6; // RGBA color type
+
+  const stride = 1 + width * 4;
+  const raw = Buffer.alloc(stride * height);
+  for (let y = 0; y < height; y += 1) {
+    pixels.copy(raw, y * stride + 1, y * width * 4, (y + 1) * width * 4);
+  }
+  const idat = deflateSync(raw);
+
+  const chunk = (type: string, data: Buffer) => {
+    const length = Buffer.alloc(4);
+    length.writeUInt32BE(data.length, 0);
+    const typeBuf = Buffer.from(type, "ascii");
+    const crc = Buffer.alloc(4);
+    crc.writeUInt32BE(crc32(Buffer.concat([typeBuf, data])), 0);
+    return Buffer.concat([length, typeBuf, data, crc]);
+  };
+
+  return Buffer.concat([
+    PNG_SIGNATURE,
+    chunk("IHDR", ihdr),
+    chunk("IDAT", idat),
+    chunk("IEND", Buffer.alloc(0)),
+  ]);
+};
+
+const parseHexColor = (value: string): [number, number, number] => {
+  const hex = value.replace("#", "");
+  return [
+    Number.parseInt(hex.slice(0, 2), 16),
+    Number.parseInt(hex.slice(2, 4), 16),
+    Number.parseInt(hex.slice(4, 6), 16),
+  ];
+};
+
+const decodePngFirstPixel = (png: Buffer): [number, number, number] => {
+  let offset = PNG_SIGNATURE.length;
+  let idat: Buffer | null = null;
+  while (offset + 8 <= png.length) {
+    const length = png.readUInt32BE(offset);
+    const type = png.toString("ascii", offset + 4, offset + 8);
+    const data = png.subarray(offset + 8, offset + 8 + length);
+    if (type === "IDAT") {
+      idat = data;
+    }
+    offset += 12 + length;
+  }
+  if (!idat) {
+    throw new Error("PNG has no IDAT chunk");
+  }
+  const inflated = inflateSync(idat);
+  return [inflated[1], inflated[2], inflated[3]];
+};
+
+const decodePngSize = (png: Buffer): { width: number; height: number } => {
+  const width = png.readUInt32BE(16);
+  const height = png.readUInt32BE(20);
+  return { width, height };
+};
+
+// Faithful local executor: runs the exact Playwright code string the thumbnail
+// step sends to Kernel, with a stub request context serving the fixture PDF and
+// pdf.js sources, and a real canvas shim that encodes rendered pixels to PNG.
+const executeGeneratedCode = async (
+  code: string,
+  options: { pdfBase64: string; libSource: string; workerSource: string }
+): Promise<any> => {
+  let canvasWidth = 0;
+  let canvasHeight = 0;
+  let canvasPixels = Buffer.alloc(0);
+  const fillState = { fillStyle: "#000000" };
+  const resizeCanvas = () => {
+    canvasPixels = Buffer.alloc(canvasWidth * canvasHeight * 4);
+    canvasPixels.fill(255);
+  };
+
+  const previousWindow = (globalThis as any).window;
+  const previousDocument = (globalThis as any).document;
+  (globalThis as any).window = {};
+  (globalThis as any).document = {
+    createElement: (tag: string) => {
+      if (tag !== "canvas") {
+        return {};
+      }
+      return {
+        get width() {
+          return canvasWidth;
+        },
+        set width(value: number) {
+          canvasWidth = Math.max(0, Math.floor(value));
+          resizeCanvas();
+        },
+        get height() {
+          return canvasHeight;
+        },
+        set height(value: number) {
+          canvasHeight = Math.max(0, Math.floor(value));
+          resizeCanvas();
+        },
+        getContext: () => ({
+          get fillStyle() {
+            return fillState.fillStyle;
+          },
+          set fillStyle(value: string) {
+            fillState.fillStyle = value;
+          },
+          fillRect: (x: number, y: number, w: number, h: number) => {
+            const [r, g, b] = parseHexColor(fillState.fillStyle);
+            const x0 = Math.max(0, Math.floor(x));
+            const y0 = Math.max(0, Math.floor(y));
+            const x1 = Math.min(canvasWidth, Math.ceil(x + w));
+            const y1 = Math.min(canvasHeight, Math.ceil(y + h));
+            for (let py = y0; py < y1; py += 1) {
+              for (let px = x0; px < x1; px += 1) {
+                const index = (py * canvasWidth + px) * 4;
+                canvasPixels[index] = r;
+                canvasPixels[index + 1] = g;
+                canvasPixels[index + 2] = b;
+                canvasPixels[index + 3] = 255;
+              }
+            }
+          },
+        }),
+        toDataURL: () =>
+          `data:image/png;base64,${encodePng(canvasWidth, canvasHeight, canvasPixels).toString("base64")}`,
+      };
+    },
+  };
+
+  try {
+    const page = {
+      setViewportSize: async () => {},
+      goto: async () => {},
+      evaluate: async (fn: (...args: never[]) => unknown, ...args: never[]) =>
+        fn(...args),
+    };
+    const context = {
+      request: {
+        get: (url: string) => {
+          if (url.includes("the-pdf")) {
+            return {
+              ok: () => true,
+              body: async () => Buffer.from(options.pdfBase64, "base64"),
+            };
+          }
+          if (url.includes("pdf.worker.min.js")) {
+            return { ok: () => true, text: async () => options.workerSource };
+          }
+          if (url.includes("pdf.min.js")) {
+            return { ok: () => true, text: async () => options.libSource };
+          }
+          return { ok: () => false };
+        },
+      },
+    };
+    const runner = new Function(
+      "page",
+      "context",
+      `return (async () => {\n${code}\n})()`
+    );
+    return await runner(page, context);
+  } finally {
+    (globalThis as any).window = previousWindow;
+    (globalThis as any).document = previousDocument;
+  }
+};
 
 beforeAll(async () => {
   // Kernel headless browser: return a canvas screenshot payload and record the
@@ -144,6 +365,51 @@ describe("generatePdfThumbnail", () => {
     expect(capturedPlaywrightCode).toContain("libSource");
     expect(capturedPlaywrightCode).toContain("(0, eval)(libSource)");
     expect(capturedPlaywrightCode).toContain("GlobalWorkerOptions.workerSrc");
+  });
+
+  test("executes the generated browser code and renders a PNG from the fixture PDF", async () => {
+    // Execution-level regression guard: the Kernel mock above only records the
+    // code string, so string assertions alone cannot catch a broken render
+    // pipeline. Run the exact generated code through a faithful local executor
+    // with the fixture PDF and assert a real PNG is produced.
+    const { ctx } = createCtx(pdfCard);
+    await generatePdfThumbnail(ctx, { cardId: "card-pdf" });
+
+    const raw = await executeGeneratedCode(capturedPlaywrightCode, {
+      pdfBase64: FIXTURE_PDF_BASE64,
+      libSource: STUB_PDFJS_SOURCE,
+      workerSource: "",
+    });
+    const result = JSON.parse(raw);
+
+    expect(result.success).toBe(true);
+    expect(result.width).toBe(401);
+    expect(result.height).toBe(566);
+
+    const png = Buffer.from(result.data, "base64");
+    expect(png.subarray(0, 8)).toEqual(PNG_SIGNATURE);
+    expect(decodePngSize(png)).toEqual({ width: 401, height: 566 });
+    // The stub pdf.js paints the page blue, so a blue first pixel proves the
+    // render call actually executed and was serialized by toDataURL.
+    expect(decodePngFirstPixel(png)).toEqual([0x33, 0x66, 0xcc]);
+  });
+
+  test("fails cleanly when pdf.js cannot be evaluated", async () => {
+    // Guards the failure path directly: if libSource is missing (or the eval
+    // is removed and pdfjsLib never initializes), the code must report a
+    // controlled error instead of throwing.
+    const { ctx } = createCtx(pdfCard);
+    await generatePdfThumbnail(ctx, { cardId: "card-pdf" });
+
+    const raw = await executeGeneratedCode(capturedPlaywrightCode, {
+      pdfBase64: FIXTURE_PDF_BASE64,
+      libSource: "",
+      workerSource: "",
+    });
+    const result = JSON.parse(raw);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("pdf.js failed to load");
   });
 
   test("skips non-PDF documents without generating a thumbnail", async () => {

--- a/packages/convex/__tests__/workflows/steps/renderables/generatePdfThumbnail.test.ts
+++ b/packages/convex/__tests__/workflows/steps/renderables/generatePdfThumbnail.test.ts
@@ -132,6 +132,20 @@ describe("generatePdfThumbnail", () => {
     expect(capturedPlaywrightCode.toLowerCase()).toContain("pdfjslib");
   });
 
+  test("loads pdf.js in-page instead of relying on addScriptTag", async () => {
+    // Regression: page.addScriptTag does not execute in the Kernel headless
+    // runtime, so pdfjsLib stayed undefined and no thumbnail was produced.
+    // The library and worker are now fetched through the request context and
+    // evaluated inside the page.
+    const { ctx } = createCtx(pdfCard);
+    await generatePdfThumbnail(ctx, { cardId: "card-pdf" });
+
+    expect(capturedPlaywrightCode).not.toContain("addScriptTag({ url:");
+    expect(capturedPlaywrightCode).toContain("libSource");
+    expect(capturedPlaywrightCode).toContain("(0, eval)(libSource)");
+    expect(capturedPlaywrightCode).toContain("GlobalWorkerOptions.workerSrc");
+  });
+
   test("skips non-PDF documents without generating a thumbnail", async () => {
     const { ctx, mutationCalls } = createCtx({
       ...pdfCard,

--- a/packages/convex/workflows/steps/renderables/generatePdfThumbnail.ts
+++ b/packages/convex/workflows/steps/renderables/generatePdfThumbnail.ts
@@ -132,17 +132,33 @@ export const generatePdfThumbnail = internalAction({
               const pdfBuffer = await pdfResponse.body();
               const pdfBase64 = pdfBuffer.toString('base64');
 
-              // Load a blank page and inject the pdf.js library.
-              await page.goto('about:blank');
-              await page.addScriptTag({ url: ${JSON.stringify(PDFJS_LIB_URL)} });
+              // Fetch the pdf.js library through the Node-side request context
+              // (which ignores browser CORS) and evaluate it in-page. External
+              // script injection via page.addScriptTag does not execute in this
+              // headless runtime, so pdfjsLib would remain undefined.
+              const libResponse = await context.request.get(${JSON.stringify(PDFJS_LIB_URL)});
+              const libSource = libResponse.ok() ? await libResponse.text() : '';
+              const workerResponse = await context.request.get(${JSON.stringify(PDFJS_WORKER_URL)});
+              const workerSource = workerResponse.ok() ? await workerResponse.text() : '';
 
-              const result = await page.evaluate(async ({ pdfBase64, workerSrc, maxWidth }) => {
+              await page.goto('about:blank');
+
+              const result = await page.evaluate(async ({ pdfBase64, libSource, workerSource, maxWidth }) => {
                 try {
+                  if (!libSource) {
+                    return { success: false, error: 'pdf.js failed to load' };
+                  }
+                  (0, eval)(libSource);
                   const pdfjsLib = window['pdfjsLib'];
                   if (!pdfjsLib) {
                     return { success: false, error: 'pdf.js failed to load' };
                   }
-                  pdfjsLib.GlobalWorkerOptions.workerSrc = workerSrc;
+                  if (workerSource) {
+                    const workerBlob = new Blob([workerSource], { type: 'text/javascript' });
+                    pdfjsLib.GlobalWorkerOptions.workerSrc = URL.createObjectURL(workerBlob);
+                  } else {
+                    pdfjsLib.GlobalWorkerOptions.workerSrc = 'data:application/javascript,';
+                  }
 
                   // Decode base64 into a byte array.
                   const binary = atob(pdfBase64);
@@ -185,7 +201,8 @@ export const generatePdfThumbnail = internalAction({
                 }
               }, {
                 pdfBase64,
-                workerSrc: ${JSON.stringify(PDFJS_WORKER_URL)},
+                libSource,
+                workerSource,
                 maxWidth: ${THUMBNAIL_MAX_WIDTH}
               });
 

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -158,6 +158,12 @@
   background: var(--primary-foreground);
 }
 
+/* Keep toast icons next to the centered title instead of pinned to the left
+   edge of the full-width bar. */
+[data-sonner-toaster] [data-sonner-toast] [data-content] {
+  flex: 0 1 auto;
+}
+
 .teak-markdown-editor {
   --teak-editor-font-size: 1rem;
 }


### PR DESCRIPTION
## What changed

- Restored first-page PDF thumbnails in the home grid: the PDF thumbnail step now loads pdf.js through Kernel's request context and evaluates it in-page with a blob worker, instead of relying on `page.addScriptTag`, which never executes in the headless runtime. Added a regression test for the new injection approach.
- Centered toast content for every toast type (loading, error, success, warning, default): the toast content no longer stretches to fill the full-width bar, so the icon, message, and close button center as one group instead of pinning the icon to the left edge.
- Updated the August changelog with both user-visible outcomes.

## Why it changed

PDF uploads stopped showing their first page as the grid preview: the old code injected pdf.js via `page.addScriptTag`, which silently no-ops in Kernel's headless browser, so `pdfjsLib` stayed undefined and no thumbnail was generated. The toast icon misalignment was the same root cause pattern: sonner gives the content wrapper `flex: 1`, which stretched it across the bar while the icon stayed pinned left.

## Validation

- End-to-end run against the live local app: uploaded a real one-page PDF through the web UI, confirmed the backend workflow logged `Successfully generated thumbnail`, and confirmed the grid card rendered a 401x566 PNG thumbnail (first-page content) served from R2 with HTTP 200.
- `bun test` on the PDF thumbnail step passes (5/5), `bunx convex typecheck` passes, and `bunx ultracite check` is clean on all changed files.
- Toast centering verified in a Playwright harness against sonner's real stylesheet across loading, error, success, and close-button variants: each icon+text group centers at the toast center.
