### PR TITLE
Fix production E2E save race and Sentry noise

### DIFF
--- a/apps/web/src/__tests__/sentryConfig.test.ts
+++ b/apps/web/src/__tests__/sentryConfig.test.ts
@@ -58,6 +58,8 @@ describe("resolveSentryEnvironment", () => {
     );
 
     expect(source).toContain(".catch(() => {");
+    expect(source).toContain("Sentry.setTag");
+    expect(source).toContain("SENTRY_USER_SEGMENT_TAG");
     expect(source).toContain("Sentry.setUser(null)");
   });
 
@@ -145,6 +147,69 @@ describe("filterClientSentryEvent", () => {
     expect(filterClientSentryEvent(event)).toBeNull();
   });
 
+  test("drops injected userscript execution failures", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [{ filename: "app:///userscript.html" }],
+            },
+            type: "EvalError",
+            value:
+              "Evaluating a string as JavaScript violates Content Security Policy",
+          },
+        ],
+      },
+    } satisfies ErrorEvent;
+
+    expect(filterClientSentryEvent(event)).toBeNull();
+  });
+
+  test("drops external DOM mutation errors raised only from React internals", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "node_modules/next/dist/compiled/react-dom/cjs/react-dom-client.production.js",
+                  function: "commitDeletionEffectsOnFiber",
+                },
+              ],
+            },
+            type: "NotFoundError",
+            value:
+              "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+          },
+        ],
+      },
+    } satisfies ErrorEvent;
+
+    expect(filterClientSentryEvent(event)).toBeNull();
+  });
+
+  test("keeps DOM removal errors with an app frame", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [{ filename: "app:///src/app/HomePageClient.tsx" }],
+            },
+            type: "NotFoundError",
+            value:
+              "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.",
+          },
+        ],
+      },
+    } satisfies ErrorEvent;
+
+    expect(filterClientSentryEvent(event)).toEqual(event);
+  });
+
   test("drops Safari Better Auth session fetch aborts for pseudonymous users", () => {
     const event = {
       exception: {
@@ -186,10 +251,10 @@ describe("filterClientSentryEvent", () => {
           },
         ],
       },
-      user: {
-        id: "pseudonymous-user-id",
-        segment: "production_e2e",
+      tags: {
+        "teak.user_segment": "production_e2e",
       },
+      user: { id: "pseudonymous-user-id" },
     } satisfies ErrorEvent;
 
     expect(filterClientSentryEvent(event)).toBeNull();

--- a/apps/web/src/components/SentryUserManager.tsx
+++ b/apps/web/src/components/SentryUserManager.tsx
@@ -3,7 +3,10 @@
 import * as Sentry from "@sentry/nextjs";
 import { useEffect } from "react";
 import { authClient } from "@/lib/auth-client";
-import { buildPseudonymousSentryUser } from "@/lib/sentry-config";
+import {
+  buildPseudonymousSentryUser,
+  SENTRY_USER_SEGMENT_TAG,
+} from "@/lib/sentry-config";
 
 /**
  * Component that syncs a pseudonymous authenticated user id to Sentry.
@@ -18,11 +21,13 @@ export function SentryUserManager() {
     void buildPseudonymousSentryUser(session?.user.id, session?.user.email)
       .then((user) => {
         if (!cancelled) {
+          Sentry.setTag(SENTRY_USER_SEGMENT_TAG, user?.segment);
           Sentry.setUser(user);
         }
       })
       .catch(() => {
         if (!cancelled) {
+          Sentry.setTag(SENTRY_USER_SEGMENT_TAG, undefined);
           Sentry.setUser(null);
         }
       });

--- a/apps/web/src/lib/sentry-config.ts
+++ b/apps/web/src/lib/sentry-config.ts
@@ -24,12 +24,15 @@ export const buildPseudonymousSentryUser = async (
   return email?.startsWith("e2e-") ? { id, segment: "production_e2e" } : { id };
 };
 
-const EXTENSION_FRAME_PREFIXES = [
+const INJECTED_FRAME_PREFIXES = [
   "app:///scripts/",
+  "app:///userscript",
   "chrome-extension://",
   "moz-extension://",
   "safari-web-extension://",
 ];
+
+export const SENTRY_USER_SEGMENT_TAG = "teak.user_segment";
 
 export const resolveSentryEnvironment = (): TelemetryEnvironment =>
   resolveTelemetryEnvironment({
@@ -84,20 +87,31 @@ export const scrubSentryPayload = <T>(payload: T): T =>
 const isExtensionFrame = (filename?: string) =>
   Boolean(
     filename &&
-      EXTENSION_FRAME_PREFIXES.some((prefix) => filename.startsWith(prefix))
+      INJECTED_FRAME_PREFIXES.some((prefix) => filename.startsWith(prefix))
   );
 
-const isExtensionFetchFailure = (event: ErrorEvent) =>
-  event.exception?.values?.some((exception) => {
-    const isFetchFailure =
-      exception.type === "TypeError" &&
-      exception.value?.startsWith("Failed to fetch");
+const isInjectedError = (event: ErrorEvent) =>
+  event.exception?.values?.some((exception) =>
+    exception.stacktrace?.frames?.some((frame) =>
+      isExtensionFrame(frame.filename)
+    )
+  ) ?? false;
 
+const isReactInternalFrame = (filename?: string) =>
+  Boolean(
+    filename &&
+      (filename.includes("/react-dom/") || filename.includes("/scheduler/"))
+  );
+
+const isExternalDomMutation = (event: ErrorEvent) =>
+  event.exception?.values?.some((exception) => {
+    const frames = exception.stacktrace?.frames ?? [];
     return (
-      isFetchFailure &&
-      exception.stacktrace?.frames?.some((frame) =>
-        isExtensionFrame(frame.filename)
-      )
+      exception.type === "NotFoundError" &&
+      exception.value ===
+        "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node." &&
+      frames.length > 0 &&
+      frames.every((frame) => isReactInternalFrame(frame.filename))
     );
   }) ?? false;
 
@@ -123,7 +137,8 @@ const isSafariBetterAuthLoadFailure = (event: ErrorEvent) =>
       isBetterAuthSessionFrame(frame.filename)
     );
     const isKnownE2eBundleAbort =
-      event.user?.segment === "production_e2e" &&
+      (event.tags?.[SENTRY_USER_SEGMENT_TAG] === "production_e2e" ||
+        event.user?.segment === "production_e2e") &&
       frames.some((frame) => isBundledNextFrame(frame.filename));
 
     return (
@@ -133,7 +148,11 @@ const isSafariBetterAuthLoadFailure = (event: ErrorEvent) =>
   }) ?? false;
 
 export function filterClientSentryEvent(event: ErrorEvent, _hint?: EventHint) {
-  if (isExtensionFetchFailure(event) || isSafariBetterAuthLoadFailure(event)) {
+  if (
+    isInjectedError(event) ||
+    isExternalDomMutation(event) ||
+    isSafariBetterAuthLoadFailure(event)
+  ) {
     return null;
   }
 

--- a/packages/tests/src/journey/02-web-journey.e2e.ts
+++ b/packages/tests/src/journey/02-web-journey.e2e.ts
@@ -26,7 +26,7 @@ test("web journey covers cards, search, settings, upload, and revoked key", asyn
     page.getByText(/Welcome to Teak|Let's add your first card/i)
   ).toBeVisible();
   await composer.fill(rawMarkdown);
-  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await composer.press("ControlOrMeta+Enter");
   const savedCard = page.locator("main p").filter({ hasText: marker }).first();
   await expect(savedCard).toBeVisible();
   await expect
@@ -101,8 +101,9 @@ test("saving a color in the composer creates a palette card", async ({
   const hex = "#2050D0";
 
   await page.goto("/");
-  await page.getByRole("textbox", { name: "Markdown content" }).fill(hex);
-  await page.getByRole("button", { name: "Save", exact: true }).click();
+  const composer = page.getByRole("textbox", { name: "Markdown content" });
+  await composer.fill(hex);
+  await composer.press("ControlOrMeta+Enter");
   // The optimistic card appears immediately; classification runs server-side.
   await expect(
     page.locator("main").getByText(hex, { exact: true }).first()


### PR DESCRIPTION
## Summary
- submit production composer journeys through the editor shortcut so successful saves cannot be misreported when the button detaches
- tag synthetic E2E users explicitly before Sentry user context and filter their expected WebKit session aborts
- filter injected userscript failures and external DOM mutation errors while preserving app-origin variants

Addresses #319.

## Verification
- `bun test apps/web/src/__tests__/sentryConfig.test.ts`
- `bun run --cwd packages/tests typecheck`
- `bun run --cwd apps/web typecheck`
- `bun run pre-commit`
- `bunx bun@1.3.14 run test`