### PR TITLE
Fix immutable E2E Sentry chunk filtering

### DIFF
--- a/apps/web/src/__tests__/sentryConfig.test.ts
+++ b/apps/web/src/__tests__/sentryConfig.test.ts
@@ -260,6 +260,33 @@ describe("filterClientSentryEvent", () => {
     expect(filterClientSentryEvent(event)).toBeNull();
   });
 
+  test("drops Safari e2e aborts from immutable Next.js chunks", () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: "Load failed (app.teakvault.com)",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "app:///_next/static/immutable/chunks/0k5wuabdzwsx5.js",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      tags: {
+        "teak.user_segment": "production_e2e",
+      },
+      user: { id: "pseudonymous-user-id" },
+    } satisfies ErrorEvent;
+
+    expect(filterClientSentryEvent(event)).toBeNull();
+  });
+
   test("keeps bare bundled load failures for real users", () => {
     const event = {
       exception: {

--- a/apps/web/src/lib/sentry-config.ts
+++ b/apps/web/src/lib/sentry-config.ts
@@ -124,7 +124,11 @@ const isBetterAuthSessionFrame = (filename?: string) =>
   );
 
 const isBundledNextFrame = (filename?: string) =>
-  filename?.includes("/_next/static/chunks/") ?? false;
+  Boolean(
+    filename &&
+      (filename.includes("/_next/static/chunks/") ||
+        filename.includes("/_next/static/immutable/chunks/"))
+  );
 
 const isSafariBetterAuthLoadFailure = (event: ErrorEvent) =>
   event.exception?.values?.some((exception) => {


### PR DESCRIPTION
## Summary
- recognize production immutable chunk paths in the synthetic Safari abort filter
- add a regression test matching the live Sentry event shape

## Verification
- bun test apps/web/src/__tests__/sentryConfig.test.ts
- bun run pre-commit