### PR TITLE
feat(ai): switch AI processing from Groq to Cloudflare Workers AI

### DIFF
--- a/apps/docs/content/docs/(developers)/development.mdx
+++ b/apps/docs/content/docs/(developers)/development.mdx
@@ -78,7 +78,7 @@ description: Setup and development workflow for Teak
 | Extensions | Wxt (Chrome), native Safari Web Extension (macOS) |
 | Auth       | Better Auth                                       |
 | UI         | shadcn/ui + Radix                                 |
-| AI         | Groq API                                          |
+| AI         | Cloudflare Workers AI                             |
 | Billing    | Polar                                             |
 | Testing    | Bun (unit), Playwright (E2E)                      |
 | Monorepo   | Turborepo                                         |

--- a/apps/docs/content/docs/(developers)/self-hosting.mdx
+++ b/apps/docs/content/docs/(developers)/self-hosting.mdx
@@ -8,7 +8,7 @@ sidebar:
 ## What you'll need
 
 - Convex CLI (`npm i -g convex`)
-- Access to secrets for the features you want: Groq (AI), Kernel (screenshots), Resend (email), Polar (billing)
+- Access to secrets for the features you want: Cloudflare Workers AI (AI), Kernel (screenshots), Resend (email), Polar (billing)
 
 :::warning[Beta]
 Self-hosting matches the hosted product, but you own uptime, secrets, and
@@ -43,7 +43,8 @@ public domain at it.
     npx convex env set TEAK_ADMIN_EMAIL you@example.com
 
     # Optional: AI (if you want card processing)
-    npx convex env set GROQ_API_KEY gsk_...
+    npx convex env set CLOUDFLARE_ACCOUNT_ID your-account-id
+    npx convex env set CLOUDFLARE_API_TOKEN your-api-token
     ```
   </Step>
   <Step title="Create local env files">
@@ -105,7 +106,8 @@ R2_SECRET_ACCESS_KEY=secret-key              # R2 S3 secret key
 R2_ENDPOINT=https://account.r2.cloudflarestorage.com
 R2_BUCKET=teak-files                         # R2 bucket for private assets
 KERNEL_API_KEY=token                         # Kernel Browser
-GROQ_API_KEY=gsk_...                         # AI processing
+CLOUDFLARE_ACCOUNT_ID=your-account-id        # AI processing (Workers AI)
+CLOUDFLARE_API_TOKEN=your-api-token          # AI processing (Workers AI)
 POLAR_ACCESS_TOKEN=token                     # Billing
 POLAR_ORGANIZATION_TOKEN=token               # Polar organization
 POLAR_SERVER=sandbox                         # sandbox|production
@@ -164,7 +166,7 @@ Convex serves the REST API at `/api/v1`, the MCP endpoint at `/mcp`, plus `/heal
   - `TEAK_ADMIN_EMAIL`: The normalized email address of the one account allowed to use administrative functions. Configure this independently for development and production.
 - **Optional Features**:
   - `R2_*`: Create a private Cloudflare R2 bucket and an API token/S3 credentials with object read, write, and delete access.
