### PR TITLE
perf(media): faster image & video loading

### DIFF
--- a/apps/docs/content/changelog/august-2026.mdx
+++ b/apps/docs/content/changelog/august-2026.mdx
@@ -7,6 +7,9 @@ changelog:
   category: Product updates
 ---
 
+- Image and video cards now load noticeably faster, with your library reusing what it has already downloaded instead of fetching everything again.
+- Videos and audio scrub smoothly without restarting from the beginning.
+- Hovering a card quietly prepares its full preview, so opening a card feels instant.
 - Saved-card links, page reloads, and Markdown file uploads now finish reliably across the web app and browser extension.
 - The iPhone and iPad apps no longer close immediately on launch, and search, refresh, card opening, and image-heavy libraries load more quickly.
 - Continue with Apple now completes sign-in reliably on the web and in Teak for Safari.

--- a/apps/files-worker/README.md
+++ b/apps/files-worker/README.md
@@ -2,11 +2,14 @@
 
 Serves private card files from `files.teakvault.com`.
 
-The Convex backend mints short-lived HMAC-signed URLs
+The Convex backend mints long-lived HMAC-signed URLs
 (`packages/convex/storage/r2.ts` → `buildSignedWorkerFileUrl`). This worker
 verifies the token, reads the object through an R2 binding, and streams it
-with `Cache-Control: private, max-age=900, immutable`. The bucket is never
-public.
+with `Cache-Control: private, max-age=518400, immutable` (6 days; keep in
+lockstep with `PRIVATE_FILE_CACHE_CONTROL` in r2.ts). It also handles single
+HTTP `Range` requests (206 responses) so video/audio seeking works, and serves
+full-object responses from the Cloudflare edge cache keyed by object path +
+content-disposition policy. The bucket is never public.
 
 ## Commands
 

--- a/apps/files-worker/src/index.ts
+++ b/apps/files-worker/src/index.ts
@@ -1,4 +1,8 @@
-import { FILES_CACHE_CONTROL, verifySignedFileRequest } from "./lib";
+import {
+  FILES_CACHE_CONTROL,
+  parseSingleByteRange,
+  verifySignedFileRequest,
+} from "./lib";
 
 export interface Env {
   BUCKET: R2Bucket;
@@ -13,8 +17,54 @@ const decodeObjectKey = (pathname: string): string => {
   }
 };
 
