### PR TITLE
fix(web): save browser audio recordings as audio cards

### DIFF
--- a/apps/docs/content/changelog/august-2026.mdx
+++ b/apps/docs/content/changelog/august-2026.mdx
@@ -19,3 +19,4 @@ changelog:
 - External apps now show an approve-or-deny screen before they can access your vault.
 - Active file types from uploads and imports now download instead of opening as web pages.
 - Image cards now retry temporary analysis failures so their AI tags and summaries appear when processing recovers.
+- Audio recordings made in Chrome and Safari now save as audio cards with the waveform player instead of video cards.

--- a/packages/convex/__tests__/shared/fileFormats.test.ts
+++ b/packages/convex/__tests__/shared/fileFormats.test.ts
@@ -96,6 +96,53 @@ describe("file format registry", () => {
     ).toMatchObject({ cardType: "video", kind: "motion" });
   });
 
+  test("classifies WebM audio recordings as audio cards", () => {
+    expect(
+      validateFileFormat({
+        fileName: "recording_1730000000.webm",
+        mimeType: "audio/webm",
+      })
+    ).toMatchObject({ cardType: "audio", id: "webm-audio", kind: "audio" });
+    expect(
+      inferFileFormat({
+        fileName: "recording_1730000000.webm",
+        mimeType: "audio/webm;codecs=opus",
+      })
+    ).toMatchObject({ cardType: "audio", id: "webm-audio" });
+    expect(
+      inferFileFormat({ fileName: "voice-memo", mimeType: "audio/webm" })
+    ).toMatchObject({ cardType: "audio" });
+  });
+
+  test("keeps WebM video files as motion cards", () => {
+    expect(
+      validateFileFormat({ fileName: "clip.webm", mimeType: "video/webm" })
+    ).toMatchObject({ cardType: "video", id: "webm", kind: "motion" });
+    expect(inferFileFormat({ fileName: "clip.webm" })).toMatchObject({
+      cardType: "video",
+      id: "webm",
+    });
+    expect(() =>
+      validateFileFormat({ fileName: "clip.webm", mimeType: "image/png" })
+    ).toThrow("does not match");
+  });
+
+  test("classifies MP4 audio files as audio cards", () => {
+    expect(
+      validateFileFormat({ fileName: "voice.mp4", mimeType: "audio/mp4" })
+    ).toMatchObject({ cardType: "audio", id: "mp4-audio" });
+    expect(
+      validateFileFormat({
+        fileName: "voice.m4a",
+        mimeType: "audio/x-m4a",
+      }).cardType
+    ).toBe("audio");
+    expect(inferFileFormat({ fileName: "movie.mp4" })).toMatchObject({
+      cardType: "video",
+      id: "mp4",
+    });
+  });
+
   test("accepts common MIME variants", () => {
     expect(
       validateFileFormat({

--- a/packages/convex/shared/fileFormats.ts
+++ b/packages/convex/shared/fileFormats.ts
@@ -382,8 +382,17 @@ export const FILE_FORMATS = [
     cardType: "video",
     extension: "webm",
     kind: "motion",
-    mimeTypes: ["video/webm", "audio/webm"],
+    mimeTypes: ["video/webm"],
     preview: "motion",
+  }),
+  defineFormat({
+    id: "webm-audio",
+    suffixes: ["webm"],
+    cardType: "audio",
+    extension: "webm",
+    kind: "audio",
+    mimeTypes: ["audio/webm"],
+    preview: "audio",
   }),
   defineFormat({
     id: "mp4",
@@ -501,7 +510,7 @@ export const FILE_FORMATS = [
   }),
   defineFormat({
     id: "mp4-audio",
-    suffixes: ["m4a"],
+    suffixes: ["m4a", "mp4"],
     cardType: "audio",
     extension: "m4a",
     kind: "audio",
@@ -599,11 +608,30 @@ const matchesFileName = (
 };
 
 const findFormatByFileName = (
-  fileName: string
+  fileName: string,
+  mimeType: string
 ): FileFormatDefinition | undefined => {
   const lowerFileName = fileName.toLowerCase();
-  return FILE_FORMATS.find((definition) =>
+  const matches = FILE_FORMATS.filter((definition) =>
     matchesFileName(definition, lowerFileName)
+  );
+  if (matches.length === 0) {
+    return undefined;
+  }
+  // Extensions such as `.webm` and `.mp4` exist in both audio and video
+  // flavors. Keep the first match as the default, but prefer a definition
+  // whose MIME types accept the provided MIME when the default rejects it.
+  const primary = matches[0];
+  if (
+    !mimeType ||
+    GENERIC_MIME_TYPES.has(mimeType) ||
+    primary.mimeTypes.includes(mimeType)
+  ) {
+    return primary;
+  }
+  return (
+    matches.find((definition) => definition.mimeTypes.includes(mimeType)) ??
+    primary
   );
 };
 
@@ -640,7 +668,7 @@ export const inferFileFormat = (input: {
   }
 
   const mimeType = normalizeMimeType(input.mimeType);
-  const byFileName = findFormatByFileName(fileName);
+  const byFileName = findFormatByFileName(fileName, mimeType);
 
   if (byFileName) {
     if (
@@ -674,7 +702,7 @@ export const validateFileFormat = (input: {
     );
   }
 
-  const byFileName = findFormatByFileName(fileName);
+  const byFileName = findFormatByFileName(fileName, mimeType);
   if (!byFileName) {
     const byMime =
       GENERIC_MIME_TYPES.has(mimeType) || !mimeType

--- a/packages/tests/src/helpers/file-formats.ts
+++ b/packages/tests/src/helpers/file-formats.ts
@@ -73,6 +73,11 @@ export const expandedFileFixtures = (marker: string): FileFixture[] => [
     fileName: `${marker}.fig`,
     mimeType: "application/octet-stream",
   },
+  {
+    bytes: strToU8(`audio-recording-${marker}`),
+    fileName: `${marker}-recording.webm`,
+    mimeType: "audio/webm",
+  },
 ];
 
 export const cliFileFixtures = (marker: string): FileFixture[] => {

--- a/packages/tests/src/journey/03-api.e2e.ts
+++ b/packages/tests/src/journey/03-api.e2e.ts
@@ -279,6 +279,9 @@ test("REST API uploads and infers the expanded file-format matrix", async () => 
       expect(fetchedCard.type).toBe("video");
       expect(fetchedCard.filePreview?.animated).toBe(true);
     }
+    if (fixture.mimeType === "audio/webm") {
+      expect(fetchedCard.type).toBe("audio");
+    }
   }
 
   const unsupported = await apiFetch("/v1/uploads", apiKey, {

--- a/packages/ui/src/components/forms/AddCardActions.tsx
+++ b/packages/ui/src/components/forms/AddCardActions.tsx
@@ -37,6 +37,31 @@ function formatTime(seconds: number) {
   return `${mins}:${secs.toString().padStart(2, "0")}`;
 }
 
+interface AudioRecordingFormat {
+  extension: string;
+  mimeType: string;
+}
+
+// Chrome and Safari expose different MediaRecorder containers: Chromium
+// records WebM/Opus while Safari only records MP4/AAC. Pick the first
+// supported type so recordings save as audio cards on every browser.
+const AUDIO_RECORDING_CANDIDATES: readonly AudioRecordingFormat[] = [
+  { extension: "webm", mimeType: "audio/webm;codecs=opus" },
+  { extension: "m4a", mimeType: "audio/mp4" },
+];
+
+const selectAudioRecordingFormat = (): AudioRecordingFormat => {
+  if (typeof MediaRecorder !== "undefined") {
+    const supported = AUDIO_RECORDING_CANDIDATES.find((candidate) =>
+      MediaRecorder.isTypeSupported(candidate.mimeType)
+    );
+    if (supported) {
+      return supported;
+    }
+  }
+  return AUDIO_RECORDING_CANDIDATES[0];
+};
+
 export function AddCardActions({
   onSuccess,
   onUpgrade,
@@ -114,13 +139,13 @@ export function AddCardActions({
   useEffect(() => clearRecordingResources, [clearRecordingResources]);
 
   const autoSaveAudio = useCallback(
-    async (blob: Blob) => {
+    async (blob: Blob, extension: string) => {
       const toastId = toast.loading("Saving audio recording...");
 
       try {
         setIsSubmitting(true);
 
-        const file = new File([blob], `recording_${Date.now()}.webm`, {
+        const file = new File([blob], `recording_${Date.now()}.${extension}`, {
           type: blob.type,
         });
 
@@ -188,8 +213,9 @@ export function AddCardActions({
 
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
+      const recordingFormat = selectAudioRecordingFormat();
       const mediaRecorder = new MediaRecorder(stream, {
-        mimeType: "audio/webm;codecs=opus",
+        mimeType: recordingFormat.mimeType,
       });
       const chunks: Blob[] = [];
 
@@ -200,9 +226,11 @@ export function AddCardActions({
         }
       };
       mediaRecorder.onstop = () => {
-        const blob = new Blob(chunks, { type: "audio/webm;codecs=opus" });
+        const blob = new Blob(chunks, {
+          type: mediaRecorder.mimeType || recordingFormat.mimeType,
+        });
         clearRecordingResources();
-        void autoSaveAudio(blob);
+        void autoSaveAudio(blob, recordingFormat.extension);
       };
 
       mediaRecorder.start();


### PR DESCRIPTION
## Summary
- Web audio recordings (mic button on app.teakvault.com) were saved as **video** cards in Chrome and Safari. Root cause: recordings upload as `.webm` files with an `audio/webm` MIME type, but the file-format registry mapped **every** `.webm` file to `cardType: "video"`.
- Split the `webm` format into video (`video/webm`) and a new `webm-audio` (`audio/webm`) entry, and made filename lookup MIME-aware for dual-flavor extensions (`.webm`, `.mp4`). `.mp4` + `audio/mp4` now maps to `mp4-audio` as well.
- The web recorder now selects the first container the browser actually supports via `MediaRecorder.isTypeSupported`: WebM/Opus (`.webm`) for Chrome, MP4/AAC (`.m4a`) for Safari — and names the uploaded file to match.
- Tests: unit coverage for WebM/MP4 audio classification (audio + video paths, mismatch rejection) and a new `audio/webm` fixture in the REST e2e upload matrix asserting the card is created as `audio`.
- Docs: changelog bullet appended to the August 2026 entry.

## Test plan
- [x] `bun test packages/convex/__tests__/shared/fileFormats.test.ts` — 47/47 pass
- [x] Full `bun run test` — only 4 pre-existing env-dependent failures (MCP OAuth metadata, billing, admin), verified identical on a clean tree
- [x] `bun run typecheck` and `bun run lint` pass repo-wide
- [x] Pre-commit affected build/typecheck/lint pass