-  - `GROQ_API_KEY`: Get from [Groq Console](https://console.groq.com/) for AI-powered card processing.
+  - `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN`: Get from the [Cloudflare dashboard](https://dash.cloudflare.com/) — create an API token with Workers AI run permission for AI-powered card processing.
   - `KERNEL_API_KEY`: Get from [Kernel](https://onkernel.com/) for automated link screenshots.
   - `RESEND_API_KEY`: Get from [Resend](https://resend.com/) for email verification and password resets.
   - `POLAR_*`: Get from [Polar](https://polar.sh/) if you want to use the built-in billing system.

--- a/bun.lock
+++ b/bun.lock
@@ -219,7 +219,7 @@
       "name": "@teak/convex",
       "version": "1.0.64",
       "dependencies": {
-        "@ai-sdk/groq": "^4.0.26",
+        "@ai-sdk/openai-compatible": "^3.0.35",
         "@aws-sdk/client-s3": "3.1106.0",
         "@aws-sdk/s3-request-presigner": "3.1106.0",
         "@better-auth/expo": "1.6.26",
@@ -357,11 +357,11 @@
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.46", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.25", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LIAO6kAG8fpXQb9L0iwPk1FIbXftvqnyC56v5NEAzeWTeL8fUsy/Hx86VPBTWEDFdwbVprjWifJOAqS6AOj3mA=="],
 
-    "@ai-sdk/groq": ["@ai-sdk/groq@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.25" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HlOdOYdy9eD12ljEudbU6r/pz90bHNRjI7lieByrvxaq0wDzrvdSa0LkkVUHZRV9gxKnUtYD1gU3MfmX6PZK4w=="],
+    "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@3.0.35", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@ai-sdk/provider-utils": "5.0.29" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-zXN7FtaUALqE677kLjUf+CwvXCrLdGP+1MnZZVmHEHTmcAAcovescUF0Iy8APds7+aZOT29rMS90ClXvBf8PGA=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@4.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.25", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-xscPPHCSjCHWrdhai25sbHCJeKNLW/3D1uSpUZa4cEtTKXA8OnPQ3+Rfu1SmM5Ea/Mf8Dfn3cllw9zeMzo/zFA=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.29", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7EIbwXiXKGa7EFk6tDZpuZBs6lxhEJpOuHeqrDb3Vd85uYdjwkdRuHnZDVDIIb2+QTSRmyph2NrXcbvuO/KAjQ=="],
 
     "@aklinker1/rollup-plugin-visualizer": ["@aklinker1/rollup-plugin-visualizer@5.12.0", "", { "dependencies": { "open": "^8.4.0", "picomatch": "^2.3.1", "source-map": "^0.7.4", "yargs": "^17.5.1" }, "peerDependencies": { "rollup": "2.x || 3.x || 4.x" }, "optionalPeers": ["rollup"], "bin": { "rollup-plugin-visualizer": "dist/bin/cli.js" } }, "sha512-X24LvEGw6UFmy0lpGJDmXsMyBD58XmX1bbwsaMLhNoM+UMQfQ3b2RtC+nz4b/NoRK5r6QJSKJHBNVeUdwqybaQ=="],
 
@@ -4677,6 +4677,8 @@
 
     "@1natsu/wait-element/defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
+    "@ai-sdk/gateway/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.25", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-xscPPHCSjCHWrdhai25sbHCJeKNLW/3D1uSpUZa4cEtTKXA8OnPQ3+Rfu1SmM5Ea/Mf8Dfn3cllw9zeMzo/zFA=="],
+
     "@aklinker1/rollup-plugin-visualizer/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
     "@aklinker1/rollup-plugin-visualizer/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -5136,6 +5138,8 @@
     "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "aggregate-error/clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
+
+    "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.25", "", { "dependencies": { "@ai-sdk/provider": "4.0.7", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-xscPPHCSjCHWrdhai25sbHCJeKNLW/3D1uSpUZa4cEtTKXA8OnPQ3+Rfu1SmM5Ea/Mf8Dfn3cllw9zeMzo/zFA=="],
 
     "ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 

--- a/packages/convex/__tests__/shared/metrics.test.ts
+++ b/packages/convex/__tests__/shared/metrics.test.ts
@@ -128,8 +128,8 @@ describe("trackAiRetry", () => {
     });
 
     trackAiRetry({
-      model: "qwen/qwen3.6-27b",
-      provider: "groq",
+      model: "@cf/qwen/qwen3-30b-a3b-fp8",
+      provider: "cloudflare",
       reason: "validation",
     });
 
@@ -137,8 +137,8 @@ describe("trackAiRetry", () => {
       {
         attributes: {
           environment: "production",
-          model: "qwen/qwen3.6-27b",
-          provider: "groq",
+          model: "@cf/qwen/qwen3-30b-a3b-fp8",
+          provider: "cloudflare",
           reason: "validation",
           surface: "backend",
         },

--- a/packages/convex/__tests__/shared/telemetry.test.ts
+++ b/packages/convex/__tests__/shared/telemetry.test.ts
@@ -72,7 +72,7 @@ describe("telemetry privacy and bounds", () => {
     const value = [
       "Authorization: Bearer secret.token.value",
       '"session":"session-secret"',
-      "GROQ_API_KEY=groq-secret",
+      "CLOUDFLARE_API_TOKEN=cf-secret",
       "owner@example.com",
       "https://bucket.example/file?X-Amz-Signature=secret&X-Amz-Expires=60",
       "data:image/png;base64,AAAAAA==",
@@ -81,7 +81,7 @@ describe("telemetry privacy and bounds", () => {
 
     expect(scrubbed).not.toContain("secret.token.value");
     expect(scrubbed).not.toContain("session-secret");
-    expect(scrubbed).not.toContain("groq-secret");
+    expect(scrubbed).not.toContain("cf-secret");
     expect(scrubbed).not.toContain("owner@example.com");
     expect(scrubbed).not.toContain("X-Amz-Signature");
     expect(scrubbed).not.toContain("AAAAAA");
@@ -215,9 +215,9 @@ describe("telemetry naming and sampling", () => {
   });
 
   test("normalizes error classes without emitting messages", () => {
-    expect(normalizeErrorClass(new Error("Groq generation rejected"))).toBe(
-      "ProviderError"
-    );
+    expect(
+      normalizeErrorClass(new Error("Workers AI generation rejected"))
+    ).toBe("ProviderError");
     expect(normalizeErrorClass(new Error("Request timed out"))).toBe(
       "TimeoutError"
     );

--- a/packages/convex/__tests__/telemetry/sentry.test.ts
+++ b/packages/convex/__tests__/telemetry/sentry.test.ts
@@ -210,7 +210,7 @@ describe("backend Sentry OpenTelemetry", () => {
   });
 
   test("captures application failures without changing the thrown error", async () => {
-    const applicationError = new Error("Groq generation failed");
+    const applicationError = new Error("Workers AI generation failed");
 
     await expect(
       telemetry.withBackendSpan(

--- a/packages/convex/__tests__/workflows/aiMetadata/generators.test.ts
+++ b/packages/convex/__tests__/workflows/aiMetadata/generators.test.ts
@@ -1,5 +1,13 @@
 // @ts-nocheck
-import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 const aiMocks = (global as any).__AI_MOCKS__ ?? {};
 aiMocks.generateText ??= mock();
@@ -30,7 +38,17 @@ const mockResponse = {
 };
 
 describe("aiMetadata generators", () => {
+  const originalFetch = global.fetch;
+  const mockImageDownload = mock();
+
   beforeAll(async () => {
+    // Image generation downloads bytes inline for Workers AI.
+    mockImageDownload.mockResolvedValue({
+      ok: true,
+      headers: { get: () => "image/png" },
+      arrayBuffer: async () => new ArrayBuffer(8),
+    });
+    global.fetch = mockImageDownload;
     const mod = await import("../../../workflows/aiMetadata/generators");
     generateTextMetadata = mod.generateTextMetadata;
     generateImageMetadata = mod.generateImageMetadata;
@@ -41,6 +59,10 @@ describe("aiMetadata generators", () => {
     maxRetries = mod.MAX_AI_METADATA_RETRIES;
     maxValidationRetries = mod.MAX_AI_METADATA_VALIDATION_RETRIES;
     isAiProviderCapacityError = mod.isAiProviderCapacityError;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
   });
 
   beforeEach(() => {
@@ -63,9 +85,6 @@ describe("aiMetadata generators", () => {
         prompt: expect.stringContaining("some content"),
         maxRetries,
         maxOutputTokens,
-        providerOptions: {
-          groq: { reasoningEffort: "low", structuredOutputs: false },
-        },
       })
     );
   });
@@ -82,7 +101,6 @@ describe("aiMetadata generators", () => {
         messages: expect.arrayContaining([expect.any(Object)]),
         maxRetries,
         maxOutputTokens,
-        providerOptions: { groq: { structuredOutputs: false } },
       })
     );
   });
@@ -99,9 +117,6 @@ describe("aiMetadata generators", () => {
         prompt: expect.stringContaining("page content"),
         maxRetries,
         maxOutputTokens,
-        providerOptions: {
-          groq: { reasoningEffort: "low", structuredOutputs: false },
-        },
       })
     );
   });

--- a/packages/convex/__tests__/workflows/aiMetadata/transcript.test.ts
+++ b/packages/convex/__tests__/workflows/aiMetadata/transcript.test.ts
@@ -9,20 +9,21 @@ import {
   test,
 } from "bun:test";
 
-const aiMocks = (global as any).__AI_MOCKS__ ?? {};
-aiMocks.generateText ??= mock();
-aiMocks.generateObject ??= mock();
-aiMocks.experimental_transcribe ??= mock();
-aiMocks.Output ??= { object: mock() };
-(global as any).__AI_MOCKS__ = aiMocks;
-const mockTranscribe = aiMocks.experimental_transcribe;
-
-mock.module("ai", () => aiMocks);
-
 const originalFetch = global.fetch;
 const mockFetch = mock();
 
 let generateTranscript: any;
+
+const audioResponse = (mimeType = "audio/mp3") => ({
+  ok: true,
+  headers: { get: () => mimeType },
+  arrayBuffer: async () => new ArrayBuffer(8),
+});
+
+const workersAiResponse = (text: string) => ({
+  ok: true,
+  json: async () => ({ result: { text }, success: true }),
+});
 
 describe("generateTranscript", () => {
   beforeAll(async () => {
@@ -37,20 +38,23 @@ describe("generateTranscript", () => {
   });
 
   beforeEach(() => {
-    mockTranscribe.mockReset();
     mockFetch.mockReset();
   });
 
   test("generates transcript successfully", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      headers: { get: () => "audio/mp3" },
-      arrayBuffer: async () => new ArrayBuffer(8),
-    });
-    mockTranscribe.mockResolvedValue({ text: "Transcript text" });
+    mockFetch
+      .mockResolvedValueOnce(audioResponse())
+      .mockResolvedValueOnce(workersAiResponse("Transcript text"));
 
     const result = await generateTranscript("https://audio.com/file.mp3");
     expect(result).toBe("Transcript text");
+
+    const request = mockFetch.mock.calls[1]?.[0];
+    expect(request).toContain("/ai/run/@cf/openai/whisper-large-v3-turbo");
+    expect(mockFetch.mock.calls[1]?.[1]?.method).toBe("POST");
+    expect(mockFetch.mock.calls[1]?.[1]?.headers["Content-Type"]).toBe(
+      "audio/mp3"
+    );
   });
 
   test("handles fetch error", async () => {
@@ -63,36 +67,45 @@ describe("generateTranscript", () => {
     expect(result).toBeNull();
   });
 
-  test("handles transcription error", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      headers: { get: () => "audio/mp3" },
-      arrayBuffer: async () => new ArrayBuffer(8),
+  test("handles transcription error response", async () => {
+    mockFetch.mockResolvedValueOnce(audioResponse()).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      json: async () => ({
+        errors: [{ message: "Invalid input" }],
+        success: false,
+      }),
     });
-    mockTranscribe.mockRejectedValue(new Error("AI error"));
+    const result = await generateTranscript("url");
+    expect(result).toBeNull();
+  });
+
+  test("handles network error during transcription", async () => {
+    mockFetch
+      .mockResolvedValueOnce(audioResponse())
+      .mockRejectedValueOnce(new Error("AI error"));
     const result = await generateTranscript("url");
     expect(result).toBeNull();
   });
 
   test("mime type extension logic > covers all branches", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      headers: { get: () => "audio/wav" },
-      arrayBuffer: async () => new ArrayBuffer(8),
-    });
-    mockTranscribe.mockResolvedValue({ text: "Wav" });
+    mockFetch
+      .mockResolvedValueOnce(audioResponse("audio/wav"))
+      .mockResolvedValueOnce(workersAiResponse("Wav"));
     await generateTranscript("u");
-    expect(mockTranscribe).toHaveBeenCalled();
+    expect(mockFetch.mock.calls[1]?.[1]?.headers["Content-Type"]).toBe(
+      "audio/wav"
+    );
   });
 
   test("mime type extension logic > uses mimeHint", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      headers: { get: () => "audio/unknown" },
-      arrayBuffer: async () => new ArrayBuffer(8),
-    });
-    mockTranscribe.mockResolvedValue({ text: "Mime" });
+    mockFetch
+      .mockResolvedValueOnce(audioResponse("audio/unknown"))
+      .mockResolvedValueOnce(workersAiResponse("Mime"));
     await generateTranscript("u", "audio/mp4");
-    expect(mockTranscribe).toHaveBeenCalled();
+    expect(mockFetch.mock.calls[1]?.[1]?.headers["Content-Type"]).toBe(
+      "audio/mp4"
+    );
   });
 });

--- a/packages/convex/__tests__/workflows/steps/metadata.test.ts
+++ b/packages/convex/__tests__/workflows/steps/metadata.test.ts
@@ -152,6 +152,12 @@ describe("metadata handler", () => {
     aiMocks.generateText.mockResolvedValue({
       output: { tags: ["tag1"], summary: "summary" },
     });
+    // Image metadata downloads bytes inline before analysis.
+    mockFetch.mockResolvedValue({
+      ok: true,
+      headers: { get: () => "image/jpeg" },
+      arrayBuffer: async () => new ArrayBuffer(8),
+    });
   });
 
   describe("error handling", () => {
@@ -492,14 +498,19 @@ describe("metadata handler", () => {
         fileMetadata: { mimeType: "audio/mp3" },
       });
       r2Mocks.resolveObjectUrl.mockResolvedValue("https://audio.mp3");
-      mockFetch.mockResolvedValue({
-        ok: true,
-        headers: { get: () => "audio/mp3" },
-        arrayBuffer: async () => new ArrayBuffer(8),
-      });
-      aiMocks.experimental_transcribe.mockResolvedValue({
-        text: "spoken text in audio",
-      });
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: { get: () => "audio/mp3" },
+          arrayBuffer: async () => new ArrayBuffer(8),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            result: { text: "spoken text in audio" },
+            success: true,
+          }),
+        });
       aiMocks.generateText.mockResolvedValue({
         output: { tags: ["speech"], summary: "Audio content" },
       });

--- a/packages/convex/ai/models.ts
+++ b/packages/convex/ai/models.ts
@@ -1,52 +1,57 @@
-import { groq } from "@ai-sdk/groq";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+
+/**
+ * Cloudflare Workers AI accessed through its OpenAI-compatible REST endpoint
+ * (`/ai/v1/chat/completions`). Credentials come from the Convex environment:
+ * CLOUDFLARE_ACCOUNT_ID + CLOUDFLARE_API_TOKEN (token needs Workers AI run
+ * permission).
+ */
+export const workersAi = createOpenAICompatible({
+  apiKey: process.env.CLOUDFLARE_API_TOKEN ?? "",
+  baseURL: `https://api.cloudflare.com/client/v4/accounts/${
+    process.env.CLOUDFLARE_ACCOUNT_ID ?? ""
+  }/ai/v1`,
+  name: "cloudflare-workers-ai",
+});
 
 /**
  * Model for text metadata generation (tags, summaries)
- * Supports prompt caching for 50% cost savings on cached tokens
+ * Qwen 3 MoE (3B active) — cheapest capable option on Workers AI.
+ * The "/no_think" suffix appended to prompts suppresses reasoning tokens.
  */
-export const TEXT_METADATA_MODEL = groq("openai/gpt-oss-20b");
-export const TEXT_METADATA_MODEL_ID = "openai/gpt-oss-20b" as const;
+export const TEXT_METADATA_MODEL = workersAi("@cf/qwen/qwen3-30b-a3b-fp8");
+export const TEXT_METADATA_MODEL_ID = "@cf/qwen/qwen3-30b-a3b-fp8" as const;
 
 /**
  * Model for link content analysis
- * Supports prompt caching for 50% cost savings on cached tokens
  */
-export const LINK_METADATA_MODEL = groq("openai/gpt-oss-20b");
-export const LINK_METADATA_MODEL_ID = "openai/gpt-oss-20b" as const;
+export const LINK_METADATA_MODEL = workersAi("@cf/qwen/qwen3-30b-a3b-fp8");
+export const LINK_METADATA_MODEL_ID = "@cf/qwen/qwen3-30b-a3b-fp8" as const;
 
 /**
  * Model for image/vision analysis
- * Note: Currently does NOT support prompt caching
- * Uses Qwen 3.6 27B for multimodal vision after Llama 4 Scout deprecation
+ * Gemma 4 26B A4B — multimodal with strong OCR/UI understanding at a low
+ * price point. Reasoning is kept on but nudged off via the system prompt.
  */
-export const IMAGE_METADATA_MODEL_ID = "qwen/qwen3.6-27b" as const;
-export const IMAGE_METADATA_MODEL = groq(IMAGE_METADATA_MODEL_ID);
-
-/**
- * Model for changelog generation (docs)
- * Supports prompt caching for 50% cost savings on cached tokens
- * Using larger model for better quality summaries
- */
-export const CHANGELOG_MODEL = groq("openai/gpt-oss-120b");
-export const CHANGELOG_MODEL_ID = "openai/gpt-oss-120b" as const;
+export const IMAGE_METADATA_MODEL_ID = "@cf/google/gemma-4-26b-a4b-it" as const;
+export const IMAGE_METADATA_MODEL = workersAi(IMAGE_METADATA_MODEL_ID);
 
 /**
  * Transcription model for audio content
- * Uses Whisper for fast, accurate speech-to-text
+ * Whisper large v3 turbo — billed per audio minute via the REST `/ai/run`
+ * endpoint (see workflows/aiMetadata/transcript.ts).
  */
-export const TRANSCRIPTION_MODEL = groq.transcription("whisper-large-v3-turbo");
-export const TRANSCRIPTION_MODEL_ID = "whisper-large-v3-turbo" as const;
+export const TRANSCRIPTION_MODEL_ID =
+  "@cf/openai/whisper-large-v3-turbo" as const;
 
 /**
- * System prompts optimized for prompt caching
- * These are placed at the beginning of requests to maximize cache hits
+ * System prompts optimized for reuse across requests.
  */
 export const SYSTEM_PROMPTS = {
   /**
    * System prompt for text content analysis
-   * Static content - will be cached across requests
    */
-  textAnalysis: `You are an expert content analyzer. Generate relevant tags and a concise summary for the given content.
+  textAnalysis: `You are an expert content analyzer. Generate relevant tags and a concise summary for the given content. /no_think
 
 Guidelines:
 - Tags should be 5-6 specific, relevant single words only (no spaces, no hyphens)
@@ -59,9 +64,8 @@ Respond with a single JSON object using exactly this shape and no other keys:
 
   /**
    * System prompt for image analysis
-   * Static content - helps with potential future caching support
    */
-  imageAnalysis: `You are an expert image analyzer. Generate relevant tags and a concise summary for the given image.
+  imageAnalysis: `You are an expert image analyzer. Generate relevant tags and a concise summary for the given image. Answer directly without thinking step by step.
 
 Guidelines:
 - Tags should be 5-6 single words describing objects, scenes, concepts, emotions (no spaces, no hyphens)
@@ -74,9 +78,8 @@ Respond with a single JSON object using exactly this shape and no other keys:
 
   /**
    * System prompt for web content analysis
-   * Static content - will be cached across requests
    */
-  linkAnalysis: `You are an expert web content analyzer. Generate relevant tags and a concise summary for the given web page content.
+  linkAnalysis: `You are an expert web content analyzer. Generate relevant tags and a concise summary for the given web page content. /no_think
 
 Guidelines:
 - Tags should be 5-6 single words capturing main topics, categories, and key concepts (no spaces, no hyphens)
@@ -88,34 +91,4 @@ Guidelines:
 
 Respond with a single JSON object using exactly this shape and no other keys:
 {"tags": ["word", "word"], "summary": "..."}`,
-
-  /**
-   * System prompt for changelog generation
-   * Static content - will be cached across requests
-   */
-  changelog: `You are writing a public changelog entry for Teak, a personal knowledge hub app. Readers are end users, not engineers.
-
-Editorial rules (non-negotiable):
-- Describe user impact only. If a user would not notice the change, do not mention it.
-- Do not mention package names, frameworks, libraries, build tooling, bundlers, loaders, ESM/CJS, schemas, data migrations, internal endpoints, refactors, tests, CI, signing/notarization, dependency bumps, or any implementation mechanics. This includes (non-exhaustive): Electron, Vite, Webpack, Forge, Next.js, Astro, Starlight, Blume, Expo, Wxt, Hono, Convex (as backend), Better Auth, Groq, Polar, electron-updater, electron-builder, oEmbed, package.json, tsconfig, node_modules.
-- Product-facing terms are allowed when users recognize them: desktop, mobile, web, browser extension, Raycast, API, MCP, sync, settings, import/export, updates, sign-in, macOS, Dock, notifications, keychain.
-- If the change is only internal tooling, dependency work, refactor, tests, CI, or cleanup, respond with the single token SKIP and nothing else.
-- Do not use inline code (backticks) or fenced code blocks. Do not use headers inside the entry.
-- Output format: a short title followed by 1 to 3 bullets, each one user-observable outcome in plain English. Trim aggressively.
-- If user action is required, state only the clear action the user needs to take.`,
-
-  /**
-   * Stricter retry prompt for changelog generation when the first pass
-   * violates the editorial rules. Use this in a single regeneration attempt
-   * before failing loudly.
-   */
-  changelogStrictRetry: `You previously produced a changelog entry that violated the editorial rules.
-
-Rewrite it now with ZERO implementation language. Treat the reader as a non-technical end user.
-
-Hard constraints:
-- Remove every mention of packages, frameworks, libraries, build tools, bundlers, loaders, ESM/CJS, schemas, migrations, internal endpoints, refactors, tests, CI, signing/notarization, dependency bumps. No exceptions.
-- Never use inline code (backticks) or fenced code blocks.
-- Output one short title, then 1 to 3 bullets. Each bullet is one user-observable outcome in plain English.
-- If the underlying change has no user impact, respond with the single token SKIP and nothing else.`,
 } as const;

--- a/packages/convex/ai/telemetry.ts
+++ b/packages/convex/ai/telemetry.ts
@@ -10,13 +10,15 @@ import { recordBackendAiContent, withBackendSpan } from "../telemetry/sentry";
 
 const ONE_MILLION = 1_000_000;
 
-const GROQ_PRICING_USD_PER_MILLION = {
-  "openai/gpt-oss-120b": { input: 0.15, output: 0.6 },
-  "openai/gpt-oss-20b": { input: 0.075, output: 0.3 },
-  "qwen/qwen3.6-27b": { input: 0.6, output: 3 },
+export const WORKERS_AI_PROVIDER = "cloudflare";
+
+const WORKERS_AI_PRICING_USD_PER_MILLION = {
+  "@cf/google/gemma-4-26b-a4b-it": { input: 0.1, output: 0.3 },
+  "@cf/qwen/qwen3-30b-a3b-fp8": { input: 0.051, output: 0.335 },
 } as const;
 
-export type PricedGroqModel = keyof typeof GROQ_PRICING_USD_PER_MILLION;
+export type PricedWorkersAiModel =
+  keyof typeof WORKERS_AI_PRICING_USD_PER_MILLION;
 
 export const createAiTelemetrySettings = (input: {
   functionId: string;
@@ -27,7 +29,7 @@ export const createAiTelemetrySettings = (input: {
   isEnabled: true,
   metadata: {
     "teak.model": input.model,
-    "teak.provider": "groq",
+    "teak.provider": WORKERS_AI_PROVIDER,
     "teak.stage": input.stage,
   },
   // Content is recorded explicitly through Teak's scrubbed/truncated span path.
@@ -35,32 +37,22 @@ export const createAiTelemetrySettings = (input: {
   recordOutputs: false,
 });
 
-export const estimateGroqCostUsd = (input: {
-  cachedInputTokens?: number;
+export const estimateWorkersAiCostUsd = (input: {
   inputTokens?: number;
   model: string;
   outputTokens?: number;
 }): number | undefined => {
-  const prices = GROQ_PRICING_USD_PER_MILLION[input.model as PricedGroqModel];
+  const prices =
+    WORKERS_AI_PRICING_USD_PER_MILLION[input.model as PricedWorkersAiModel];
   if (!prices) {
     return;
   }
-  const inputTokens = input.inputTokens ?? 0;
-  const cachedInputTokens = Math.min(
-    inputTokens,
-    Math.max(0, input.cachedInputTokens ?? 0)
-  );
-  const uncachedInputTokens = inputTokens - cachedInputTokens;
-  const inputCost =
-    (uncachedInputTokens * prices.input +
-      cachedInputTokens * prices.input * 0.5) /
-    ONE_MILLION;
+  const inputCost = ((input.inputTokens ?? 0) * prices.input) / ONE_MILLION;
   const outputCost = ((input.outputTokens ?? 0) * prices.output) / ONE_MILLION;
   return inputCost + outputCost;
 };
 
 interface AiUsage {
-  inputTokenDetails?: { cacheReadTokens?: number };
   inputTokens?: number;
   outputTokens?: number;
 }
@@ -88,8 +80,7 @@ export const observeAiGeneration = async <T>(
     try {
       const result = await generate();
       const usage = getUsage(result);
-      const costUsd = estimateGroqCostUsd({
-        cachedInputTokens: usage?.inputTokenDetails?.cacheReadTokens,
+      const costUsd = estimateWorkersAiCostUsd({
         inputTokens: usage?.inputTokens,
         model: input.model,
         outputTokens: usage?.outputTokens,
@@ -101,13 +92,17 @@ export const observeAiGeneration = async <T>(
         model: input.model,
         outcome: "success",
         outputTokens: usage?.outputTokens,
-        provider: "groq",
+        provider: WORKERS_AI_PROVIDER,
       });
       if (costUsd !== undefined) {
         distribution(
           TELEMETRY_METRICS.aiCostUsd,
           costUsd,
-          { function: input.functionId, model: input.model, provider: "groq" },
+          {
+            function: input.functionId,
+            model: input.model,
+            provider: WORKERS_AI_PROVIDER,
+          },
           "none"
         );
       }
@@ -117,7 +112,7 @@ export const observeAiGeneration = async <T>(
         durationMs: Date.now() - startedAt,
         model: input.model,
         outcome: "failure",
-        provider: "groq",
+        provider: WORKERS_AI_PROVIDER,
         validationFailure: normalizeErrorClass(error) === "ValidationError",
       });
       throw error;
@@ -130,7 +125,7 @@ export const observeAiGeneration = async <T>(
 
   return await withBackendSpan(
     {
-      attributes: { model: input.model, provider: "groq" },
+      attributes: { model: input.model, provider: WORKERS_AI_PROVIDER },
       name: input.functionId,
       operation: "gen_ai.generate",
       stage: input.stage ?? "ai_metadata",

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -31,7 +31,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ai-sdk/groq": "^4.0.26",
+    "@ai-sdk/openai-compatible": "^3.0.35",
     "@aws-sdk/client-s3": "3.1106.0",
     "@aws-sdk/s3-request-presigner": "3.1106.0",
     "@better-auth/expo": "1.6.26",

--- a/packages/convex/shared/telemetry.ts
+++ b/packages/convex/shared/telemetry.ts
@@ -335,7 +335,7 @@ export const normalizeErrorClass = (error: unknown): TelemetryErrorClass => {
   if (/storage|upload|r2|s3/u.test(normalized)) {
     return "StorageError";
   }
-  if (/provider|groq|model|generation/u.test(normalized)) {
+  if (/provider|cloudflare|workers.?ai|model|generation/u.test(normalized)) {
     return "ProviderError";
   }
   if (/network|fetch|connection|socket/u.test(normalized)) {

--- a/packages/convex/workflows/aiMetadata/generators.ts
+++ b/packages/convex/workflows/aiMetadata/generators.ts
@@ -13,31 +13,24 @@ import {
 import {
   createAiTelemetrySettings,
   observeAiGeneration,
+  WORKERS_AI_PROVIDER,
 } from "../../ai/telemetry";
 import { trackAiRetry } from "../../shared/metrics";
 import { recordBackendLog } from "../../telemetry/sentry";
 import { aiMetadataSchema } from "./schemas";
 
 /**
- * Force Groq into JSON object mode instead of strict json_schema mode.
+ * Cloudflare Workers AI notes:
  *
- * With `structuredOutputs: true` (the provider default) the JSON schema is
- * enforced server-side. The gpt-oss models occasionally emit the schema
- * definition itself (`$schema`, `properties`, `additionalProperties`, ...)
- * which fails that strict validation with an HTTP 400 (`json_validate_failed`).
+ * The provider targets the OpenAI-compatible `/ai/v1` endpoint, which maps
+ * `Output.object` requests to server-side `response_format: { type:
+ * "json_object" }`. The schema itself is enforced client-side against the Zod
+ * schema (unknown keys stripped), so leaked or malformed fields fail softly
+ * and are handled by the bounded validation retries below.
  *
- * Disabling it switches the request to `response_format: { type: "json_object" }`.
- * The model still returns JSON, but validation happens client-side against the
- * Zod schema, which strips unknown keys instead of throwing.
+ * Reasoning models (qwen3) are switched to non-thinking mode via the
+ * "/no_think" suffix baked into the system prompts in ai/models.ts.
  */
-const GROQ_JSON_OBJECT_OPTIONS = {
-  groq: { structuredOutputs: false },
-} as const;
-
-const GROQ_LOW_REASONING_JSON_OBJECT_OPTIONS = {
-  groq: { reasoningEffort: "low", structuredOutputs: false },
-} as const;
-
 export const MAX_AI_METADATA_INPUT_CHARS = 6000;
 export const MAX_AI_METADATA_OUTPUT_TOKENS = 768;
 export const MAX_AI_METADATA_RETRIES = 0;
@@ -77,11 +70,15 @@ const generateWithValidationRetries = async <T>(
       ) {
         throw error;
       }
-      trackAiRetry({ model, provider: "groq", reason: "validation" });
+      trackAiRetry({
+        model,
+        provider: WORKERS_AI_PROVIDER,
+        reason: "validation",
+      });
       recordBackendLog("warn", "ai.generation.validation_retry", {
         attempt: attempt + 1,
         model,
-        provider: "groq",
+        provider: WORKERS_AI_PROVIDER,
         reason: "validation",
       });
     }
@@ -103,10 +100,8 @@ export const boundAiMetadataInput = (content: string): string => {
 
 /**
  * Generate AI metadata for text content
- * Uses prompt caching-enabled model (openai/gpt-oss-20b)
  */
 export const generateTextMetadata = async (content: string, title?: string) => {
-  // Dynamic content placed last for optimal caching
   const fullContent = title
     ? `Title: ${title}\n\nContent: ${content}`
     : content;
@@ -136,19 +131,13 @@ export const generateTextMetadata = async (content: string, title?: string) => {
           // without the SDK waiting through provider-supplied reset windows.
           maxRetries: MAX_AI_METADATA_RETRIES,
           maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
-          // Static system prompt - will be cached across requests
+          // Static system prompt
           system: SYSTEM_PROMPTS.textAnalysis,
-          // Dynamic content last for cache optimization
+          // Dynamic content last
           prompt: validationRetryPrompt(prompt, attempt),
           output: Output.object({
             schema: aiMetadataSchema,
           }),
-          // Use Groq JSON object mode instead of strict json_schema. gpt-oss
-          // models intermittently echo the schema definition back, which the
-          // strict server-side validator rejects with a 400. In json_object mode
-          // the SDK validates client-side against the Zod schema (unknown keys are
-          // stripped), so leaked schema fields no longer fail the request.
-          providerOptions: GROQ_LOW_REASONING_JSON_OBJECT_OPTIONS,
         })
       )
   );
@@ -161,12 +150,39 @@ export const generateTextMetadata = async (content: string, title?: string) => {
 
 /**
  * Generate AI metadata for image content (using vision)
- * Note: Qwen 3.6 vision does NOT currently support prompt caching
+ *
+ * Cloudflare Workers AI only accepts inline base64 image data on its
+ * OpenAI-compatible endpoint (no remote URL fetching), so the image is
+ * downloaded here and sent as bytes.
  */
+export const resolveImageAnalysisInput = async (
+  imageUrl: string
+): Promise<{ data: Uint8Array; mediaType?: string }> => {
+  const response = await fetch(imageUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch image: ${response.status} ${response.statusText}`
+    );
+  }
+  const buffer = await response.arrayBuffer();
+  const contentType = response.headers
+    .get("content-type")
+    ?.split(";")[0]
+    ?.trim();
+  return {
+    data: new Uint8Array(buffer),
+    // Omit the media type unless it is actually an image so the SDK falls
+    // back to its default instead of sending something invalid.
+    mediaType:
+      contentType && /^image\//u.test(contentType) ? contentType : undefined,
+  };
+};
+
 export const generateImageMetadata = async (
   imageUrl: string,
   title?: string
 ) => {
+  const image = await resolveImageAnalysisInput(imageUrl);
   const prompt = boundAiMetadataInput(
     title
       ? `Image title: ${title}\n\nAnalyze this image and generate tags and summary:`
@@ -191,7 +207,7 @@ export const generateImageMetadata = async (
           model: IMAGE_METADATA_MODEL,
           maxRetries: MAX_AI_METADATA_RETRIES,
           maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
-          // Static system prompt - structured for potential future caching support
+          // Static system prompt
           system: SYSTEM_PROMPTS.imageAnalysis,
           messages: [
             {
@@ -204,8 +220,9 @@ export const generateImageMetadata = async (
                 },
                 {
                   type: "image",
-                  // Dynamic image content
-                  image: imageUrl,
+                  // Inline bytes — Workers AI rejects remote image URLs
+                  image: image.data,
+                  ...(image.mediaType ? { mediaType: image.mediaType } : {}),
                 },
               ],
             },
@@ -213,7 +230,6 @@ export const generateImageMetadata = async (
           output: Output.object({
             schema: aiMetadataSchema,
           }),
-          providerOptions: GROQ_JSON_OBJECT_OPTIONS,
         })
       )
   );
@@ -226,7 +242,6 @@ export const generateImageMetadata = async (
 
 /**
  * Generate AI metadata for link content
- * Uses prompt caching-enabled model (openai/gpt-oss-20b)
  */
 export const generateLinkMetadata = async (content: string, url?: string) => {
   const prompt = boundAiMetadataInput(
@@ -257,14 +272,13 @@ Generate tags and summary that will help the user rediscover and understand the 
           model: LINK_METADATA_MODEL,
           maxRetries: MAX_AI_METADATA_RETRIES,
           maxOutputTokens: MAX_AI_METADATA_OUTPUT_TOKENS,
-          // Static system prompt - will be cached across requests
+          // Static system prompt
           system: SYSTEM_PROMPTS.linkAnalysis,
-          // Dynamic content last for cache optimization
+          // Dynamic content last
           prompt: validationRetryPrompt(prompt, attempt),
           output: Output.object({
             schema: aiMetadataSchema,
           }),
-          providerOptions: GROQ_LOW_REASONING_JSON_OBJECT_OPTIONS,
         })
       )
   );

--- a/packages/convex/workflows/aiMetadata/transcript.ts
+++ b/packages/convex/workflows/aiMetadata/transcript.ts
@@ -1,7 +1,6 @@
 "use node";
 
-import { experimental_transcribe as transcribe } from "ai";
-import { TRANSCRIPTION_MODEL, TRANSCRIPTION_MODEL_ID } from "../../ai/models";
+import { TRANSCRIPTION_MODEL_ID } from "../../ai/models";
 import { observeAiGeneration } from "../../ai/telemetry";
 import {
   recordBackendAiContent,
@@ -9,6 +8,43 @@ import {
   recordBackendLog,
   withBackendSpan,
 } from "../../telemetry/sentry";
+
+const workersAiRunUrl = () =>
+  `https://api.cloudflare.com/client/v4/accounts/${
+    process.env.CLOUDFLARE_ACCOUNT_ID ?? ""
+  }/ai/run/${TRANSCRIPTION_MODEL_ID}`;
+
+// Transcribe audio bytes via Cloudflare Workers AI. The REST `/ai/run`
+// endpoint accepts the raw audio as the request body and returns a
+// `{ result: { text } }` envelope.
+export const transcribeWorkersAi = async (
+  audio: ArrayBuffer,
+  mimeType: string
+): Promise<string> => {
+  const response = await fetch(workersAiRunUrl(), {
+    body: new Blob([audio], { type: mimeType }),
+    headers: {
+      Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN ?? ""}`,
+      "Content-Type": mimeType,
+    },
+    method: "POST",
+  });
+
+  const payload = (await response.json().catch(() => null)) as {
+    errors?: { message?: string }[];
+    result?: { text?: string };
+    success?: boolean;
+  } | null;
+
+  if (!(response.ok && payload?.success && payload.result)) {
+    const detail =
+      payload?.errors?.map((error) => error.message).join("; ") ??
+      `${response.status} ${response.statusText}`;
+    throw new Error(`Workers AI transcription failed: ${detail}`);
+  }
+
+  return payload.result.text ?? "";
+};
 
 // Generate transcript for audio content
 export const generateTranscript = async (
@@ -34,13 +70,14 @@ export const generateTranscript = async (
 
     const arrayBuffer = await response.arrayBuffer();
 
-    // Use Groq's whisper-large-v3-turbo for fast, cost-effective transcription
+    // Use Whisper large v3 turbo on Cloudflare Workers AI for fast,
+    // cost-effective transcription (billed per audio minute)
     return await withBackendSpan(
       {
         attributes: {
           "audio.byte_length": arrayBuffer.byteLength,
           model: TRANSCRIPTION_MODEL_ID,
-          provider: "groq",
+          provider: "cloudflare",
         },
         name: "teak.ai.transcript",
         operation: "gen_ai.generate",
@@ -54,10 +91,9 @@ export const generateTranscript = async (
             model: TRANSCRIPTION_MODEL_ID,
           },
           () =>
-            transcribe({
-              audio: new Uint8Array(arrayBuffer),
-              model: TRANSCRIPTION_MODEL,
-            })
+            transcribeWorkersAi(arrayBuffer, mimeType).then((text) => ({
+              text,
+            }))
         );
         recordBackendAiContent({ response: text });
         return text;


### PR DESCRIPTION
## Summary

Replaces the Groq provider with Cloudflare Workers AI across the card-processing pipeline, cutting vision costs ~6x while keeping quality high.

## Model changes

| Purpose | Before (Groq) | After (Workers AI) |
|---|---|---|
| Text metadata | openai/gpt-oss-20b | `@cf/qwen/qwen3-30b-a3b-fp8` |
| Link metadata | openai/gpt-oss-20b | `@cf/qwen/qwen3-30b-a3b-fp8` |
| Image metadata (vision) | qwen/qwen3.6-27b | `@cf/google/gemma-4-26b-a4b-it` |
| Audio transcription | whisper-large-v3-turbo | `@cf/openai/whisper-large-v3-turbo` |
| Changelog gen (unused) | openai/gpt-oss-120b | removed |

## Implementation notes

- Uses Workers AI's OpenAI-compatible endpoint (`/ai/v1/chat/completions`) via `@ai-sdk/openai-compatible`; transcription calls the REST `/ai/run` endpoint directly (binary body).
- Qwen 3 reasoning tokens are suppressed with the documented `/no_think\) prompt suffix (verified: 751 → 44 completion tokens on a sample task).
- Gemma 4 vision receives inline base64 bytes — Workers AI rejects remote image URLs (`6004: Property image_url only supports base64 encoded image data`), so images are downloaded before analysis.
- Structured output keeps the existing client-side Zod + bounded validation-retry pattern; server-side `response_format: json_object` is still requested.
- Telemetry: pricing table updated to Workers AI rates, provider label changed to `cloudflare`, unused changelog model/prompts removed.
- Removed `@ai-sdk/groq`; added `@ai-sdk/openai-compatible`.

## Config

New Convex env vars (set on dev + prod): `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`. `GROQ_API_KEY` remains temporarily for rollback and will be deleted after verification.

## Testing

- [x] All convex unit tests pass (4 pre-existing env-dependent failures on main unchanged)
- [x] Typecheck + biome clean
- [x] Live integration test of all four generation paths against real Workers AI (text/link/image/transcript) — all returned valid tags/summary JSON
- [x] New token verified against inference endpoints for both chat + whisper

Docs: self-hosting + development guides updated for the new env vars.