+/**
+ * Edge-cache key for a full-object response. The object key already embeds the
+ * owning user's hash prefix, so entries are never shared across users; ct/cd
+ * are folded in because they vary per request policy (inline vs attachment)
+ * and are echoed back verbatim from the cached headers.
+ */
+const buildCacheKey = (request: Request): Request => {
+  const url = new URL(request.url);
+  const cacheUrl = new URL(url.origin + url.pathname);
+  const contentType = url.searchParams.get("ct");
+  const contentDisposition = url.searchParams.get("cd");
+  if (contentType) {
+    cacheUrl.searchParams.set("ct", contentType);
+  }
+  if (contentDisposition) {
+    cacheUrl.searchParams.set("cd", contentDisposition);
+  }
+  return new Request(cacheUrl.toString(), {
+    method: "GET",
+    headers: { accept: request.headers.get("accept") ?? "*/*" },
+  });
+};
+
+const applyObjectHeaders = (
+  headers: Headers,
+  request: Request,
+  objectHttpMetadata: R2HTTPMetadata | undefined,
+  httpEtag: string
+): void => {
+  const url = new URL(request.url);
+  headers.set("Cache-Control", FILES_CACHE_CONTROL);
+  headers.set("ETag", httpEtag);
+  headers.set("Accept-Ranges", "bytes");
+  headers.set(
+    "Content-Type",
+    url.searchParams.get("ct") ||
+      objectHttpMetadata?.contentType ||
+      "application/octet-stream"
+  );
+  const contentDisposition =
+    url.searchParams.get("cd") || objectHttpMetadata?.contentDisposition;
+  if (contentDisposition) {
+    headers.set("Content-Disposition", contentDisposition);
+  }
+};
+
 export default {
-  async fetch(request, env): Promise<Response> {
+  async fetch(request, env, ctx): Promise<Response> {
     if (request.method !== "GET") {
       return new Response(null, { status: 405 });
     }
@@ -39,25 +89,76 @@ export default {
       return new Response(null, { status: verification.status });
     }
 
-    const object = await env.BUCKET.get(key);
+    // Only full-object responses are served from (and written to) the edge
+    // cache; ranged video/audio requests always go to R2 so seeking stays
+    // accurate.
+    const parsedRange = parseSingleByteRange(request.headers.get("range"));
+    if (!parsedRange) {
+      const cacheKey = buildCacheKey(request);
+      const cached = await caches.default.match(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
+      const object = await env.BUCKET.get(key);
+      if (!object) {
+        return new Response(null, { status: 404 });
+      }
+
+      const headers = new Headers();
+      applyObjectHeaders(headers, request, object.httpMetadata, object.httpEtag);
+      const response = new Response(object.body, { headers });
+
+      ctx.waitUntil(caches.default.put(cacheKey, response.clone()));
+      return response;
+    }
+
+    // Resolve the requested range against the true object size so the
+    // Content-Range header is exact and out-of-bounds requests get a proper
+    // 416 instead of relying on R2's clamping behavior.
+    const meta = await env.BUCKET.head(key);
+    if (!meta) {
+      return new Response(null, { status: 404 });
+    }
+    const { size } = meta;
+
+    let start: number;
+    let length: number;
+    if (parsedRange.kind === "offset") {
+      start = parsedRange.offset;
+      const rawEnd =
+        parsedRange.length === undefined
+          ? size - 1
+          : Math.min(start + parsedRange.length - 1, size - 1);
+      if (start >= size || rawEnd < start) {
+        return new Response(null, {
+          status: 416,
+          headers: { "Content-Range": `bytes */${size}` },
+        });
+      }
+      length = rawEnd - start + 1;
+    } else {
+      length = Math.min(parsedRange.suffix, size);
+      if (length <= 0) {
+        return new Response(null, {
+          status: 416,
+          headers: { "Content-Range": `bytes */${size}` },
+        });
+      }
+      start = size - length;
+    }
+
+    const object = await env.BUCKET.get(key, {
+      range: { offset: start, length },
+    });
     if (!object) {
       return new Response(null, { status: 404 });
     }
 
     const headers = new Headers();
-    headers.set("Cache-Control", FILES_CACHE_CONTROL);
-    headers.set("ETag", object.httpEtag);
-    headers.set(
-      "Content-Type",
-      url.searchParams.get("ct") ||
-        object.httpMetadata?.contentType ||
-        "application/octet-stream"
-    );
-    const contentDisposition =
-      url.searchParams.get("cd") || object.httpMetadata?.contentDisposition;
-    if (contentDisposition) {
-      headers.set("Content-Disposition", contentDisposition);
-    }
-    return new Response(object.body, { headers });
+    applyObjectHeaders(headers, request, object.httpMetadata, object.httpEtag);
+    headers.set("Content-Range", `bytes ${start}-${start + length - 1}/${size}`);
+
+    return new Response(object.body, { status: 206, headers });
   },
 } satisfies ExportedHandler<Env>;

--- a/apps/files-worker/src/index.ts
+++ b/apps/files-worker/src/index.ts
@@ -1,5 +1,6 @@
 import {
   FILES_CACHE_CONTROL,
+  FILES_EDGE_CACHE_CONTROL,
   parseSingleByteRange,
   verifySignedFileRequest,
 } from "./lib";
@@ -97,7 +98,16 @@ export default {
       const cacheKey = buildCacheKey(request);
       const cached = await caches.default.match(cacheKey);
       if (cached) {
-        return cached;
+        // The edge copy is stored with a public directive (the Cache API
+        // refuses to store private responses); browsers must still receive
+        // the private variant.
+        const headers = new Headers(cached.headers);
+        headers.set("Cache-Control", FILES_CACHE_CONTROL);
+        return new Response(cached.body, {
+          status: cached.status,
+          statusText: cached.statusText,
+          headers,
+        });
       }
 
       const object = await env.BUCKET.get(key);
@@ -107,9 +117,18 @@ export default {
 
       const headers = new Headers();
       applyObjectHeaders(headers, request, object.httpMetadata, object.httpEtag);
-      const response = new Response(object.body, { headers });
 
-      ctx.waitUntil(caches.default.put(cacheKey, response.clone()));
+      const [clientBody, edgeBody] = object.body.tee();
+      const response = new Response(clientBody, { headers });
+
+      const edgeHeaders = new Headers(headers);
+      edgeHeaders.set("Cache-Control", FILES_EDGE_CACHE_CONTROL);
+      ctx.waitUntil(
+        caches.default.put(
+          cacheKey,
+          new Response(edgeBody, { status: 200, headers: edgeHeaders })
+        )
+      );
       return response;
     }
 

--- a/apps/files-worker/src/lib.test.ts
+++ b/apps/files-worker/src/lib.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   buildSigningPayload,
   hmacSha256Hex,
+  parseSingleByteRange,
   verifySignedFileRequest,
 } from "./lib";
 
@@ -110,5 +111,49 @@ describe("files proxy verification", () => {
         sig: "zz",
       })
     ).toEqual({ ok: false, status: 403 });
+  });
+});
+
+describe("range header parsing", () => {
+  test("returns null for absent or ignored headers", () => {
+    expect(parseSingleByteRange(null)).toBeNull();
+    expect(parseSingleByteRange(undefined)).toBeNull();
+    // Multi-range and non-byte units are ignored, not rejected.
+    expect(parseSingleByteRange("bytes=0-1,5-9")).toBeNull();
+    expect(parseSingleByteRange("items=0-5")).toBeNull();
+    expect(parseSingleByteRange("bytes=")).toBeNull();
+    expect(parseSingleByteRange("bytes=-")).toBeNull();
+    expect(parseSingleByteRange("bytes=9-5")).toBeNull();
+    expect(parseSingleByteRange("bytes=abc-def")).toBeNull();
+    expect(parseSingleByteRange("bytes=-0")).toBeNull();
+  });
+
+  test("parses start-end ranges into offset+length", () => {
+    expect(parseSingleByteRange("bytes=0-0")).toEqual({
+      kind: "offset",
+      offset: 0,
+      length: 1,
+    });
+    expect(parseSingleByteRange("bytes=10-19")).toEqual({
+      kind: "offset",
+      offset: 10,
+      length: 10,
+    });
+    expect(parseSingleByteRange(" bytes=100-200 ")).toEqual({
+      kind: "offset",
+      offset: 100,
+      length: 101,
+    });
+  });
+
+  test("parses open-ended and suffix ranges", () => {
+    expect(parseSingleByteRange("bytes=500-")).toEqual({
+      kind: "offset",
+      offset: 500,
+    });
+    expect(parseSingleByteRange("bytes=-256")).toEqual({
+      kind: "suffix",
+      suffix: 256,
+    });
   });
 });

--- a/apps/files-worker/src/lib.ts
+++ b/apps/files-worker/src/lib.ts
@@ -3,7 +3,61 @@
 // exact same payload format; the fixed test vector in lib.test.ts locks both
 // runtimes to identical HMAC output.
 
-export const FILES_CACHE_CONTROL = "private, max-age=900, immutable";
+// Must stay in lockstep with PRIVATE_FILE_CACHE_CONTROL in
+// packages/convex/storage/r2.ts, and below the signed-URL minimum remaining
+// validity (7 days) so browsers never replay an expired signature.
+export const FILES_CACHE_CONTROL = "private, max-age=518400, immutable"; // 6 days.
+
+export interface R2GetRange {
+  offset?: number;
+  length?: number;
+  suffix?: number;
+}
+
+export type ParsedRange =
+  | { kind: "offset"; offset: number; length?: number }
+  | { kind: "suffix"; suffix: number };
+
+/**
+ * Parse a single-range `Range` header into an R2 get() range option.
+ * Multi-range, non-bytes, and malformed headers are ignored (the caller serves
+ * the full object), which RFC 9110 permits. Returns null when the header is
+ * absent.
+ */
+export const parseSingleByteRange = (
+  rangeHeader: string | null | undefined
+): ParsedRange | null => {
+  if (!rangeHeader) {
+    return null;
+  }
+  const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+  if (!match) {
+    return null;
+  }
+  const [, rawStart, rawEnd] = match;
+  if (rawStart === "" && rawEnd === "") {
+    return null;
+  }
+  if (rawStart === "") {
+    const suffix = Number.parseInt(rawEnd ?? "", 10);
+    if (!Number.isSafeInteger(suffix) || suffix <= 0) {
+      return null;
+    }
+    return { kind: "suffix", suffix };
+  }
+  const start = Number.parseInt(rawStart ?? "", 10);
+  if (!Number.isSafeInteger(start) || start < 0 || start > Number.MAX_SAFE_INTEGER - 1) {
+    return null;
+  }
+  if (rawEnd === "") {
+    return { kind: "offset", offset: start };
+  }
+  const end = Number.parseInt(rawEnd ?? "", 10);
+  if (!Number.isSafeInteger(end) || end < start) {
+    return null;
+  }
+  return { kind: "offset", offset: start, length: end - start + 1 };
+};
 
 export interface FileSigningFields {
   contentDisposition?: string | null;

--- a/apps/files-worker/src/lib.ts
+++ b/apps/files-worker/src/lib.ts
@@ -8,6 +8,12 @@
 // validity (7 days) so browsers never replay an expired signature.
 export const FILES_CACHE_CONTROL = "private, max-age=518400, immutable"; // 6 days.
 
+// The Workers Cache API refuses to store responses marked `private`, so the
+// copy handed to cache.put() is rewritten to public. Entries are keyed by the
+// user-scoped object path, so nothing is shared across users; client-facing
+// responses always carry the private directive above.
+export const FILES_EDGE_CACHE_CONTROL = "public, max-age=518400, immutable";
+
 export interface R2GetRange {
   offset?: number;
   length?: number;

--- a/apps/files-worker/tsconfig.json
+++ b/apps/files-worker/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "lib": ["ES2022"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "strict": true,

--- a/packages/convex/__tests__/storage/r2.test.ts
+++ b/packages/convex/__tests__/storage/r2.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createHmac } from "node:crypto";
 import {
+  bucketedSignatureExpiry,
   buildSignedFilePayload,
   buildSignedWorkerFileUrl,
 } from "../../storage/r2";
@@ -37,8 +38,9 @@ describe("signed worker file urls", () => {
 
     expect(url.origin + url.pathname).toBe(`${BASE}/${KEY}`);
     const exp = Number.parseInt(url.searchParams.get("exp") ?? "", 10);
-    expect(exp).toBeGreaterThanOrEqual(before + 900);
-    expect(exp).toBeLessThanOrEqual(after + 900);
+    // Default validity is the full 7-day signature lifetime.
+    expect(exp).toBeGreaterThanOrEqual(before + 604_800);
+    expect(exp).toBeLessThanOrEqual(after + 604_800);
 
     // No overrides -> no ct/cd params -> worker falls back to stored metadata.
     expect(url.searchParams.get("ct")).toBeNull();
@@ -46,6 +48,35 @@ describe("signed worker file urls", () => {
     expect(url.searchParams.get("sig")).toBe(
       hmacHex(buildSignedFilePayload({ key: KEY, exp: `${exp}` }))
     );
+  });
+
+  test("mints identical urls for repeated signing within one window", async () => {
+    const first = await buildSignedWorkerFileUrl(BASE, SECRET, KEY);
+    const second = await buildSignedWorkerFileUrl(BASE, SECRET, KEY);
+    expect(second).toBe(first);
+  });
+
+  test("bucketed expiry stays constant per window with ample remaining ttl", () => {
+    const windowSeconds = 6 * 60 * 60;
+    const windowStart =
+      Math.floor(Math.floor(Date.now() / 60_000) * 60 / windowSeconds) *
+      windowSeconds;
+    const inWindow = [
+      windowStart,
+      windowStart + 1,
+      windowStart + windowSeconds - 1,
+    ];
+    const expiries = inWindow.map((now) => bucketedSignatureExpiry(now));
+    expect(new Set(expiries).size).toBe(1);
+
+    // Every minted URL stays valid for at least the full 7-day TTL.
+    expect(expiries[0]).toBeGreaterThanOrEqual(
+      windowStart + windowSeconds - 1 + 604_800
+    );
+
+    // Crossing into the next window mints a new (still valid) expiry.
+    const nextWindow = bucketedSignatureExpiry(windowStart + windowSeconds);
+    expect(nextWindow).toBe(expiries[0]! + windowSeconds);
   });
 
   test("signs content-type and disposition overrides into the token", async () => {

--- a/packages/convex/storage/r2.ts
+++ b/packages/convex/storage/r2.ts
@@ -7,8 +7,38 @@ import type { ActionCtx, MutationCtx } from "../_generated/server";
 import { internalMutation, mutation, query } from "../_generated/server";
 import { inferFileFormat } from "../shared/fileFormats";
 
-const SIGNED_URL_EXPIRES_IN_SECONDS = 15 * 60;
-const PRIVATE_FILE_CACHE_CONTROL = `private, max-age=${SIGNED_URL_EXPIRES_IN_SECONDS}, immutable`;
+// Object keys are content-immutable (every upload writes a fresh UUID key), so
+// signed URLs can live far longer than a single session. Long-lived,
+// time-bucketed URLs keep the URL string identical across reactive query
+// re-runs and page loads, which is what lets the browser HTTP cache actually
+// serve repeat views instead of refetching every card image.
+const SIGNED_URL_EXPIRES_IN_SECONDS = 7 * 24 * 60 * 60; // SigV4 presign cap: 7 days.
+// All signatures produced within one bucket window share the same exp (and
+// therefore the exact same URL). Buckets also guarantee a minimum remaining
+// validity of SIGNED_URL_EXPIRES_IN_SECONDS at generation time.
+const SIGNED_URL_BUCKET_SECONDS = 6 * 60 * 60;
+
+// Must stay below the minimum remaining validity above (7 days); keep in
+// lockstep with FILES_CACHE_CONTROL in apps/files-worker/src/lib.ts.
+const PRIVATE_FILE_CACHE_CONTROL = "private, max-age=518400, immutable"; // 6 days.
+
+/**
+ * Deterministic expiry for the current bucket window: every call made within
+ * the same window returns an identical exp string.
+ */
+export const bucketedSignatureExpiry = (
+  nowSeconds = Math.floor(Date.now() / 1000)
+): number =>
+  (Math.floor(nowSeconds / SIGNED_URL_BUCKET_SECONDS) + 1) *
+    SIGNED_URL_BUCKET_SECONDS +
+  SIGNED_URL_EXPIRES_IN_SECONDS;
+
+// Best-effort memo for the presigned-S3 fallback path (no worker proxy
+// configured): re-signing on every query execution churns the URL string and
+// defeats the browser cache even within a single isolate lifetime. Keyed by
+// object key + response policy, evicted shortly before expiry.
+const presignedUrlMemo = new Map<string, { url: string; refreshAt: number }>();
+const PRESIGN_REFRESH_MARGIN_SECONDS = 15 * 60;
 
 export const r2 = new R2(components.r2);
 
@@ -112,16 +142,32 @@ export const getR2Url = async (
       filesBase,
       signingSecret,
       key,
-      response
+      response,
+      bucketedSignatureExpiry()
     );
   }
-  return getSignedUrl(
+  const memoKey = [
+    key,
+    response.contentType ?? "",
+    response.contentDisposition ?? "",
+  ].join("\n");
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const memoized = presignedUrlMemo.get(memoKey);
+  if (memoized && memoized.refreshAt > nowSeconds) {
+    return memoized.url;
+  }
+  const url = await getSignedUrl(
     getDownloadClient(),
     buildR2DownloadCommand(key, undefined, response),
     {
       expiresIn: SIGNED_URL_EXPIRES_IN_SECONDS,
     }
   );
+  presignedUrlMemo.set(memoKey, {
+    url,
+    refreshAt: nowSeconds + SIGNED_URL_EXPIRES_IN_SECONDS - PRESIGN_REFRESH_MARGIN_SECONDS,
+  });
+  return url;
 };
 
 const hexEncode = (buffer: ArrayBuffer): string =>
@@ -147,7 +193,8 @@ export const buildSignedWorkerFileUrl = async (
   base: string,
   secret: string,
   key: string,
-  response: DownloadResponsePolicy = {}
+  response: DownloadResponsePolicy = {},
+  expSeconds = Math.floor(Date.now() / 1000) + SIGNED_URL_EXPIRES_IN_SECONDS
 ): Promise<string> => {
   const encoder = new TextEncoder();
   const cryptoKey = await crypto.subtle.importKey(
@@ -157,9 +204,7 @@ export const buildSignedWorkerFileUrl = async (
     false,
     ["sign"]
   );
-  const exp = String(
-    Math.floor(Date.now() / 1000) + SIGNED_URL_EXPIRES_IN_SECONDS
-  );
+  const exp = String(expSeconds);
   const signature = hexEncode(
     await crypto.subtle.sign(
       "HMAC",

--- a/packages/convex/storage/r2.ts
+++ b/packages/convex/storage/r2.ts
@@ -18,8 +18,9 @@ const SIGNED_URL_EXPIRES_IN_SECONDS = 7 * 24 * 60 * 60; // SigV4 presign cap: 7 
 // validity of SIGNED_URL_EXPIRES_IN_SECONDS at generation time.
 const SIGNED_URL_BUCKET_SECONDS = 6 * 60 * 60;
 
-// Must stay below the minimum remaining validity above (7 days); keep in
-// lockstep with FILES_CACHE_CONTROL in apps/files-worker/src/lib.ts.
+// Must stay below the signed-URL minimum remaining validity above; keep in
+// lockstep between PRIVATE_FILE_CACHE_CONTROL here (browser-facing) and
+// FILES_CACHE_CONTROL / FILES_EDGE_CACHE_CONTROL in apps/files-worker/src/lib.ts.
 const PRIVATE_FILE_CACHE_CONTROL = "private, max-age=518400, immutable"; // 6 days.
 
 /**

--- a/packages/convex/workflows/steps/renderables/generateThumbnail.ts
+++ b/packages/convex/workflows/steps/renderables/generateThumbnail.ts
@@ -261,12 +261,13 @@ export const generateThumbnail = internalAction({
         targetWidth = Math.round(targetHeight * aspectRatio);
       }
 
-      // Always resize to thumbnail dimensions (let compression do the heavy lifting for size reduction)
+      // Triangle (bilinear) avoids the aliasing/shimmer artifacts that
+      // Nearest introduces on downscales, at a similar encode size.
       const outputImage = resize(
         orientedImage,
         targetWidth,
         targetHeight,
-        SamplingFilter.Nearest
+        SamplingFilter.Triangle
       );
 
       // Generate output bytes with appropriate format and quality

--- a/packages/ui/src/components/cards/Card.tsx
+++ b/packages/ui/src/components/cards/Card.tsx
@@ -24,6 +24,7 @@ import {
 import type { SyntheticEvent } from "react";
 import { memo, useState } from "react";
 import { markdownToPlainText } from "../../lib/markdownToPlainText";
+import { prefetchCardModalMedia } from "../../lib/prefetchCardMedia";
 import { prefetchFileTextPreview } from "../card-previews/fileTextPreviewCache";
 import { AudioWavePreview } from "./previews/AudioWavePreview";
 import { GridDocumentPreview } from "./previews/GridDocumentPreview";
@@ -45,6 +46,7 @@ export const Card = memo(function Card({
   onCopyImage,
   isSelectionMode,
   isSelected,
+  isPriority = false,
   onEnterSelectionMode,
   onToggleSelection,
 }: CardProps) {
@@ -72,6 +74,14 @@ export const Card = memo(function Card({
     }).catch(() => {
       // The modal retries and keeps file facts visible if intent prefetch fails.
     });
+  };
+
+  const handlePrefetch = () => {
+    if (isOptimistic) {
+      return;
+    }
+    prefetchDocumentPreview();
+    prefetchCardModalMedia(card);
   };
 
   const handleClick = () => {
@@ -328,6 +338,7 @@ export const Card = memo(function Card({
           altText={card.content}
           height={card.fileMetadata?.height}
           imageUrl={card.thumbnailUrl ?? card.fileUrl ?? undefined}
+          isPriority={isPriority}
           width={card.fileMetadata?.width}
         />
       );
@@ -341,6 +352,7 @@ export const Card = memo(function Card({
         <GridVideoPreview
           height={card.fileMetadata?.height}
           isGif={isGif}
+          isPriority={isPriority}
           thumbnailUrl={card.thumbnailUrl ?? undefined}
           videoUrl={card.fileUrl ?? undefined}
           width={card.fileMetadata?.width}
@@ -357,6 +369,7 @@ export const Card = memo(function Card({
         <GridDocumentPreview
           fileName={card.fileMetadata?.fileName || card.content}
           height={card.fileMetadata?.height}
+          isPriority={isPriority}
           thumbnailUrl={card.thumbnailUrl ?? undefined}
           width={card.fileMetadata?.width}
         />
@@ -410,9 +423,9 @@ export const Card = memo(function Card({
             isOptimistic ? "cursor-default opacity-70" : "cursor-pointer"
           } ${card.isDeleted ? "opacity-60" : ""} ${isSelected ? "rounded-xl ring-2 ring-primary" : ""}`}
           onClick={handleClick}
-          onFocus={prefetchDocumentPreview}
-          onPointerDown={prefetchDocumentPreview}
-          onPointerEnter={prefetchDocumentPreview}
+          onFocus={handlePrefetch}
+          onPointerDown={handlePrefetch}
+          onPointerEnter={handlePrefetch}
         >
           {isOptimistic && (
             <div className="absolute inset-0 z-10 flex items-center justify-center">

--- a/packages/ui/src/components/cards/previews/GridDocumentPreview.tsx
+++ b/packages/ui/src/components/cards/previews/GridDocumentPreview.tsx
@@ -4,6 +4,7 @@ import { File } from "lucide-react";
 interface GridDocumentPreviewProps {
   fileName?: string;
   height?: number;
+  isPriority?: boolean;
   thumbnailUrl?: string;
   width?: number;
 }
@@ -17,6 +18,7 @@ export function GridDocumentPreview({
   fileName,
   width,
   height,
+  isPriority = false,
 }: GridDocumentPreviewProps) {
   if (thumbnailUrl) {
     return (
@@ -31,7 +33,9 @@ export function GridDocumentPreview({
           <Image
             alt={`Preview of ${fileName || "document"}`}
             className="h-full w-full bg-muted object-contain"
-            loading="lazy"
+            decoding="async"
+            fetchPriority={isPriority ? "high" : undefined}
+            loading={isPriority ? "eager" : "lazy"}
             preview={false}
             rootClassName="h-full w-full"
             src={thumbnailUrl}

--- a/packages/ui/src/components/cards/previews/GridImagePreview.tsx
+++ b/packages/ui/src/components/cards/previews/GridImagePreview.tsx
@@ -4,6 +4,7 @@ interface GridImagePreviewProps {
   altText?: string;
   height?: number;
   imageUrl?: string;
+  isPriority?: boolean;
   width?: number;
 }
 
@@ -12,6 +13,7 @@ export function GridImagePreview({
   altText,
   width,
   height,
+  isPriority = false,
 }: GridImagePreviewProps) {
   return (
     <div
@@ -22,7 +24,9 @@ export function GridImagePreview({
         <Image
           alt={altText ?? "Image"}
           className="h-full w-full object-cover"
-          loading="lazy"
+          decoding="async"
+          fetchPriority={isPriority ? "high" : undefined}
+          loading={isPriority ? "eager" : "lazy"}
           preview={false}
           rootClassName="h-full w-full"
           src={imageUrl}

--- a/packages/ui/src/components/cards/previews/GridVideoPreview.tsx
+++ b/packages/ui/src/components/cards/previews/GridVideoPreview.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react";
 interface GridVideoPreviewProps {
   height?: number;
   isGif?: boolean;
+  isPriority?: boolean;
   thumbnailUrl?: string;
   videoUrl?: string;
   width?: number;
@@ -22,10 +23,12 @@ function PlayOverlay() {
 
 function HoverVideoPreview({
   aspectRatio,
+  isPriority,
   thumbnailUrl,
   videoUrl,
 }: {
   aspectRatio: number;
+  isPriority?: boolean;
   thumbnailUrl?: string;
   videoUrl: string;
 }) {
@@ -76,7 +79,9 @@ function HoverVideoPreview({
           <Image
             alt="Video thumbnail"
             className="h-full w-full object-cover"
-            loading="lazy"
+            decoding="async"
+            fetchPriority={isPriority ? "high" : undefined}
+            loading={isPriority ? "eager" : "lazy"}
             preview={false}
             rootClassName="h-full w-full"
             src={thumbnailUrl}
@@ -111,6 +116,7 @@ function HoverVideoPreview({
 export function GridVideoPreview({
   height,
   isGif,
+  isPriority,
   thumbnailUrl,
   videoUrl,
   width,
@@ -126,8 +132,10 @@ export function GridVideoPreview({
         <img
           alt="GIF preview"
           className="h-full w-full object-cover"
+          decoding="async"
+          fetchPriority={isPriority ? "high" : undefined}
           height={height ?? 480}
-          loading="lazy"
+          loading={isPriority ? "eager" : "lazy"}
           src={videoUrl}
           width={width ?? 640}
         />
@@ -139,6 +147,7 @@ export function GridVideoPreview({
     return (
       <HoverVideoPreview
         aspectRatio={aspectRatio}
+        isPriority={isPriority}
         thumbnailUrl={thumbnailUrl}
         videoUrl={videoUrl}
       />
@@ -154,7 +163,9 @@ export function GridVideoPreview({
         <Image
           alt="Video thumbnail"
           className="h-full w-full object-cover"
-          loading="lazy"
+          decoding="async"
+          fetchPriority={isPriority ? "high" : undefined}
+          loading={isPriority ? "eager" : "lazy"}
           preview={false}
           rootClassName="h-full w-full"
           src={thumbnailUrl}

--- a/packages/ui/src/components/cards/previews/__tests__/GridDocumentPreview.test.tsx
+++ b/packages/ui/src/components/cards/previews/__tests__/GridDocumentPreview.test.tsx
@@ -15,8 +15,13 @@ describe("GridDocumentPreview", () => {
     expect(source).toContain("aspectRatio:");
   });
 
-  test("contains the lazy-loaded thumbnail inside the reserved box", () => {
-    expect(source).toContain('loading="lazy"');
+  test("lazy-loads the thumbnail inside the reserved box by default", () => {
+    expect(source).toContain('loading={isPriority ? "eager" : "lazy"}');
     expect(source).toContain('className="relative w-full overflow-hidden"');
+  });
+
+  test("prioritizes above-the-fold thumbnails", () => {
+    expect(source).toContain('fetchPriority={isPriority ? "high" : undefined}');
+    expect(source).toContain('decoding="async"');
   });
 });

--- a/packages/ui/src/components/cards/previews/__tests__/GridImagePreview.test.tsx
+++ b/packages/ui/src/components/cards/previews/__tests__/GridImagePreview.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const source = readFileSync(
+  join(import.meta.dir, "../GridImagePreview.tsx"),
+  "utf8"
+);
+
+describe("GridImagePreview", () => {
+  test("lazy-loads by default and reserves aspect ratio", () => {
+    expect(source).toContain('loading={isPriority ? "eager" : "lazy"}');
+    expect(source).toContain("aspectRatio:");
+  });
+
+  test("prioritizes above-the-fold images", () => {
+    expect(source).toContain('fetchPriority={isPriority ? "high" : undefined}');
+    expect(source).toContain('decoding="async"');
+  });
+});

--- a/packages/ui/src/components/cards/types.ts
+++ b/packages/ui/src/components/cards/types.ts
@@ -56,6 +56,8 @@ export interface CardProps {
   card: CardWithUrls & Record<string, unknown>;
   isSelected?: boolean;
   isSelectionMode?: boolean;
+  /** Above-the-fold card: its media loads eagerly with high priority. */
+  isPriority?: boolean;
   isTrashMode?: boolean;
   onAddTags?: (cardId: string) => void;
   onClick?: (card: CardWithUrls & Record<string, unknown>) => void;

--- a/packages/ui/src/components/grids/MasonryGrid.tsx
+++ b/packages/ui/src/components/grids/MasonryGrid.tsx
@@ -12,6 +12,7 @@ type CardItem = Doc<"cards"> | "add-form";
 
 interface MasonryItemData {
   data: CardItem;
+  isPriority?: boolean;
   key: string | number;
 }
 
@@ -28,6 +29,9 @@ type MasonryColumns =
 
 const DEFAULT_BATCH_SIZE = 24;
 const DEFAULT_ROOT_MARGIN = "200px 0px";
+// Cards near the top of the grid are above the fold on every screen size, so
+// their media loads eagerly with high fetch priority instead of lazily.
+const PRIORITY_CARD_COUNT = 10;
 
 export interface MasonryGridProps {
   AddCardFormComponent?: React.ComponentType;
@@ -305,10 +309,13 @@ export function MasonryGrid({
       });
     }
 
-    for (const card of filteredCards.slice(0, visibleCount)) {
+    for (const [index, card] of filteredCards
+      .slice(0, visibleCount)
+      .entries()) {
       items.push({
-        key: card._id,
         data: card,
+        isPriority: index < PRIORITY_CARD_COUNT,
+        key: card._id,
       });
     }
 
@@ -334,6 +341,7 @@ export function MasonryGrid({
           card={card}
           isSelected={selectedCardIds.has(card._id)}
           isSelectionMode={isSelectionMode}
+          isPriority={item.isPriority === true}
           isTrashMode={showTrashOnly}
           onAddTags={onAddTags}
           onClick={handleCardClick}

--- a/packages/ui/src/lib/__tests__/prefetchCardMedia.test.ts
+++ b/packages/ui/src/lib/__tests__/prefetchCardMedia.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { prefetchCardModalMedia } from "../prefetchCardMedia";
+
+class StubImage {
+  static created: StubImage[] = [];
+  decoding?: string;
+  src = "";
+
+  constructor() {
+    StubImage.created.push(this);
+  }
+}
+
+describe("lib/prefetchCardMedia", () => {
+  test("warms image cards once per url", () => {
+    const originalImage = globalThis.Image;
+    globalThis.Image = StubImage as unknown as typeof Image;
+    try {
+      const card = {
+        fileUrl: "https://files.example.com/original.jpg",
+        thumbnailUrl: "https://files.example.com/thumb.webp",
+        type: "image",
+      };
+      prefetchCardModalMedia(card);
+      prefetchCardModalMedia(card);
+
+      expect(StubImage.created).toHaveLength(1);
+      expect(StubImage.created[0]!.src).toBe(card.fileUrl);
+    } finally {
+      globalThis.Image = originalImage;
+    }
+  });
+
+  test("warms only the poster for video cards and ignores other types", () => {
+    const originalImage = globalThis.Image;
+    globalThis.Image = StubImage as unknown as typeof Image;
+    StubImage.created.length = 0;
+    try {
+      prefetchCardModalMedia({
+        fileUrl: "https://files.example.com/clip.mp4",
+        thumbnailUrl: "https://files.example.com/poster.webp",
+        type: "video",
+      });
+      prefetchCardModalMedia({
+        content: "just text",
+        type: "text",
+      });
+
+      expect(StubImage.created).toHaveLength(1);
+      expect(StubImage.created[0]!.src).toBe(
+        "https://files.example.com/poster.webp"
+      );
+    } finally {
+      globalThis.Image = originalImage;
+    }
+  });
+});

--- a/packages/ui/src/lib/prefetchCardMedia.ts
+++ b/packages/ui/src/lib/prefetchCardMedia.ts
@@ -1,0 +1,36 @@
+// Warm the browser cache with the URLs a card's modal view will request, so
+// opening the modal feels instant. Called from grid cards on pointer enter;
+// each URL is fetched at most once per page session.
+
+const prefetchedUrls = new Set<string>();
+
+const warmImage = (url: string | null | undefined): void => {
+  if (!url || prefetchedUrls.has(url)) {
+    return;
+  }
+  prefetchedUrls.add(url);
+  const image = new Image();
+  image.decoding = "async";
+  image.src = url;
+};
+
+interface PrefetchableMedia {
+  fileUrl?: string | null;
+  thumbnailUrl?: string | null;
+  type?: string | null;
+}
+
+/**
+ * Prefetch the media the card modal will render. Image cards load their full
+ * file in the modal, so that is what gets warmed; videos only warm their
+ * poster thumbnail since the clip itself should keep streaming on demand.
+ */
+export const prefetchCardModalMedia = (card: PrefetchableMedia): void => {
+  if (card.type === "image") {
+    warmImage(card.fileUrl ?? card.thumbnailUrl);
+    return;
+  }
+  if (card.type === "video") {
+    warmImage(card.thumbnailUrl);
+  }
+};


### PR DESCRIPTION
## Summary

Four targeted changes that make image- and video-heavy libraries load much faster:

### 1. Stable, long-lived signed file URLs (biggest win)
`resolveObjectUrl` re-signed every file URL with a fresh 15-minute expiry on every Convex query execution. Any reactive update (new card, favorite toggle) changed the URL string for **every** card, so all `<img src>` elements changed and the browser refetched everything — the `immutable` cache header never got used.

Signed URLs are now deterministic per 6-hour bucket with 7-day validity (`bucketedSignatureExpiry`). Object keys are content-immutable (UUID per upload), so this is safe. Cache-Control raised from `max-age=900` to `private, max-age=518400, immutable` in lockstep between `packages/convex/storage/r2.ts` and the worker. The presigned-S3 fallback path (dev) is memoized per key+policy until shortly before expiry.

**Trade-off note:** leaked URLs now stay valid up to ~7 days instead of 15 minutes. They remain HMAC-signed and user-scoped; happy to tune TTL down if that's too long.

### 2. HTTP Range support in files-worker
The worker ignored `Range` headers — every video/audio seek restarted the download from byte 0. Now parses single byte-ranges, resolves them against true object size via `head()` for exact `Content-Range` math, returns proper `206`/`416`, and advertises `Accept-Ranges: bytes`.

### 3. Edge caching in files-worker
Full-object responses are served from / written to the Cloudflare edge cache (`caches.default`), keyed by object path + ct/cd policy. Keys embed the per-user hash prefix so entries are never shared across users; signatures are still verified **before** any cache lookup. Ranged requests always bypass the cache.

### 4. Frontend priority hints + hover prefetch
- First 10 grid cards render their media `loading="eager"` + `fetchpriority="high"`; everything else stays lazy.
- Pointer-enter on a grid card prefetches what its modal will show (image originals via a once-per-URL set; video posters), alongside the existing document-text prefetch.

Also: thumbnails now downscale with Triangle (bilinear) instead of Nearest filtering — same byte cost, no aliasing artifacts.

## Test plan
- [x] New tests: range parsing (worker), URL stability + bucketed expiry (convex), priority loading (grid previews), prefetch dedupe util
- [x] `bun run typecheck`, `bun run lint`, `bun run test` pass (pre-existing env-dependent failures in mcp/billing test files reproduced on clean `main`)
- [x] Pre-commit turbo build passes across all workspaces