### PR TITLE
perf(files): process images, exports, and inspection on the edge worker

### DIFF
--- a/apps/docs/content/changelog/august-2026.mdx
+++ b/apps/docs/content/changelog/august-2026.mdx
@@ -14,6 +14,7 @@ changelog:
 - The iPhone and iPad apps no longer close immediately on launch, and search, refresh, card opening, and image-heavy libraries load more quickly.
 - Continue with Apple now completes sign-in reliably on the web and in Teak for Safari.
 - Uploaded PDFs show their first page as the card preview in the grid again.
+- New image cards finish preparing their previews and colors noticeably faster, and large exports build quicker and more reliably.
 - Document cards now keep their spot in the grid while their preview loads, so other cards no longer jump around.
 - Notification banners now keep their icon, message, and close button centered together.
 - External apps now show an approve-or-deny screen before they can access your vault.

--- a/apps/files-worker/README.md
+++ b/apps/files-worker/README.md
@@ -1,6 +1,7 @@
 # @teak/files-worker
 
-Serves private card files from `files.teakvault.com`.
+Serves private card files from `files.teakvault.com` and runs internal file
+ops (image processing, export building, bounded inspection) at the edge.
 
 The Convex backend mints long-lived HMAC-signed URLs
 (`packages/convex/storage/r2.ts` → `buildSignedWorkerFileUrl`). This worker
@@ -10,6 +11,24 @@ lockstep with `PRIVATE_FILE_CACHE_CONTROL` in r2.ts). It also handles single
 HTTP `Range` requests (206 responses) so video/audio seeking works, and serves
 full-object responses from the Cloudflare edge cache keyed by object path +
 content-disposition policy. The bucket is never public.
+
+## Internal ops
+
+Besides downloads, the worker executes short-lived signed ops minted per
+action invocation (`packages/convex/storage/filesWorkerClient.ts`; payload
+shape in `src/lib.ts`, param order in `src/index.ts` — keep both sides in
+lockstep):
+
+- `op=process-image` — decodes a card image over the R2 binding, applies EXIF
+  orientation, optionally writes a bounded WebP thumbnail back to R2, and
+  returns dimensions plus a dominant-color palette (`src/image.ts`).
+- `op=build-export` — streams a manifest-described set of objects through
+  client-zip into a multipart-uploaded ZIP artifact (`src/export.ts`).
+- `op=inspect` — bounded zip/CSS/text inspection returning facts or AI text
+  without the object transiting Convex (`src/inspect.ts`).
+
+Convex keeps orchestration; every op has a legacy in-action fallback for
+local dev (no `FILES_BASE`/`FILES_SIGNING_SECRET`) and permanent rejections.
 
 ## Commands
 

--- a/apps/files-worker/package.json
+++ b/apps/files-worker/package.json
@@ -8,6 +8,12 @@
     "test": "bun test src",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "@cf-wasm/photon": "^0.4.0",
+    "client-zip": "^2.4.5",
+    "exifr": "^7.1.3",
+    "fflate": "^0.8.2"
+  },
   "devDependencies": {
     "@cloudflare/workers-types": "^5.20260822.1",
     "wrangler": "^4.125.0"

--- a/apps/files-worker/src/export.test.ts
+++ b/apps/files-worker/src/export.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import { unzipSync } from "fflate";
+import {
+  buildExportIntoBucket,
+  EXPORT_MANIFEST_VERSION,
+  ExportManifestInvalid,
+  ExportTooLarge,
+  parseExportManifest,
+} from "./export";
+import { FakeBucket, makePng } from "./testsupport";
+
+const encodeBase64 = (text: string): string =>
+  Buffer.from(text, "utf8").toString("base64");
+
+describe("export manifest parsing", () => {
+  const valid = {
+    v: EXPORT_MANIFEST_VERSION,
+    maxBytes: 1024,
+    entries: [{ path: "cards.json", contentBase64: encodeBase64("{}") }],
+  };
+
+  test("accepts a structurally valid manifest", () => {
+    expect(parseExportManifest(JSON.stringify(valid))).toEqual(valid);
+  });
+
+  test("rejects malformed json, bad versions, and unsafe paths", () => {
+    expect(() => parseExportManifest("not-json")).toThrow(
+      ExportManifestInvalid
+    );
+    expect(() =>
+      parseExportManifest(JSON.stringify({ ...valid, v: 99 }))
+    ).toThrow(ExportManifestInvalid);
+    expect(() =>
+      parseExportManifest(
+        JSON.stringify({
+          ...valid,
+          entries: [{ path: "../escape", contentBase64: "" }],
+        })
+      )
+    ).toThrow(ExportManifestInvalid);
+    expect(() =>
+      parseExportManifest(
+        JSON.stringify({ ...valid, entries: [{ path: "/abs" }] })
+      )
+    ).toThrow(ExportManifestInvalid);
+    expect(() =>
+      parseExportManifest(JSON.stringify({ ...valid, entries: [{}] }))
+    ).toThrow(ExportManifestInvalid);
+  });
+});
+
+describe("build-export op", () => {
+  test("streams inline and stored entries into a valid zip archive", async () => {
+    const bucket = new FakeBucket();
+    bucket.objects.set("users/a/file/a.png", { bytes: makeZipPng() });
+
+    const manifest = {
+      v: EXPORT_MANIFEST_VERSION,
+      maxBytes: 1024 * 1024 * 1024,
+      entries: [
+        { path: "manifest.json", contentBase64: encodeBase64('{"ok":true}') },
+        { path: "cards.json", contentBase64: encodeBase64('{"cards":[]}') },
+        { path: "files/a.png", storageKey: "users/a/file/a.png" },
+      ],
+    };
+    bucket.objects.set("exports/manifest.json", {
+      bytes: new TextEncoder().encode(JSON.stringify(manifest)),
+    });
+
+    const result = await buildExportIntoBucket(
+      bucket,
+      "exports/manifest.json",
+      "exports/artifact.zip",
+      "teak-export.zip"
+    );
+
+    expect(result.filesIncluded).toBe(1);
+    expect(result.filesOmitted).toBe(0);
+    expect(result.omittedPaths).toEqual([]);
+    expect(result.artifactBytes).toBeGreaterThan(0);
+
+    const zip = bucket.multipartCompletions.find(
+      (entry) => entry.key === "exports/artifact.zip"
+    );
+    expect(zip).toBeDefined();
+
+    const unzipped = unzipSync(zip!.bytes);
+    expect(Object.keys(unzipped).sort()).toEqual([
+      "cards.json",
+      "files/a.png",
+      "manifest.json",
+    ]);
+    expect(new TextDecoder().decode(unzipped["manifest.json"])).toBe(
+      '{"ok":true}'
+    );
+    expect(unzipped["files/a.png"]).toEqual(makeZipPng());
+  });
+
+  test("omits missing files after retries and reports them by path", async () => {
+    const bucket = new FakeBucket();
+    const manifest = {
+      v: EXPORT_MANIFEST_VERSION,
+      maxBytes: 1024 * 1024 * 1024,
+      entries: [
+        { path: "cards.json", contentBase64: encodeBase64("x") },
+        { path: "files/missing.png", storageKey: "users/a/file/gone.png" },
+      ],
+    };
+    bucket.objects.set("m.json", {
+      bytes: new TextEncoder().encode(JSON.stringify(manifest)),
+    });
+
+    const result = await buildExportIntoBucket(
+      bucket,
+      "m.json",
+      "out.zip",
+      "teak-export.zip"
+    );
+    expect(result.filesIncluded).toBe(0);
+    expect(result.filesOmitted).toBe(1);
+    expect(result.omittedPaths).toEqual(["files/missing.png"]);
+
+    const zip = bucket.multipartCompletions[0];
+    const unzipped = unzipSync(zip.bytes);
+    expect(Object.keys(unzipped)).toEqual(["cards.json"]);
+  });
+
+  test("aborts with a size error when the manifest exceeds its cap", async () => {
+    const bucket = new FakeBucket();
+    const manifest = {
+      v: EXPORT_MANIFEST_VERSION,
+      maxBytes: 10,
+      entries: [
+        { path: "big.bin", contentBase64: encodeBase64("0123456789abcdef") },
+      ],
+    };
+    bucket.objects.set("m2.json", {
+      bytes: new TextEncoder().encode(JSON.stringify(manifest)),
+    });
+
+    await expect(
+      buildExportIntoBucket(bucket, "m2.json", "out.zip", "t.zip")
+    ).rejects.toBeInstanceOf(ExportTooLarge);
+    // Nothing was persisted.
+    expect(bucket.multipartCompletions).toHaveLength(0);
+  });
+});
+
+/** Tiny valid PNG so the zip contains real bytes. */
+const makeZipPng = (): Uint8Array => makePng(1, 1);

--- a/apps/files-worker/src/export.ts
+++ b/apps/files-worker/src/export.ts
@@ -1,0 +1,274 @@
+// Edge export builder for the build-export op: reads a small JSON manifest
+// from R2, streams every referenced object through client-zip, and writes the
+// finished archive back to R2 via a multipart upload — constant memory, no
+// bytes transiting Convex.
+//
+// Manifest contract (minted by packages/convex/export/runExport.ts):
+//   {
+//     "v": 1,
+//     "maxBytes": 5368709120,
+//     "entries": [
+//       { "path": "manifest.json", "contentBase64": "..." },
+//       { "path": "files/x.png",   "storageKey": "users/.../cards/file/..." }
+//     ]
+//   }
+//
+// Missing/unreadable objects are retried once and then omitted (mirroring the
+// legacy Node archive builder); omissions are reported by path so the caller
+// can correct cards.json if needed.
+
+import { downloadZip } from "client-zip";
+
+export const EXPORT_MANIFEST_VERSION = 1;
+
+const MISSING_FILE_MAX_ATTEMPTS = 2;
+
+// R2 multipart parts (min 5 MiB except last). 32 MiB keeps peak memory low on
+// the Workers runtime while capping part count far below limits even for the
+// 5 GB export ceiling.
+const PART_SIZE = 32 * 1024 * 1024;
+
+export class ExportManifestInvalid extends Error {
+  constructor() {
+    super("manifest_invalid");
+  }
+}
+
+export class ExportTooLarge extends Error {
+  constructor() {
+    super("export_too_large");
+  }
+}
+
+export interface ExportManifestEntry {
+  contentBase64?: string;
+  path: string;
+  storageKey?: string;
+}
+
+export interface ExportManifest {
+  entries: ExportManifestEntry[];
+  maxBytes: number;
+  v: number;
+}
+
+export interface BuildExportResult {
+  artifactBytes: number;
+  filesIncluded: number;
+  filesOmitted: number;
+  omittedPaths: string[];
+}
+
+const base64ToBytes = (base64: string): Uint8Array => {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+};
+
+const isValidArchivePath = (path: string): boolean =>
+  path.length > 0 &&
+  !path.startsWith("/") &&
+  !path.split("/").includes("..") &&
+  !path.includes("\0");
+
+/** Parse and structurally validate the manifest JSON body. */
+export const parseExportManifest = (raw: string): ExportManifest => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new ExportManifestInvalid();
+  }
+  const manifest = parsed as ExportManifest;
+  if (
+    !manifest ||
+    typeof manifest !== "object" ||
+    manifest.v !== EXPORT_MANIFEST_VERSION ||
+    !Array.isArray(manifest.entries) ||
+    manifest.entries.length === 0 ||
+    typeof manifest.maxBytes !== "number" ||
+    !(manifest.maxBytes > 0)
+  ) {
+    throw new ExportManifestInvalid();
+  }
+  for (const entry of manifest.entries) {
+    if (!entry || typeof entry.path !== "string") {
+      throw new ExportManifestInvalid();
+    }
+    if (!isValidArchivePath(entry.path)) {
+      throw new ExportManifestInvalid();
+    }
+    if (entry.contentBase64 === undefined && !entry.storageKey) {
+      throw new ExportManifestInvalid();
+    }
+  }
+  return manifest;
+};
+
+/**
+ * Read an object's bytes with one retry; null when both attempts fail.
+ * Mirrors readWithRetry in the legacy archive builder so omission semantics
+ * stay identical.
+ */
+const readWithRetry = async (
+  bucket: R2Bucket,
+  key: string
+): Promise<R2ObjectBody | null> => {
+  for (let attempt = 0; attempt < MISSING_FILE_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const object = await bucket.get(key);
+      if (object) {
+        return object;
+      }
+    } catch {
+      // fall through to retry / omission
+    }
+  }
+  return null;
+};
+
+interface ZipInput {
+  input: ReadableStream | Uint8Array;
+  name: string;
+}
+
+/**
+ * Sequentially materialize zip inputs. Storage-backed entries stream their
+ * R2 bodies directly into the zip without full-file buffering; inclusion
+ * decisions (retry + omit) happen before an entry is handed to client-zip so
+ * the resulting archive never contains placeholders.
+ */
+const collectZipInputs = async function* (
+  bucket: R2Bucket,
+  manifest: ExportManifest,
+  stats: {
+    filesIncluded: number;
+    filesOmitted: number;
+    omittedPaths: string[];
+    totalBytes: number;
+  }
+): AsyncGenerator<ZipInput> {
+  for (const entry of manifest.entries) {
+    if (entry.contentBase64 !== undefined) {
+      const bytes = base64ToBytes(entry.contentBase64);
+      stats.totalBytes += bytes.byteLength;
+      if (stats.totalBytes > manifest.maxBytes) {
+        throw new ExportTooLarge();
+      }
+      yield { name: entry.path, input: bytes };
+      continue;
+    }
+
+    const key = entry.storageKey as string;
+    const object = await readWithRetry(bucket, key);
+    if (!object || object.size === 0) {
+      await object?.body.cancel().catch(() => undefined);
+      stats.filesOmitted += 1;
+      stats.omittedPaths.push(entry.path);
+      continue;
+    }
+    stats.totalBytes += object.size;
+    if (stats.totalBytes > manifest.maxBytes) {
+      await object.body.cancel();
+      throw new ExportTooLarge();
+    }
+    stats.filesIncluded += 1;
+    yield { name: entry.path, input: object.body };
+  }
+};
+
+/**
+ * Build the export archive described by `manifestKey` and store it at
+ * `artifactKey` inside the bucket.
+ */
+export const buildExportIntoBucket = async (
+  bucket: R2Bucket,
+  manifestKey: string,
+  artifactKey: string,
+  fileName: string
+): Promise<BuildExportResult> => {
+  const manifestObject = await bucket.get(manifestKey);
+  if (!manifestObject) {
+    throw new ExportManifestInvalid();
+  }
+  const manifest = parseExportManifest(await manifestObject.text());
+
+  const mpu = await bucket.createMultipartUpload(artifactKey, {
+    httpMetadata: {
+      contentType: "application/zip",
+      contentDisposition: `attachment; filename="${fileName.replace(/["\\]/g, "")}"`,
+    },
+  });
+
+  const stats = {
+    filesIncluded: 0,
+    filesOmitted: 0,
+    omittedPaths: [] as string[],
+    totalBytes: 0,
+  };
+
+  try {
+    const zipStream = downloadZip(
+      collectZipInputs(bucket, manifest, stats)
+    ).body;
+    if (!zipStream) {
+      throw new Error("zip_stream_unavailable");
+    }
+
+    const reader = zipStream.getReader();
+    const buffer = new Uint8Array(PART_SIZE);
+    let fill = 0;
+    let artifactBytes = 0;
+    const uploadedParts: R2UploadedPart[] = [];
+
+    const flushPart = async (bytes: Uint8Array): Promise<void> => {
+      // uploadPart requires a stable copy; slice() detaches from our scratch
+      // buffer so it can be reused immediately afterwards.
+      const part = await mpu.uploadPart(
+        uploadedParts.length + 1,
+        bytes.slice()
+      );
+      uploadedParts.push(part);
+      artifactBytes += bytes.byteLength;
+    };
+
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      let offset = 0;
+      while (offset < value.length) {
+        const take = Math.min(PART_SIZE - fill, value.length - offset);
+        buffer.set(value.subarray(offset, offset + take), fill);
+        fill += take;
+        offset += take;
+        if (fill === PART_SIZE) {
+          await flushPart(buffer.subarray(0, fill));
+          fill = 0;
+        }
+      }
+    }
+    if (fill > 0) {
+      await flushPart(buffer.subarray(0, fill));
+    } else if (uploadedParts.length === 0) {
+      // Degenerate empty archive: still emit a valid (tiny) final part.
+      await flushPart(buffer.subarray(0, 0));
+    }
+
+    await mpu.complete(uploadedParts);
+
+    return {
+      artifactBytes,
+      filesIncluded: stats.filesIncluded,
+      filesOmitted: stats.filesOmitted,
+      omittedPaths: stats.omittedPaths,
+    };
+  } catch (error) {
+    await mpu.abort().catch(() => undefined);
+    throw error;
+  }
+};

--- a/apps/files-worker/src/image.test.ts
+++ b/apps/files-worker/src/image.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { ImageSourceMissing, ImageTooLarge, processImage } from "./image";
+import { FakeBucket, makePng } from "./testsupport";
+
+describe("process-image op", () => {
+  test("skips thumbnails for small images but still returns dimensions and palette", async () => {
+    const bucket = new FakeBucket();
+    bucket.objects.set("src.png", { bytes: makePng(100, 80) });
+
+    const result = await processImage(bucket, "src.png", "dest/t.webp");
+    expect(result).toEqual({
+      width: 100,
+      height: 80,
+      thumbnailGenerated: false,
+      thumbnailKey: null,
+      palette: ["#FF0000"],
+    });
+    expect(bucket.puts).toHaveLength(0);
+  });
+
+  test("resizes large images to bounded webp thumbnails and writes them back", async () => {
+    const bucket = new FakeBucket();
+    bucket.objects.set("src.png", { bytes: makePng(600, 400) });
+
+    const result = await processImage(bucket, "src.png", "dest/t.webp");
+    expect(result.thumbnailGenerated).toBe(true);
+    expect(result.thumbnailKey).toBe("dest/t.webp");
+    expect(result.width).toBe(600);
+    expect(result.height).toBe(400);
+    expect(result.palette.length).toBeGreaterThan(0);
+
+    expect(bucket.puts).toHaveLength(1);
+    const put = bucket.puts[0];
+    expect((put as any).key).toBe("dest/t.webp");
+    expect((put as any).httpMetadata?.contentType).toBe("image/webp");
+    // WebP container magic.
+    expect((put as any).bytes.subarray(0, 4)).toEqual(
+      new Uint8Array([82, 73, 70, 70])
+    );
+    expect(new TextDecoder().decode((put as any).bytes.slice(8, 12))).toBe(
+      "WEBP"
+    );
+  });
+
+  test("supports palette-only invocations without a destination", async () => {
+    const bucket = new FakeBucket();
+    bucket.objects.set("src.png", { bytes: makePng(600, 400) });
+
+    const result = await processImage(bucket, "src.png", null);
+    expect(result.thumbnailGenerated).toBe(false);
+    expect(result.palette).toEqual(["#FF0000"]);
+    expect(bucket.puts).toHaveLength(0);
+  });
+
+  test("reports missing sources distinctly from oversized ones", async () => {
+    const bucket = new FakeBucket();
+    await expect(
+      processImage(bucket, "missing.png", null)
+    ).rejects.toBeInstanceOf(ImageSourceMissing);
+
+    bucket.objects.set("big.png", { bytes: new Uint8Array(31 * 1024 * 1024) });
+    await expect(processImage(bucket, "big.png", null)).rejects.toBeInstanceOf(
+      ImageTooLarge
+    );
+  });
+});

--- a/apps/files-worker/src/image.ts
+++ b/apps/files-worker/src/image.ts
@@ -1,0 +1,312 @@
+// Edge image processing for the process-image op: decodes a card's original
+// raster image straight from the R2 binding, applies EXIF orientation,
+// optionally writes a bounded WebP thumbnail back to R2, and returns original
+// dimensions plus a dominant-color palette — all in one pass.
+//
+// Logic mirrors packages/convex/workflows/steps/renderables/generateThumbnail.ts
+// and steps/palette.ts (the legacy Convex action fallback paths), including
+// the quality-tier table and the small-image skip rule.
+
+import {
+  fliph,
+  flipv,
+  PhotonImage,
+  resize,
+  rotate,
+  SamplingFilter,
+} from "@cf-wasm/photon";
+import { orientation } from "exifr";
+
+export const THUMBNAIL_MAX_WIDTH = 500;
+export const THUMBNAIL_MAX_HEIGHT = 500;
+
+// Workers have a hard memory ceiling well below Convex actions; refuse very
+// large originals so callers can fall back to the legacy action path instead
+// of risking an OOM kill mid-decode.
+export const MAX_INPUT_BYTES = 30 * 1024 * 1024;
+
+const MAX_COLORS = 5;
+const SAMPLE_TARGET = 4000;
+const CHANNEL_PRECISION = 16;
+
+export class ImageSourceMissing extends Error {
+  constructor() {
+    super("source_not_found");
+  }
+}
+
+export class ImageTooLarge extends Error {
+  constructor() {
+    super("source_too_large");
+  }
+}
+
+export interface ProcessImageResult {
+  height: number;
+  palette: string[];
+  thumbnailGenerated: boolean;
+  /** Set only when a thumbnail was written; echoes the destination key. */
+  thumbnailKey: string | null;
+  width: number;
+}
+
+interface OutputSettings {
+  quality: number;
+  skipThumbnail: boolean;
+  useJpeg: boolean;
+}
+
+/**
+ * Determine output quality and format based on file size. Aggressive
+ * compression keeps thumbnails smaller than originals. Must stay in lockstep
+ * with generateThumbnail.ts in the Convex package.
+ */
+export const getOutputSettings = (fileSizeBytes: number): OutputSettings => {
+  // Skip thumbnail generation for very small files (< 500KB) - they're already optimized
+  if (fileSizeBytes < 500_000) {
+    return { quality: 100, useJpeg: false, skipThumbnail: true };
+  }
+
+  if (fileSizeBytes < 1_000_000) {
+    // < 1MB - good WebP compression
+    return { quality: 80, useJpeg: false, skipThumbnail: false };
+  }
+  if (fileSizeBytes < 2_000_000) {
+    return { quality: 70, useJpeg: false, skipThumbnail: false };
+  }
+  if (fileSizeBytes < 5_000_000) {
+    return { quality: 65, useJpeg: false, skipThumbnail: false };
+  }
+  if (fileSizeBytes < 10_000_000) {
+    return { quality: 60, useJpeg: false, skipThumbnail: false };
+  }
+  if (fileSizeBytes < 20_000_000) {
+    return { quality: 60, useJpeg: false, skipThumbnail: false };
+  }
+  // >= 20MB - maximum WebP compression
+  return { quality: 50, useJpeg: false, skipThumbnail: false };
+};
+
+export const shouldSkipThumbnail = (
+  fileSizeBytes: number,
+  width: number,
+  height: number
+): boolean =>
+  getOutputSettings(fileSizeBytes).skipThumbnail &&
+  width <= THUMBNAIL_MAX_WIDTH &&
+  height <= THUMBNAIL_MAX_HEIGHT;
+
+/**
+ * Apply EXIF orientation to fix iOS HEIC-exports' rotation. Values follow the
+ * EXIF spec (2=flip-h, 3=180°, 4=flip-v, 5/7=transpose variants, 6=90° CW,
+ * 8=270° CW). Mirrors applyExifOrientation in generateThumbnail.ts.
+ */
+const applyExifOrientation = (
+  image: PhotonImage,
+  orientationValue: number
+): PhotonImage => {
+  let resultImage = image;
+
+  switch (orientationValue) {
+    case 2:
+      fliph(resultImage);
+      break;
+    case 3:
+      resultImage = rotate(resultImage, 180);
+      break;
+    case 4:
+      flipv(resultImage);
+      break;
+    case 5:
+      fliph(resultImage);
+      resultImage = rotate(resultImage, 270);
+      break;
+    case 6:
+      resultImage = rotate(resultImage, 90);
+      break;
+    case 7:
+      fliph(resultImage);
+      resultImage = rotate(resultImage, 90);
+      break;
+    case 8:
+      resultImage = rotate(resultImage, 270);
+      break;
+    default:
+      // No transformation needed
+      break;
+  }
+
+  return resultImage;
+};
+
+const quantizeChannel = (value: number): number => {
+  const clamped = Math.max(0, Math.min(255, value));
+  const bucket = Math.round(clamped / CHANNEL_PRECISION) * CHANNEL_PRECISION;
+  return Math.max(0, Math.min(255, bucket));
+};
+
+const toHex = (value: number): string => value.toString(16).padStart(2, "0");
+const rgbToHex = (r: number, g: number, b: number): string =>
+  `#${toHex(r)}${toHex(g)}${toHex(b)}`.toUpperCase();
+
+/** Dominant-color extraction over RGBA pixels. Mirrors palette.ts. */
+export const computePalette = (
+  pixels: Uint8Array,
+  maxColors: number
+): string[] => {
+  if (!pixels.length) {
+    return [];
+  }
+
+  const pixelCount = Math.floor(pixels.length / 4);
+  if (!pixelCount) {
+    return [];
+  }
+
+  const stride = Math.max(1, Math.floor(pixelCount / SAMPLE_TARGET));
+  const colorCounts = new Map<string, number>();
+
+  for (let i = 0; i < pixelCount; i += stride) {
+    const offset = i * 4;
+    const alpha = pixels[offset + 3];
+    if (alpha < 16) {
+      continue;
+    }
+
+    const r = quantizeChannel(pixels[offset]);
+    const g = quantizeChannel(pixels[offset + 1]);
+    const b = quantizeChannel(pixels[offset + 2]);
+    const hex = rgbToHex(r, g, b);
+    colorCounts.set(hex, (colorCounts.get(hex) ?? 0) + 1);
+  }
+
+  if (!colorCounts.size) {
+    const [r = 0, g = 0, b = 0] = pixels;
+    return [rgbToHex(r, g, b)];
+  }
+
+  return [...colorCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, maxColors)
+    .map(([hex]) => hex);
+};
+
+const readSourceBytes = async (
+  bucket: R2Bucket,
+  key: string
+): Promise<{ bytes: Uint8Array; httpMetadata?: R2HTTPMetadata }> => {
+  const object = await bucket.get(key);
+  if (!object) {
+    throw new ImageSourceMissing();
+  }
+  if ((object.size ?? 0) > MAX_INPUT_BYTES) {
+    await object.body.cancel();
+    throw new ImageTooLarge();
+  }
+  const bytes = new Uint8Array(await object.arrayBuffer());
+  return { bytes, httpMetadata: object.httpMetadata };
+};
+
+/**
+ * Run the combined decode → orient → resize → encode pipeline.
+ *
+ * @param destKey when non-null and generation is not skipped, the thumbnail
+ *   WebP is written here with its content type stored as httpMetadata so the
+ *   download path serves it correctly even without ct overrides.
+ */
+export const processImage = async (
+  bucket: R2Bucket,
+  srcKey: string,
+  destKey: string | null
+): Promise<ProcessImageResult> => {
+  const source = await readSourceBytes(bucket, srcKey);
+
+  let decoded: PhotonImage;
+  try {
+    decoded = PhotonImage.new_from_byteslice(source.bytes);
+  } catch {
+    throw new Error("decode_failed");
+  }
+
+  const exifOrientationValue = await orientation(
+    source.bytes.buffer instanceof ArrayBuffer
+      ? source.bytes.buffer
+      : source.bytes.slice().buffer
+  ).catch(() => undefined);
+
+  const oriented = applyExifOrientation(decoded, exifOrientationValue ?? 1);
+  const width = oriented.get_width();
+  const height = oriented.get_height();
+  const fileSizeBytes = source.bytes.byteLength;
+
+  const settings = getOutputSettings(fileSizeBytes);
+  const skipThumbnail =
+    destKey === null || shouldSkipThumbnail(fileSizeBytes, width, height);
+
+  let thumbnailGenerated = false;
+  let paletteSource: PhotonImage = oriented;
+
+  if (!skipThumbnail && destKey) {
+    // Triangle (bilinear) avoids the aliasing/shimmer artifacts that Nearest
+    // introduces on downscales, at a similar encode size.
+    const aspectRatio = width / height;
+    let targetWidth: number;
+    let targetHeight: number;
+
+    if (aspectRatio > 1) {
+      targetWidth = Math.min(width, THUMBNAIL_MAX_WIDTH);
+      targetHeight = Math.max(1, Math.round(targetWidth / aspectRatio));
+    } else {
+      targetHeight = Math.min(height, THUMBNAIL_MAX_HEIGHT);
+      targetWidth = Math.max(1, Math.round(targetHeight * aspectRatio));
+    }
+    if (targetWidth > THUMBNAIL_MAX_WIDTH) {
+      targetWidth = THUMBNAIL_MAX_WIDTH;
+      targetHeight = Math.max(1, Math.round(targetWidth / aspectRatio));
+    }
+    if (targetHeight > THUMBNAIL_MAX_HEIGHT) {
+      targetHeight = THUMBNAIL_MAX_HEIGHT;
+      targetWidth = Math.max(1, Math.round(targetHeight * aspectRatio));
+    }
+
+    const outputImage = resize(
+      oriented,
+      targetWidth,
+      targetHeight,
+      SamplingFilter.Triangle
+    );
+    paletteSource = outputImage;
+
+    const outputBytes = settings.useJpeg
+      ? outputImage.get_bytes_jpeg(settings.quality)
+      : outputImage.get_bytes_webp();
+    const contentType = settings.useJpeg ? "image/jpeg" : "image/webp";
+    const blob = new Blob([outputBytes], { type: contentType });
+
+    await bucket.put(destKey, blob, {
+      httpMetadata: { contentType },
+    });
+    thumbnailGenerated = true;
+  }
+
+  const rawPixels = paletteSource.get_raw_pixels();
+  const palette = computePalette(rawPixels, MAX_COLORS);
+
+  // Release WASM-owned pixel buffers promptly; workers have a tight memory
+  // ceiling and these can be tens of megabytes for large originals.
+  try {
+    if (paletteSource !== oriented) {
+      paletteSource.free();
+    }
+  } finally {
+    oriented.free();
+  }
+
+  return {
+    width,
+    height,
+    thumbnailGenerated,
+    thumbnailKey: thumbnailGenerated && destKey ? destKey : null,
+    palette,
+  };
+};

--- a/apps/files-worker/src/index.ts
+++ b/apps/files-worker/src/index.ts
@@ -1,8 +1,16 @@
 import {
+  buildExportIntoBucket,
+  ExportManifestInvalid,
+  ExportTooLarge,
+} from "./export";
+import { ImageSourceMissing, ImageTooLarge, processImage } from "./image";
+import { InspectSourceMissing, runInspect } from "./inspect";
+import {
   FILES_CACHE_CONTROL,
   FILES_EDGE_CACHE_CONTROL,
   parseSingleByteRange,
   verifySignedFileRequest,
+  verifySignedOpRequest,
 } from "./lib";
 
 export interface Env {
@@ -17,6 +25,129 @@ const decodeObjectKey = (pathname: string): string => {
     return "";
   }
 };
+
+const json = (data: unknown, status = 200): Response =>
+  new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "no-store",
+    },
+  });
+
+/**
+ * Internal signed ops: image processing, export building, file inspection.
+ * Payload shapes are defined in lib.ts; Convex mirrors them in
+ * packages/convex/storage/filesWorkerClient.ts.
+ */
+const handleOp = async (
+  env: Env,
+  url: URL,
+  key: string,
+  op: string
+): Promise<Response> => {
+  const query = url.searchParams;
+  const fieldNamesByOp: Record<string, string[]> = {
+    "process-image": ["dest"],
+    "build-export": ["artifact", "name"],
+    inspect: ["mode", "mb", "rtf", "fmt"],
+  };
+  const fieldNames = fieldNamesByOp[op];
+  if (!fieldNames) {
+    return json({ error: "unknown_op" }, 400);
+  }
+  const fields = fieldNames.map((name) => query.get(name) ?? "");
+  const verification = await verifySignedOpRequest(
+    env.FILES_SIGNING_SECRET,
+    op,
+    key,
+    {
+      fields,
+      exp: query.get("exp"),
+      sig: query.get("sig"),
+    }
+  );
+  if (!verification.ok) {
+    return new Response(null, { status: verification.status });
+  }
+
+  try {
+    switch (op) {
+      case "process-image": {
+        const result = await processImage(env.BUCKET, key, fields[0] || null);
+        return json(result);
+      }
+      case "build-export": {
+        const [artifactKey, fileName] = fields;
+        if (!(artifactKey && isValidArtifactName(fileName ?? ""))) {
+          return json({ error: "invalid_params" }, 400);
+        }
+        const result = await buildExportIntoBucket(
+          env.BUCKET,
+          key,
+          artifactKey,
+          fileName as string
+        );
+        return json(result);
+      }
+      case "inspect": {
+        const [mode, mb, rtf] = fields;
+        if (mode !== "zip" && mode !== "css" && mode !== "text") {
+          return json({ error: "invalid_mode" }, 400);
+        }
+        const maxBytes = Number.parseInt(mb ?? "", 10);
+        if (
+          !Number.isSafeInteger(maxBytes) ||
+          maxBytes <= 0 ||
+          maxBytes > 64 * 1024 * 1024
+        ) {
+          return json({ error: "invalid_max_bytes" }, 400);
+        }
+        const result = await runInspect(
+          env.BUCKET,
+          key,
+          mode,
+          query.get("fmt") ?? "",
+          maxBytes,
+          rtf === "1"
+        );
+        return json(result);
+      }
+      default:
+        return json({ error: "unknown_op" }, 400);
+    }
+  } catch (error) {
+    if (
+      error instanceof ImageSourceMissing ||
+      error instanceof InspectSourceMissing
+    ) {
+      return json({ error: error.message }, 404);
+    }
+    if (error instanceof ImageTooLarge) {
+      // Callers treat this as "fall back to the legacy action path".
+      return json({ error: error.message }, 413);
+    }
+    if (error instanceof ExportManifestInvalid) {
+      return json({ error: error.message }, 400);
+    }
+    if (error instanceof ExportTooLarge) {
+      return json({ error: error.message }, 413);
+    }
+    const message = error instanceof Error ? error.message : "unknown_error";
+    if (message === "decode_failed" || message === "archive_parse_failed") {
+      return json({ error: message }, 422);
+    }
+    console.error(`[files-worker] op ${op} failed`, error);
+    return json({ error: "internal_error" }, 500);
+  }
+};
+
+const isValidArtifactName = (name: string): boolean =>
+  name.length > 0 &&
+  name.length <= 200 &&
+  !name.includes('"') &&
+  !name.includes("\\") &&
+  !name.includes("\0");
 
 /**
  * Edge-cache key for a full-object response. The object key already embeds the
@@ -76,6 +207,11 @@ export default {
       return new Response(null, { status: 404 });
     }
 
+    const op = url.searchParams.get("op");
+    if (op) {
+      return await handleOp(env, url, key, op);
+    }
+
     const verification = await verifySignedFileRequest(
       env.FILES_SIGNING_SECRET,
       {
@@ -116,7 +252,12 @@ export default {
       }
 
       const headers = new Headers();
-      applyObjectHeaders(headers, request, object.httpMetadata, object.httpEtag);
+      applyObjectHeaders(
+        headers,
+        request,
+        object.httpMetadata,
+        object.httpEtag
+      );
 
       const [clientBody, edgeBody] = object.body.tee();
       const response = new Response(clientBody, { headers });
@@ -176,7 +317,10 @@ export default {
 
     const headers = new Headers();
     applyObjectHeaders(headers, request, object.httpMetadata, object.httpEtag);
-    headers.set("Content-Range", `bytes ${start}-${start + length - 1}/${size}`);
+    headers.set(
+      "Content-Range",
+      `bytes ${start}-${start + length - 1}/${size}`
+    );
 
     return new Response(object.body, { status: 206, headers });
   },

--- a/apps/files-worker/src/inspect.test.ts
+++ b/apps/files-worker/src/inspect.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { zipSync } from "fflate";
+import { extractRtfText, inspectZipInMemory, runInspect } from "./inspect";
+import { FakeBucket } from "./testsupport";
+
+describe("zip inspection", () => {
+  test("counts entries and extracts docx body text", () => {
+    const bytes = zipSync({
+      "[Content_Types].xml": new TextEncoder().encode("<Types/>"),
+      "word/document.xml": new TextEncoder().encode(
+        "<w:body><w:p><w:t>Hello</w:t></w:p><w:p><w:t>World</w:t></w:p></w:body>"
+      ),
+    });
+
+    const inspection = inspectZipInMemory(bytes, "word");
+    expect(inspection).not.toBeNull();
+    expect(inspection!.facts.archiveFileCount).toBe(2);
+    expect(inspection!.facts.archiveDirectoryCount).toBe(0);
+    expect(inspection!.facts.inspectedEntryCount).toBe(2);
+    expect(inspection!.facts.slideCount).toBeUndefined();
+    expect(inspection!.text).toBe("Hello World");
+  });
+
+  test("counts pptx slides without reading them for word docs", () => {
+    const bytes = zipSync({
+      "ppt/slides/slide1.xml": new TextEncoder().encode("<p><t>A</t></p>"),
+      "ppt/slides/slide2.xml": new TextEncoder().encode("<p><t>B</t></p>"),
+      "ppt/slides/slide3.xml": new TextEncoder().encode("<p><t>C</t></p>"),
+    });
+
+    const pptx = inspectZipInMemory(bytes, "powerpoint");
+    expect(pptx!.facts.slideCount).toBe(3);
+    expect(pptx!.text).toBe("A\nB\nC");
+
+    const asWord = inspectZipInMemory(bytes, "word");
+    expect(asWord!.facts.slideCount).toBeUndefined();
+    expect(asWord!.text).toBe("");
+  });
+
+  test("returns null for non-archive bytes", () => {
+    expect(inspectZipInMemory(new Uint8Array([1, 2, 3]), "zip")).toBeNull();
+  });
+});
+
+describe("runInspect dispatch", () => {
+  const bucket = new FakeBucket();
+
+  test("css mode counts color variable declarations", async () => {
+    bucket.objects.set("theme.css", {
+      bytes: new TextEncoder().encode(
+        ":root{--brand:#ff0000;--accent:rgb(1 2 3);--plain: red;}"
+      ),
+    });
+    const result = await runInspect(
+      bucket,
+      "theme.css",
+      "css",
+      "tokens",
+      1024,
+      false
+    );
+    expect(result.facts?.colorVariableCount).toBe(2);
+  });
+
+  test("text mode decodes bounded text with optional rtf stripping", async () => {
+    bucket.objects.set("notes.md", {
+      bytes: new TextEncoder().encode("# Notes\n\nhello"),
+    });
+    expect(
+      (await runInspect(bucket, "notes.md", "text", "markdown", 1024, false))
+        .text
+    ).toBe("# Notes\n\nhello");
+
+    bucket.objects.set("notes.rtf", {
+      bytes: new TextEncoder().encode(
+        "{\\rtf1\\ansi{\\fonttbl}\\fs28 RTF  text, line}"
+      ),
+    });
+    expect(
+      (await runInspect(bucket, "notes.rtf", "text", "rtf", 1024, true)).text
+    ).toBe("RTF text, line");
+  });
+
+  test("missing sources surface a distinct error", async () => {
+    await expect(
+      runInspect(bucket, "gone.css", "css", "tokens", 1024, false)
+    ).rejects.toThrow("source_not_found");
+  });
+});
+
+describe("rtf stripping", () => {
+  test("removes control words and groups while keeping readable text", () => {
+    expect(extractRtfText("{\\rtf1\\ansi Hello \\'48ello}")).not.toContain(
+      "\\"
+    );
+    expect(extractRtfText("{\\b bold} plain")).toContain("bold");
+  });
+});

--- a/apps/files-worker/src/inspect.ts
+++ b/apps/files-worker/src/inspect.ts
@@ -1,0 +1,330 @@
+// Bounded file inspection for the inspect op: reads at most `mb` bytes of an
+// object from the R2 binding and extracts preview facts / AI text without the
+// object ever transiting a Convex action.
+//
+// Ports packages/convex/workflows/fileProcessing.ts:
+//   - mode "zip"  → archive stats (+ DOCX/PPTX body text) via yauzl there,
+//     via a minimal central-directory walker + fflate inflate here
+//   - mode "css"  → count of color variable declarations
+//   - mode "text" → decoded (optionally RTF-stripped) text for AI analysis
+
+import { inflateSync } from "fflate";
+
+const MAX_AI_TEXT_BYTES = 512 * 1024;
+const MAX_ARCHIVE_ENTRIES = 2000;
+const MAX_ARCHIVE_ENTRY_BYTES = 512 * 1024;
+const MAX_COMPRESSION_RATIO = 100;
+
+const PPTX_SLIDE_REGEX = /^ppt\/slides\/slide\d+\.xml$/iu;
+const PPTX_TEXT_REGEX = /^ppt\/slides\/slide\d+\.xml$/iu;
+const DOCX_TEXT_PATH = "word/document.xml";
+const XML_ENTITY_REGEX = /&(amp|apos|gt|lt|quot|#39);/gu;
+const XML_ENTITIES: Record<string, string> = {
+  "&#39;": "'",
+  "&amp;": "&",
+  "&apos;": "'",
+  "&gt;": ">",
+  "&lt;": "<",
+  "&quot;": '"',
+};
+const CSS_COLOR_VARIABLE_REGEX =
+  /--[a-z0-9_-]+\s*:\s*(?:#[0-9a-f]{3,8}\b|(?:rgb|hsl|oklab|oklch|lab|lch|color)\([^;]+\))/giu;
+
+export type InspectMode = "css" | "text" | "zip";
+
+export interface InspectResult {
+  facts?: Record<string, number>;
+  text?: string;
+}
+
+export class InspectSourceMissing extends Error {
+  constructor() {
+    super("source_not_found");
+  }
+}
+
+const decodeXmlText = (value: string): string =>
+  value
+    .replace(/<[^>]+>/gu, " ")
+    .replace(XML_ENTITY_REGEX, (entity) => XML_ENTITIES[entity] ?? entity)
+    .replace(/\s+/gu, " ")
+    .trim();
+
+export const extractRtfText = (value: string): string =>
+  value
+    .replace(/\\'[0-9a-f]{2}/giu, " ")
+    .replace(/\\[a-z]+-?\d* ?/giu, " ")
+    .replace(/[{}]/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+
+/**
+ * Read at most maxBytes bytes of an object; null when missing, and objects
+ * larger than the cap resolve to exactly maxBytes bytes (callers treat
+ * truncation as acceptable — mirrors fetchBoundedBytes' content-length guard
+ * plus streaming fallback).
+ */
+const boundedRead = async (
+  bucket: R2Bucket,
+  key: string,
+  maxBytes: number
+): Promise<Uint8Array | null> => {
+  const object = await bucket.get(key);
+  if (!object) {
+    return null;
+  }
+  if ((object.size ?? 0) <= maxBytes) {
+    return new Uint8Array(await object.arrayBuffer());
+  }
+  // Larger than the cap: read only the prefix we would have used anyway.
+  await object.body.cancel();
+  const partial = await bucket.get(key, {
+    range: { offset: 0, length: maxBytes },
+  });
+  if (!partial) {
+    return null;
+  }
+  return new Uint8Array(await partial.arrayBuffer());
+};
+
+interface ZipCentralEntry {
+  compressedSize: number;
+  compressionMethod: number;
+  localHeaderOffset: number;
+  name: string;
+  uncompressedSize: number;
+}
+
+const EOCD_SIGNATURE = 0x06_05_4b_50;
+const CD_ENTRY_SIGNATURE = 0x02_01_4b_50;
+const LOCAL_HEADER_SIGNATURE = 0x04_03_4b_50;
+
+/** ZIP integers are little-endian; DataView keeps the bit-twiddling honest. */
+const viewFor = (bytes: Uint8Array): DataView =>
+  new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+const u16 = (bytes: Uint8Array, offset: number): number =>
+  viewFor(bytes).getUint16(offset, true);
+const u32 = (bytes: Uint8Array, offset: number): number =>
+  viewFor(bytes).getUint32(offset, true);
+
+/**
+ * Locate the End of Central Directory record and parse the central directory.
+ * Archives inspected here are capped well below zip64 territory, so the
+ * classic 32-bit structure is sufficient.
+ */
+const parseCentralDirectory = (
+  bytes: Uint8Array
+): { entries: ZipCentralEntry[] } | null => {
+  const minEocdOffset = Math.max(0, bytes.length - 22 - 65_536);
+  let eocd = -1;
+  for (let i = bytes.length - 22; i >= minEocdOffset; i -= 1) {
+    if (u32(bytes, i) === EOCD_SIGNATURE) {
+      eocd = i;
+      break;
+    }
+  }
+  if (eocd < 0) {
+    return null;
+  }
+
+  const entryCount = u16(bytes, eocd + 10);
+  let offset = u32(bytes, eocd + 16);
+  const entries: ZipCentralEntry[] = [];
+
+  for (let index = 0; index < entryCount; index += 1) {
+    if (
+      offset + 46 > bytes.length ||
+      u32(bytes, offset) !== CD_ENTRY_SIGNATURE
+    ) {
+      break;
+    }
+    const nameLength = u16(bytes, offset + 28);
+    const extraLength = u16(bytes, offset + 30);
+    const commentLength = u16(bytes, offset + 32);
+    const name = new TextDecoder().decode(
+      bytes.subarray(offset + 46, offset + 46 + nameLength)
+    );
+    entries.push({
+      name,
+      compressionMethod: u16(bytes, offset + 10),
+      compressedSize: u32(bytes, offset + 20),
+      uncompressedSize: u32(bytes, offset + 24),
+      localHeaderOffset: u32(bytes, offset + 42),
+    });
+    offset += 46 + nameLength + extraLength + commentLength;
+  }
+
+  return { entries };
+};
+
+/** Decompress one entry's payload given its central-directory descriptor. */
+const readEntryBytes = (
+  bytes: Uint8Array,
+  entry: ZipCentralEntry
+): Uint8Array | null => {
+  if (
+    entry.localHeaderOffset + 30 > bytes.length ||
+    u32(bytes, entry.localHeaderOffset) !== LOCAL_HEADER_SIGNATURE
+  ) {
+    return null;
+  }
+  const nameLength = u16(bytes, entry.localHeaderOffset + 26);
+  const extraLength = u16(bytes, entry.localHeaderOffset + 28);
+  const dataStart = entry.localHeaderOffset + 30 + nameLength + extraLength;
+  const raw = bytes.subarray(dataStart, dataStart + entry.compressedSize);
+  try {
+    if (entry.compressionMethod === 0) {
+      return raw.slice();
+    }
+    if (entry.compressionMethod === 8) {
+      return inflateSync(raw);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const canReadArchiveEntry = (entry: ZipCentralEntry): boolean => {
+  if (entry.uncompressedSize > MAX_ARCHIVE_ENTRY_BYTES) {
+    return false;
+  }
+  if (entry.compressedSize === 0) {
+    return entry.uncompressedSize === 0;
+  }
+  return entry.uncompressedSize / entry.compressedSize <= MAX_COMPRESSION_RATIO;
+};
+
+export interface ZipInspection {
+  facts: {
+    archiveDirectoryCount: number;
+    archiveFileCount: number;
+    inspectedEntryCount: number;
+    slideCount?: number;
+  };
+  text: string;
+}
+
+/**
+ * Inspect an in-memory archive. Mirrors inspectZip in fileProcessing.ts:
+ * counts every entry up to MAX_ARCHIVE_ENTRIES, extracts slide/document XML
+ * text for Word/PowerPoint previews within the byte/ratio guards.
+ */
+export const inspectZipInMemory = (
+  bytes: Uint8Array,
+  formatId: string
+): ZipInspection | null => {
+  const parsed = parseCentralDirectory(bytes);
+  if (!parsed) {
+    return null;
+  }
+
+  let archiveDirectoryCount = 0;
+  let archiveFileCount = 0;
+  let inspectedEntryCount = 0;
+  let slideCount = 0;
+  let textBytes = 0;
+  const textParts: string[] = [];
+
+  for (const entry of parsed.entries) {
+    inspectedEntryCount += 1;
+    if (entry.name.endsWith("/")) {
+      archiveDirectoryCount += 1;
+    } else {
+      archiveFileCount += 1;
+    }
+
+    if (PPTX_SLIDE_REGEX.test(entry.name)) {
+      slideCount += 1;
+    }
+
+    const shouldReadText =
+      formatId === "word"
+        ? entry.name === DOCX_TEXT_PATH
+        : formatId === "powerpoint" && PPTX_TEXT_REGEX.test(entry.name);
+
+    if (
+      shouldReadText &&
+      textBytes < MAX_AI_TEXT_BYTES &&
+      canReadArchiveEntry(entry)
+    ) {
+      const entryBytes = readEntryBytes(bytes, entry);
+      if (entryBytes) {
+        textBytes += entryBytes.byteLength;
+        if (textBytes <= MAX_AI_TEXT_BYTES) {
+          const decoded = decodeXmlText(new TextDecoder().decode(entryBytes));
+          if (decoded) {
+            textParts.push(decoded);
+          }
+        }
+      }
+    }
+
+    if (inspectedEntryCount >= MAX_ARCHIVE_ENTRIES) {
+      break;
+    }
+  }
+
+  return {
+    facts: {
+      archiveDirectoryCount,
+      archiveFileCount,
+      inspectedEntryCount,
+      ...(formatId === "powerpoint" ? { slideCount } : {}),
+    },
+    text: textParts.join("\n").trim(),
+  };
+};
+
+/**
+ * Dispatch one inspect request.
+ *
+ * @param formatId file-format id (zip/word/powerpoint/css tokens/etc.) so the
+ *   zip mode knows which entries carry user-visible text
+ * @param rtf when true, text mode applies the RTF control-word stripper
+ */
+export const runInspect = async (
+  bucket: R2Bucket,
+  key: string,
+  mode: InspectMode,
+  formatId: string,
+  maxBytes: number,
+  rtf: boolean
+): Promise<InspectResult> => {
+  if (mode === "css") {
+    const bytes = await boundedRead(bucket, key, maxBytes);
+    if (!bytes) {
+      throw new InspectSourceMissing();
+    }
+    const text = new TextDecoder().decode(bytes);
+    return {
+      facts: {
+        colorVariableCount: Array.from(text.matchAll(CSS_COLOR_VARIABLE_REGEX))
+          .length,
+      },
+    };
+  }
+
+  if (mode === "text") {
+    const bytes = await boundedRead(bucket, key, maxBytes);
+    if (!bytes) {
+      throw new InspectSourceMissing();
+    }
+    const decoded = new TextDecoder().decode(bytes.slice(0, MAX_AI_TEXT_BYTES));
+    return {
+      text: rtf ? extractRtfText(decoded).trim() : decoded.trim(),
+    };
+  }
+
+  // zip mode: needs the whole (bounded) archive for the central directory.
+  const bytes = await boundedRead(bucket, key, maxBytes);
+  if (!bytes) {
+    throw new InspectSourceMissing();
+  }
+  const inspection = inspectZipInMemory(bytes, formatId);
+  if (!inspection) {
+    throw new Error("archive_parse_failed");
+  }
+  return inspection;
+};

--- a/apps/files-worker/src/lib.test.ts
+++ b/apps/files-worker/src/lib.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
+  buildOpSigningPayload,
   buildSigningPayload,
   hmacSha256Hex,
   parseSingleByteRange,
   verifySignedFileRequest,
+  verifySignedOpRequest,
 } from "./lib";
 
 const SECRET = "test-signing-secret";
@@ -155,5 +157,143 @@ describe("range header parsing", () => {
       kind: "suffix",
       suffix: 256,
     });
+  });
+});
+
+describe("op signing", () => {
+  const OP_KEY = "users/abc/cards/file/x.png";
+  const OP_DEST = "users/abc/cards/thumbnail/t.webp";
+
+  // Fixed vector shared with packages/convex/__tests__/storage/r2.test.ts —
+  // proves Node/Bun (Convex) and workerd (worker) agree on op payloads.
+  const OP_VECTOR_DIGEST =
+    "08bf451235a9af51ddc744b0b7be67622a06dc36696f87675fda746fc8efae47";
+
+  test("op payload format matches the shared cross-runtime vector", async () => {
+    const digest = await hmacSha256Hex(
+      SECRET,
+      buildOpSigningPayload({
+        op: "process-image",
+        key: OP_KEY,
+        fields: [OP_DEST],
+        exp: EXP,
+      })
+    );
+    expect(digest).toBe(OP_VECTOR_DIGEST);
+  });
+
+  test("accepts a valid unexpired op token", async () => {
+    const sig = await hmacSha256Hex(
+      SECRET,
+      buildOpSigningPayload({
+        op: "inspect",
+        key: OP_KEY,
+        fields: ["zip", String(25 * 1024 * 1024), ""],
+        exp: EXP,
+      })
+    );
+    expect(
+      await verifySignedOpRequest(
+        SECRET,
+        "inspect",
+        OP_KEY,
+        { fields: ["zip", String(25 * 1024 * 1024), ""], exp: EXP, sig },
+        1_699_999_999
+      )
+    ).toEqual({ ok: true });
+  });
+
+  test("rejects expired, tampered, over-long-ttl, and malformed tokens", async () => {
+    const sig = await hmacSha256Hex(
+      SECRET,
+      buildOpSigningPayload({
+        op: "process-image",
+        key: OP_KEY,
+        fields: [OP_DEST],
+        exp: EXP,
+      })
+    );
+    const params = { fields: [OP_DEST], exp: EXP, sig };
+
+    expect(
+      await verifySignedOpRequest(
+        SECRET,
+        "process-image",
+        OP_KEY,
+        params,
+        1_700_000_001
+      )
+    ).toEqual({ ok: false, status: 410 });
+    // Wrong op name is a signature mismatch (checked before expiry).
+    expect(
+      await verifySignedOpRequest(
+        SECRET,
+        "build-export",
+        OP_KEY,
+        params,
+        1_699_999_999
+      )
+    ).toEqual({ ok: false, status: 403 });
+    expect(
+      await verifySignedOpRequest(
+        SECRET,
+        "process-image",
+        "other/key.png",
+        params,
+        1_699_999_999
+      )
+    ).toEqual({ ok: false, status: 403 });
+    expect(
+      await verifySignedOpRequest(
+        SECRET,
+        "process-image",
+        OP_KEY,
+        {
+          ...params,
+          fields: ["users/other/t.webp"],
+        },
+        1_699_999_999
+      )
+    ).toEqual({ ok: false, status: 403 });
+
+    // Op URLs must be short-lived: mint-time TTL is bounded.
+    const farFuture = String(1_699_999_990 + 60 * 60 * 24);
+    const farSig = await hmacSha256Hex(
+      SECRET,
+      buildOpSigningPayload({
+        op: "process-image",
+        key: OP_KEY,
+        fields: [OP_DEST],
+        exp: farFuture,
+      })
+    );
+    expect(
+      await verifySignedOpRequest(
+        SECRET,
+        "process-image",
+        OP_KEY,
+        {
+          fields: [OP_DEST],
+          exp: farFuture,
+          sig: farSig,
+        },
+        1_699_999_990 + 60
+      )
+    ).toEqual({ ok: false, status: 403 });
+
+    expect(
+      await verifySignedOpRequest(SECRET, "process-image", OP_KEY, {
+        fields: [OP_DEST],
+        exp: null,
+        sig,
+      })
+    ).toEqual({ ok: false, status: 401 });
+    expect(
+      await verifySignedOpRequest(SECRET, "process-image", OP_KEY, {
+        fields: [OP_DEST],
+        exp: "12",
+        sig: null,
+      })
+    ).toEqual({ ok: false, status: 401 });
   });
 });

--- a/apps/files-worker/src/lib.ts
+++ b/apps/files-worker/src/lib.ts
@@ -15,8 +15,8 @@ export const FILES_CACHE_CONTROL = "private, max-age=518400, immutable"; // 6 da
 export const FILES_EDGE_CACHE_CONTROL = "public, max-age=518400, immutable";
 
 export interface R2GetRange {
-  offset?: number;
   length?: number;
+  offset?: number;
   suffix?: number;
 }
 
@@ -52,7 +52,11 @@ export const parseSingleByteRange = (
     return { kind: "suffix", suffix };
   }
   const start = Number.parseInt(rawStart ?? "", 10);
-  if (!Number.isSafeInteger(start) || start < 0 || start > Number.MAX_SAFE_INTEGER - 1) {
+  if (
+    !Number.isSafeInteger(start) ||
+    start < 0 ||
+    start > Number.MAX_SAFE_INTEGER - 1
+  ) {
     return null;
   }
   if (rawEnd === "") {
@@ -134,6 +138,29 @@ export const hmacSha256Hex = async (
   ).join("");
 };
 
+// Ops (process-image / build-export / inspect) are internal, short-lived
+// requests signed with the same secret as downloads but a distinct payload
+// shape so download URLs can never be replayed against an op and vice versa:
+//
+//   ["op", <op>, <key>, ...extra fields..., <exp>].join("\n")
+//
+// Extra field values are joined in a fixed per-op order agreed on both sides
+// (packages/convex/storage/filesWorkerClient.ts mirrors this module). Empty
+// strings are allowed slots.
+export const FILES_OP_MAX_TTL_SECONDS = 15 * 60;
+
+export const buildOpSigningPayload = ({
+  exp,
+  fields,
+  key,
+  op,
+}: {
+  op: string;
+  key: string;
+  fields: string[];
+  exp: string;
+}): string => ["op", op, key, ...fields, exp].join("\n");
+
 export type FileRequestVerification =
   | { ok: true }
   | { ok: false; status: 401 | 403 | 410 };
@@ -169,6 +196,47 @@ export const verifySignedFileRequest = async (
       contentType: ct ?? "",
       contentDisposition: cd ?? "",
     })
+  );
+  return timingSafeEqualHex(sig, expected)
+    ? { ok: true }
+    : { ok: false, status: 403 };
+};
+
+export interface SignedOpRequestParams {
+  exp: string | null | undefined;
+  fields?: string[];
+  sig: string | null | undefined;
+}
+
+/**
+ * Verify an internal op request. Identical rules to download verification
+ * plus an upper bound on remaining validity: op URLs are minted per action
+ * invocation and should never live longer than FILES_OP_MAX_TTL_SECONDS, so a
+ * leaked URL has a tightly bounded replay window.
+ */
+export const verifySignedOpRequest = async (
+  secret: string,
+  op: string,
+  key: string,
+  { fields = [], exp, sig }: SignedOpRequestParams,
+  nowSeconds = Math.floor(Date.now() / 1000)
+): Promise<FileRequestVerification> => {
+  if (!(exp && sig)) {
+    return { ok: false, status: 401 };
+  }
+  const expiresAt = Number.parseInt(exp, 10);
+  if (!Number.isSafeInteger(expiresAt) || `${expiresAt}` !== exp) {
+    return { ok: false, status: 403 };
+  }
+  if (expiresAt < nowSeconds) {
+    return { ok: false, status: 410 };
+  }
+  if (expiresAt - nowSeconds > FILES_OP_MAX_TTL_SECONDS) {
+    return { ok: false, status: 403 };
+  }
+  const expected = await hmacSha256Hex(
+    secret,
+    buildOpSigningPayload({ op, key, fields, exp })
   );
   return timingSafeEqualHex(sig, expected)
     ? { ok: true }

--- a/apps/files-worker/src/testsupport.ts
+++ b/apps/files-worker/src/testsupport.ts
@@ -1,0 +1,182 @@
+// Test-only helpers. Never imported by src/index.ts, so none of this ships in
+// the deployed worker bundle.
+
+import { crc32, deflateSync } from "node:zlib";
+
+/* ------------------------------------------------------------------ *
+ * Minimal PNG encoder (truecolor + alpha) so image tests can build
+ * deterministic fixtures of any dimension without binary assets.
+ * ------------------------------------------------------------------ */
+
+const pngChunk = (type: string, data: Uint8Array): Uint8Array => {
+  const out = new Uint8Array(12 + data.length);
+  const view = new DataView(out.buffer);
+  view.setUint32(0, data.length);
+  out.set(new TextEncoder().encode(type), 4);
+  out.set(data, 8);
+  const typed = out.subarray(4, 8 + data.length);
+  view.setUint32(8 + data.length, crc32(typed));
+  return out;
+};
+
+/** Encode a solid-color RGBA PNG of the given dimensions. */
+export const makePng = (
+  width: number,
+  height: number,
+  rgba: [number, number, number, number] = [255, 0, 0, 255]
+): Uint8Array => {
+  const rowLength = 1 + width * 4;
+  const raw = new Uint8Array(rowLength * height);
+  for (let y = 0; y < height; y += 1) {
+    const rowStart = y * rowLength;
+    raw[rowStart] = 0; // filter type: none
+    for (let x = 0; x < width; x += 1) {
+      const offset = rowStart + 1 + x * 4;
+      raw[offset] = rgba[0];
+      raw[offset + 1] = rgba[1];
+      raw[offset + 2] = rgba[2];
+      raw[offset + 3] = rgba[3];
+    }
+  }
+
+  const ihdr = new Uint8Array(13);
+  const view = new DataView(ihdr.buffer);
+  view.setUint32(0, width);
+  view.setUint32(4, height);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 6; // color type: truecolor + alpha
+
+  const signature = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+  const parts = [
+    signature,
+    pngChunk("IHDR", ihdr),
+    pngChunk("IDAT", deflateSync(raw)),
+    pngChunk("IEND", new Uint8Array(0)),
+  ];
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+};
+
+/* ------------------------------------------------------------------ *
+ * In-memory R2 bucket double covering the binding surface the worker
+ * uses: get/head/put plus multipart uploads. Methods are synchronous
+ * under the hood; awaiting their plain results behaves identically.
+ * ------------------------------------------------------------------ */
+
+export interface FakeStoredObject {
+  bytes: Uint8Array | null;
+  httpMetadata?: Record<string, string>;
+}
+
+interface PutRecord {
+  bytes: Uint8Array;
+  httpMetadata?: Record<string, string>;
+  key: string;
+}
+
+const asBody = (bytes: Uint8Array) => {
+  const copy =
+    bytes.buffer instanceof ArrayBuffer &&
+    bytes.byteOffset === 0 &&
+    bytes.byteLength === bytes.buffer.byteLength
+      ? bytes
+      : bytes.slice();
+  return {
+    // A real ReadableStream — client-zip instanceof-checks its inputs.
+    body: new Response(new Uint8Array(copy)).body as ReadableStream,
+    arrayBuffer: async () =>
+      copy.buffer.slice(
+        copy.byteOffset,
+        copy.byteOffset + copy.byteLength
+      ) as ArrayBuffer,
+    text: async () => new TextDecoder().decode(copy),
+  };
+};
+
+export class FakeBucket {
+  objects = new Map<string, FakeStoredObject>();
+  puts: PutRecord[] = [];
+  multipartCompletions: Array<{ key: string; bytes: Uint8Array }> = [];
+  failKeys = new Set<string>();
+
+  get(key: string, range?: { offset?: number; length?: number }) {
+    if (this.failKeys.has(key)) {
+      return null;
+    }
+    const stored = this.objects.get(key);
+    if (!stored?.bytes) {
+      return null;
+    }
+    let slice = stored.bytes;
+    if (range?.offset !== undefined || range?.length !== undefined) {
+      const start = range?.offset ?? 0;
+      const end =
+        range?.length === undefined ? slice.length : start + range.length;
+      slice = slice.subarray(start, Math.min(end, slice.length));
+    }
+    return {
+      ...asBody(slice),
+      size: slice.length,
+      httpMetadata: stored.httpMetadata,
+    };
+  }
+
+  head(key: string) {
+    const stored = this.objects.get(key);
+    if (!stored) {
+      return null;
+    }
+    return {
+      size: stored.bytes?.length ?? 0,
+      httpMetadata: stored.httpMetadata,
+    };
+  }
+
+  async put(
+    key: string,
+    value: Blob,
+    options?: { httpMetadata?: Record<string, string> }
+  ) {
+    const bytes = new Uint8Array(await value.arrayBuffer());
+    this.puts.push({ key, bytes, httpMetadata: options?.httpMetadata });
+    this.objects.set(key, { bytes, httpMetadata: options?.httpMetadata });
+    return {};
+  }
+
+  createMultipartUpload(
+    key: string,
+    options?: { httpMetadata?: Record<string, string> }
+  ) {
+    const parts: Uint8Array[] = [];
+    return {
+      uploadPart: (partNumber: number, value: Uint8Array) => {
+        parts.push(value);
+        return { partNumber, etag: `etag-${partNumber}` };
+      },
+      complete: () => {
+        const total = parts.reduce((sum, part) => sum + part.length, 0);
+        const bytes = new Uint8Array(total);
+        let offset = 0;
+        for (const part of parts) {
+          bytes.set(part, offset);
+          offset += part.length;
+        }
+        this.multipartCompletions.push({ key, bytes });
+        this.objects.set(key, { bytes, httpMetadata: options?.httpMetadata });
+        return {};
+      },
+      abort: () => Promise.resolve(),
+    };
+  }
+
+  /** Bytes stored under a key via put() or a completed multipart upload. */
+  storedBytes(key: string): Uint8Array | null {
+    return this.objects.get(key)?.bytes ?? null;
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -101,6 +101,12 @@
     "apps/files-worker": {
       "name": "@teak/files-worker",
       "version": "0.1.0",
+      "dependencies": {
+        "@cf-wasm/photon": "^0.4.0",
+        "client-zip": "^2.4.5",
+        "exifr": "^7.1.3",
+        "fflate": "^0.8.2",
+      },
       "devDependencies": {
         "@cloudflare/workers-types": "^5.20260822.1",
         "wrangler": "^4.125.0",
@@ -2366,6 +2372,8 @@
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
+
+    "client-zip": ["client-zip@2.5.0", "", {}, "sha512-ydG4nDZesbFurnNq0VVCp/yyomIBh+X/1fZPI/P24zbnG4dtC4tQAfI5uQsomigsUMeiRO2wiTPizLWQh+IAyQ=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 

--- a/packages/convex/__tests__/storage/r2.test.ts
+++ b/packages/convex/__tests__/storage/r2.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { createHmac } from "node:crypto";
 import {
+  buildSignedWorkerOpPayload,
+  buildSignedWorkerOpUrl,
+} from "../../storage/filesWorkerClient";
+import {
   bucketedSignatureExpiry,
   buildSignedFilePayload,
   buildSignedWorkerFileUrl,
@@ -59,7 +63,7 @@ describe("signed worker file urls", () => {
   test("bucketed expiry stays constant per window with ample remaining ttl", () => {
     const windowSeconds = 6 * 60 * 60;
     const windowStart =
-      Math.floor(Math.floor(Date.now() / 60_000) * 60 / windowSeconds) *
+      Math.floor((Math.floor(Date.now() / 60_000) * 60) / windowSeconds) *
       windowSeconds;
     const inWindow = [
       windowStart,
@@ -99,5 +103,72 @@ describe("signed worker file urls", () => {
         })
       )
     );
+  });
+});
+
+describe("signed worker op urls", () => {
+  const OP_KEY = "users/abc/cards/file/x.png";
+  const OP_DEST = "users/abc/cards/thumbnail/t.webp";
+
+  // Fixed vector shared with apps/files-worker/src/lib.test.ts — proves the
+  // Node/Bun (Convex) and workerd (worker) HMAC implementations agree on the
+  // op payload shape too.
+  const OP_VECTOR_DIGEST =
+    "08bf451235a9af51ddc744b0b7be67622a06dc36696f87675fda746fc8efae47";
+
+  test("op payload format matches the shared cross-runtime vector", () => {
+    const payload = buildSignedWorkerOpPayload({
+      op: "process-image",
+      key: OP_KEY,
+      fields: [OP_DEST],
+      exp: EXP,
+    });
+    expect(payload).toBe(`op\nprocess-image\n${OP_KEY}\n${OP_DEST}\n${EXP}`);
+    expect(hmacHex(payload)).toBe(OP_VECTOR_DIGEST);
+  });
+
+  test("mints short-lived signed op urls with all params", async () => {
+    process.env.FILES_BASE = BASE;
+    process.env.FILES_SIGNING_SECRET = SECRET;
+    try {
+      const before = Math.floor(Date.now() / 1000);
+      const rawUrl = await buildSignedWorkerOpUrl({
+        op: "inspect",
+        key: OP_KEY,
+        params: {
+          mode: "zip",
+          mb: String(25 * 1024 * 1024),
+          rtf: "",
+          fmt: "word",
+        },
+      });
+      const after = Math.floor(Date.now() / 1000);
+      const url = new URL(rawUrl);
+
+      expect(url.origin + url.pathname).toBe(`${BASE}/${OP_KEY}`);
+      expect(url.searchParams.get("op")).toBe("inspect");
+      expect(url.searchParams.get("mode")).toBe("zip");
+      expect(url.searchParams.get("fmt")).toBe("word");
+      // Empty-string slots may be omitted from the URL but stay signed.
+      expect(url.searchParams.get("rtf")).toBeNull();
+
+      const exp = Number.parseInt(url.searchParams.get("exp") ?? "", 10);
+      expect(exp).toBeGreaterThan(before);
+      expect(exp).toBeLessThanOrEqual(after + 10 * 60);
+
+      expect(url.searchParams.get("sig")).toBe(
+        hmacHex(
+          buildSignedWorkerOpPayload({
+            op: "inspect",
+            key: OP_KEY,
+            fields: ["zip", String(25 * 1024 * 1024), "", "word"],
+            exp: `${exp}`,
+          })
+        )
+      );
+    } finally {
+      delete process.env.FILES_BASE;
+      delete process.env.FILES_SIGNING_SECRET;
+    }
   });
 });

--- a/packages/convex/export/runExport.ts
+++ b/packages/convex/export/runExport.ts
@@ -21,13 +21,31 @@ import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { type ActionCtx, internalAction } from "../_generated/server";
 import { TELEMETRY_OPERATIONS } from "../shared/telemetry";
+import {
+  buildSignedWorkerOpUrl,
+  callFilesWorkerJson,
+  type FilesWorkerBuildExportResult,
+  isFilesWorkerConfigured,
+} from "../storage/filesWorkerClient";
+import { buildR2ObjectKey, storeObject } from "../storage/r2";
 import { withBackendSpan } from "../telemetry/sentry";
 import {
   type ArchiveCardInput,
   buildExportArchive,
   type FileReader,
 } from "./archiveBuilder";
-import { computeExpiry } from "./serialize";
+import {
+  CARDS_ENTRY_NAME,
+  EXPORT_FAILURE_CLASS,
+  MANIFEST_ENTRY_NAME,
+  MAX_EXPORT_BYTES,
+} from "./constants";
+import {
+  buildFilePath,
+  buildManifest,
+  computeExpiry,
+  serializeCard,
+} from "./serialize";
 
 const internalAny = internal as Record<string, any>;
 
@@ -114,6 +132,193 @@ function buildArtifactKey(userId: string, jobId: string): string {
   return ["users", hashUserId, "exports", `${jobId}-${stamp}.zip`].join("/");
 }
 
+const EXPORT_MANIFEST_VERSION = 1;
+
+/**
+ * Worker-backed export fast path.
+ *
+ * Serializes cards and entry paths exactly like the legacy Node builder, but
+ * hands the worker a small manifest (inline JSON entries + storage keys); the
+ * worker streams object bytes straight through client-zip into a multipart
+ * R2 upload without the bytes ever transiting this action.
+ *
+ * When files turn out to be missing, the worker reports their archive paths
+ * and cards.json is rebuilt with those cards' `file` entries dropped, then
+ * the op runs once more — matching legacy omission semantics.
+ *
+ * Returns null whenever the caller should fall back to the legacy path
+ * (worker unconfigured, permanent rejection, or any unexpected error).
+ */
+async function runExportArchiveViaFilesWorker(
+  ctx: ActionCtx,
+  args: {
+    userId: string;
+    jobId: string;
+    inputs: ArchiveCardInput[];
+    createdAtMs: number;
+    expiresAtMs: number;
+    s3Client: S3Client;
+    bucket: string;
+  }
+): Promise<{
+  ok: boolean;
+  artifactKey: string;
+  artifactBytes: number;
+  cardCount: number;
+  filesIncluded: number;
+  filesOmitted: number;
+} | null> {
+  try {
+    if (!isFilesWorkerConfigured()) {
+      return null;
+    }
+
+    const { userId, jobId, inputs, createdAtMs, expiresAtMs } = args;
+    const artifactKey = buildArtifactKey(userId, jobId);
+    const downloadName = `teak-export-${new Date().toISOString().slice(0, 10)}.zip`;
+
+    // Path of each file entry → card id, so omissions can be attributed.
+    const cardIdByPath = new Map<string, string>();
+    const omittedCardIds = new Set<string>();
+    for (const input of inputs) {
+      if (!input.fileKey) {
+        continue;
+      }
+      cardIdByPath.set(
+        buildFilePath(input.card._id, input.card.fileMetadata?.fileName),
+        input.card._id
+      );
+    }
+
+    const buildManifestObject = async (): Promise<string> => {
+      const fileEntries = inputs
+        .filter((input) => input.fileKey)
+        .map((input) => ({
+          path: buildFilePath(
+            input.card._id,
+            input.card.fileMetadata?.fileName
+          ),
+          storageKey: input.fileKey as string,
+        }));
+      const serializedCards = inputs.map((input) => {
+        const included =
+          Boolean(input.fileKey) && !omittedCardIds.has(input.card._id);
+        return serializeCard(input.card, { includeFile: included });
+      });
+      const filesIncluded = serializedCards.filter(
+        (card) => card.file !== undefined
+      ).length;
+      const manifestJson = JSON.stringify({
+        v: EXPORT_MANIFEST_VERSION,
+        maxBytes: MAX_EXPORT_BYTES,
+        entries: [
+          {
+            path: MANIFEST_ENTRY_NAME,
+            contentBase64: Buffer.from(
+              JSON.stringify(
+                buildManifest({
+                  createdAtMs,
+                  expiresAtMs,
+                  cardCount: serializedCards.length,
+                  filesIncluded,
+                  filesOmitted:
+                    inputs.filter((input) => input.fileKey).length -
+                    filesIncluded,
+                }),
+                null,
+                2
+              ),
+              "utf8"
+            ).toString("base64"),
+          },
+          {
+            path: CARDS_ENTRY_NAME,
+            contentBase64: Buffer.from(
+              JSON.stringify({ cards: serializedCards }, null, 2),
+              "utf8"
+            ).toString("base64"),
+          },
+          ...fileEntries,
+        ],
+      });
+
+      const manifestKey = buildR2ObjectKey({
+        userId,
+        role: "export-manifest",
+      });
+      await storeObject(ctx, new Blob([manifestJson]), {
+        key: manifestKey,
+        type: "application/json",
+      });
+      return manifestKey;
+    };
+
+    const deleteManifest = async (key: string): Promise<void> => {
+      try {
+        await args.s3Client.send(
+          new DeleteObjectCommand({ Bucket: args.bucket, Key: key })
+        );
+      } catch {
+        // Manifest cleanup is best-effort; the object is tiny and harmless.
+      }
+    };
+
+    let artifactBytes = 0;
+    let filesIncluded = 0;
+    let filesOmitted = 0;
+
+    // Two attempts maximum: the second only when files were omitted and
+    // cards.json must be corrected.
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const manifestKey = await buildManifestObject();
+      let url: string;
+      try {
+        url = await buildSignedWorkerOpUrl({
+          op: "build-export",
+          key: manifestKey,
+          params: { artifact: artifactKey, name: downloadName },
+        });
+      } catch {
+        await deleteManifest(manifestKey);
+        return null;
+      }
+      const outcome =
+        await callFilesWorkerJson<FilesWorkerBuildExportResult>(url);
+      await deleteManifest(manifestKey);
+
+      if (outcome.kind === "fallback") {
+        return null;
+      }
+
+      artifactBytes = outcome.data.artifactBytes;
+      filesIncluded = outcome.data.filesIncluded;
+      filesOmitted = outcome.data.filesOmitted;
+
+      if (outcome.data.omittedPaths.length === 0 || attempt === 1) {
+        break;
+      }
+      for (const path of outcome.data.omittedPaths) {
+        const cardId = cardIdByPath.get(path);
+        if (cardId) {
+          omittedCardIds.add(cardId);
+        }
+      }
+    }
+
+    return {
+      ok: true,
+      artifactKey,
+      artifactBytes,
+      cardCount: inputs.length,
+      filesIncluded,
+      filesOmitted,
+    };
+  } catch {
+    // Any unexpected failure falls back to the proven Node path.
+    return null;
+  }
+}
+
 export const runExportArchive = internalAction({
   args: { jobId: v.id("exportJobs"), userId: v.string() },
   returns: v.object({
@@ -169,6 +374,31 @@ export const runExportArchive = internalAction({
 
       const createdAtMs = Date.now();
       const expiresAtMs = computeExpiry(createdAtMs);
+
+      // Preferred path: build the archive on the files worker over the R2
+      // binding. Falls back to the legacy Node builder below whenever the
+      // worker is unconfigured or reports a permanent condition.
+      if (isFilesWorkerConfigured()) {
+        const workerResult = await runExportArchiveViaFilesWorker(ctx, {
+          jobId,
+          inputs,
+          userId,
+          createdAtMs,
+          expiresAtMs,
+          s3Client: client,
+          bucket: config.bucket,
+        });
+        if (workerResult) {
+          const canceledAfterWorker = await ctx.runQuery(
+            internalAny.dataExport.isCancelRequested,
+            { jobId }
+          );
+          if (canceledAfterWorker) {
+            return { ok: false, failureClass: EXPORT_FAILURE_CLASS.CANCELED };
+          }
+          return workerResult;
+        }
+      }
 
       let result: Awaited<ReturnType<typeof buildExportArchive>>;
       try {

--- a/packages/convex/storage/filesWorkerClient.ts
+++ b/packages/convex/storage/filesWorkerClient.ts
@@ -1,0 +1,129 @@
+/**
+ * Client for internal ops on the files.teakvault.com worker (image processing,
+ * export building, bounded inspection).
+ *
+ * Signing mirrors apps/files-worker/src/lib.ts (`buildOpSigningPayload`) and
+ * the op field lists in apps/files-worker/src/index.ts — keep all three in
+ * lockstep. The fixed test vectors in __tests__/storage/r2.test.ts and
+ * apps/files-worker/src/lib.test.ts prove both runtimes produce identical
+ * HMAC output.
+ */
+
+import { hmacSha256Hex } from "./r2";
+
+export type FilesWorkerOp = "process-image" | "build-export" | "inspect";
+
+/** Signed extra-field order per op; empty-string slots are allowed. */
+const OP_PARAM_ORDER: Record<FilesWorkerOp, string[]> = {
+  "process-image": ["dest"],
+  "build-export": ["artifact", "name"],
+  inspect: ["mode", "mb", "rtf", "fmt"],
+};
+
+// Op URLs are minted per action invocation; a short TTL bounds the replay
+// window (the worker additionally rejects exps further than 15 min out).
+export const FILES_OP_TTL_SECONDS = 10 * 60;
+
+export const isFilesWorkerConfigured = (): boolean =>
+  Boolean(process.env.FILES_BASE && process.env.FILES_SIGNING_SECRET);
+
+export const buildSignedWorkerOpPayload = ({
+  op,
+  key,
+  fields,
+  exp,
+}: {
+  op: string;
+  key: string;
+  fields: string[];
+  exp: string;
+}): string => ["op", op, key, ...fields, exp].join("\n");
+
+/**
+ * Mint a signed op URL against the files worker. Throws when the worker is
+ * not configured — gate calls behind isFilesWorkerConfigured().
+ */
+export const buildSignedWorkerOpUrl = async (
+  spec: {
+    op: FilesWorkerOp;
+    /** Object key used as the request path (source key / manifest key). */
+    key: string;
+    params?: Record<string, string>;
+  },
+  nowSeconds = Math.floor(Date.now() / 1000)
+): Promise<string> => {
+  const base = process.env.FILES_BASE;
+  const secret = process.env.FILES_SIGNING_SECRET;
+  if (!(base && secret)) {
+    throw new Error("files_worker_not_configured");
+  }
+  const order = OP_PARAM_ORDER[spec.op];
+  const fields = order.map((name) => spec.params?.[name] ?? "");
+  const exp = String(nowSeconds + FILES_OP_TTL_SECONDS);
+  const sig = await hmacSha256Hex(
+    secret,
+    buildSignedWorkerOpPayload({ op: spec.op, key: spec.key, fields, exp })
+  );
+  const url = new URL(`${base.replace(/\/+$/, "")}/${spec.key}`);
+  url.searchParams.set("op", spec.op);
+  order.forEach((name, index) => {
+    if (fields[index]) {
+      url.searchParams.set(name, fields[index] as string);
+    }
+  });
+  url.searchParams.set("exp", exp);
+  url.searchParams.set("sig", sig);
+  return url.toString();
+};
+
+/**
+ * - ok: the op succeeded and returned JSON
+ * - fallback: a permanent client-side condition (missing source, oversized
+ *   input, malformed input) — caller should use the legacy action path
+ *
+ * Network and 5xx responses throw so workflow retries apply.
+ */
+export type FilesWorkerOutcome<T> =
+  | { kind: "ok"; data: T }
+  | { kind: "fallback" };
+
+export const callFilesWorkerJson = async <T>(
+  url: string
+): Promise<FilesWorkerOutcome<T>> => {
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch (error) {
+    throw new Error(
+      `files_worker_network_error:${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
+    if (response.status >= 500 || response.status === 429) {
+      throw new Error(`files_worker_server_error:${response.status}`);
+    }
+    return { kind: "fallback" };
+  }
+  return { kind: "ok", data: (await response.json()) as T };
+};
+
+export interface FilesWorkerProcessImageResult {
+  height: number;
+  palette: string[];
+  thumbnailGenerated: boolean;
+  thumbnailKey: string | null;
+  width: number;
+}
+
+export interface FilesWorkerBuildExportResult {
+  artifactBytes: number;
+  filesIncluded: number;
+  filesOmitted: number;
+  omittedPaths: string[];
+}
+
+export interface FilesWorkerInspectResult {
+  facts?: Record<string, number>;
+  text?: string;
+}

--- a/packages/convex/storage/r2.ts
+++ b/packages/convex/storage/r2.ts
@@ -166,7 +166,10 @@ export const getR2Url = async (
   );
   presignedUrlMemo.set(memoKey, {
     url,
-    refreshAt: nowSeconds + SIGNED_URL_EXPIRES_IN_SECONDS - PRESIGN_REFRESH_MARGIN_SECONDS,
+    refreshAt:
+      nowSeconds +
+      SIGNED_URL_EXPIRES_IN_SECONDS -
+      PRESIGN_REFRESH_MARGIN_SECONDS,
   });
   return url;
 };
@@ -175,6 +178,25 @@ const hexEncode = (buffer: ArrayBuffer): string =>
   Array.from(new Uint8Array(buffer), (byte) =>
     byte.toString(16).padStart(2, "0")
   ).join("");
+
+// Must stay in lockstep with apps/files-worker/src/lib.ts — the shared test
+// vectors prove both runtimes produce identical HMAC output.
+export const hmacSha256Hex = async (
+  secret: string,
+  message: string
+): Promise<string> => {
+  const encoder = new TextEncoder();
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  return hexEncode(
+    await crypto.subtle.sign("HMAC", cryptoKey, encoder.encode(message))
+  );
+};
 
 // Must stay in lockstep with apps/files-worker/src/lib.ts — the shared test
 // vector proves both runtimes produce identical HMAC output.
@@ -197,21 +219,10 @@ export const buildSignedWorkerFileUrl = async (
   response: DownloadResponsePolicy = {},
   expSeconds = Math.floor(Date.now() / 1000) + SIGNED_URL_EXPIRES_IN_SECONDS
 ): Promise<string> => {
-  const encoder = new TextEncoder();
-  const cryptoKey = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"]
-  );
   const exp = String(expSeconds);
-  const signature = hexEncode(
-    await crypto.subtle.sign(
-      "HMAC",
-      cryptoKey,
-      encoder.encode(buildSignedFilePayload({ key, exp, ...response }))
-    )
+  const signature = await hmacSha256Hex(
+    secret,
+    buildSignedFilePayload({ key, exp, ...response })
   );
   const params = new URLSearchParams({ exp, sig: signature });
   if (response.contentType) {

--- a/packages/convex/workflows/fileProcessing.ts
+++ b/packages/convex/workflows/fileProcessing.ts
@@ -2,6 +2,13 @@
 
 import yauzl from "yauzl";
 import type { FileFormat, FilePreviewFacts } from "../shared/fileFormats";
+import {
+  buildSignedWorkerOpUrl,
+  callFilesWorkerJson,
+  type FilesWorkerInspectResult,
+  isFilesWorkerConfigured,
+} from "../storage/filesWorkerClient";
+import { resolveObjectUrl } from "../storage/r2";
 
 const MAX_AI_TEXT_BYTES = 512 * 1024;
 const MAX_ARCHIVE_ENTRIES = 2000;
@@ -258,4 +265,95 @@ export const extractFileTextForAi = async (
   return card.fileMetadata?.kind === "text" && format.id === "rtf"
     ? extractRtfText(decoded)
     : decoded.trim();
+};
+
+/* ------------------------------------------------------------------ *
+ * Files-worker backed variants.
+ *
+ * The worker reads the object over its R2 binding and returns facts/text
+ * as JSON, so bounded inspection no longer pulls up to 25 MB through an
+ * action's memory. Both wrappers fall back to the URL-based legacy
+ * implementations above when the worker is unconfigured or rejects the
+ * request permanently (missing source, malformed archive).
+ * ------------------------------------------------------------------ */
+
+export const buildFilePreviewFactsForKey = async (
+  key: string,
+  format: FileFormat
+): Promise<FilePreviewFacts | null> => {
+  if (isFilesWorkerConfigured()) {
+    let mode: "zip" | "css" | null = null;
+    if (["zip", "word", "powerpoint"].includes(format.id)) {
+      mode = "zip";
+    } else if (format.kind === "tokens" && format.language === "css") {
+      mode = "css";
+    }
+    if (mode) {
+      const maxBytes =
+        mode === "zip" ? MAX_ARCHIVE_DOWNLOAD_BYTES : MAX_SOURCE_DOWNLOAD_BYTES;
+      try {
+        const url = await buildSignedWorkerOpUrl({
+          op: "inspect",
+          key,
+          params: { mode, mb: String(maxBytes), rtf: "", fmt: format.id },
+        });
+        const outcome =
+          await callFilesWorkerJson<FilesWorkerInspectResult>(url);
+        if (outcome.kind === "ok") {
+          return (outcome.data.facts as FilePreviewFacts | undefined) ?? null;
+        }
+      } catch {
+        // Transient worker failure → legacy path below keeps this best-effort.
+      }
+    } else {
+      return null;
+    }
+  }
+  const url = await resolveObjectUrl(key);
+  return url ? buildFilePreviewFacts(url, format) : null;
+};
+
+export const extractFileTextForAiForKey = async (
+  key: string,
+  format: FileFormat,
+  card: FileCardInput
+): Promise<string> => {
+  if (isFilesWorkerConfigured()) {
+    const isArchive = ["word", "powerpoint"].includes(format.id);
+    const isTextKind = ["markdown", "source", "text", "tokens"].includes(
+      format.kind
+    );
+    if (isArchive || isTextKind) {
+      try {
+        const url = await buildSignedWorkerOpUrl({
+          op: "inspect",
+          key,
+          params: {
+            mode: isArchive ? "zip" : "text",
+            mb: String(
+              isArchive ? MAX_ARCHIVE_DOWNLOAD_BYTES : MAX_SOURCE_DOWNLOAD_BYTES
+            ),
+            rtf:
+              !isArchive &&
+              card.fileMetadata?.kind === "text" &&
+              format.id === "rtf"
+                ? "1"
+                : "",
+            fmt: format.id,
+          },
+        });
+        const outcome =
+          await callFilesWorkerJson<FilesWorkerInspectResult>(url);
+        if (outcome.kind === "ok") {
+          return outcome.data.text ?? "";
+        }
+      } catch {
+        // Transient worker failure → legacy path below.
+      }
+    } else {
+      return "";
+    }
+  }
+  const url = await resolveObjectUrl(key);
+  return url ? extractFileTextForAi(url, format, card) : "";
 };

--- a/packages/convex/workflows/steps/metadata.ts
+++ b/packages/convex/workflows/steps/metadata.ts
@@ -26,7 +26,7 @@ import {
   isAiProviderCapacityError,
 } from "../aiMetadata/generators";
 import { generateTranscript } from "../aiMetadata/transcript";
-import { extractFileTextForAi } from "../fileProcessing";
+import { extractFileTextForAiForKey } from "../fileProcessing";
 import {
   hasKnownTinyImageDimensions,
   hasMinimumImageAnalysisDimensions,
@@ -311,10 +311,9 @@ export async function generateHandler(
             fileName: card.fileMetadata.fileName,
             mimeType: card.fileMetadata.mimeType,
           });
-          const fileUrl = await resolveObjectUrl(card.fileKey);
-          if (format && fileUrl) {
-            const extractedText = await extractFileTextForAi(
-              fileUrl,
+          if (format) {
+            const extractedText = await extractFileTextForAiForKey(
+              card.fileKey,
               format,
               card
             );

--- a/packages/convex/workflows/steps/palette.ts
+++ b/packages/convex/workflows/steps/palette.ts
@@ -5,6 +5,12 @@ import { v } from "convex/values";
 import { internal } from "../../_generated/api";
 import { internalAction } from "../../_generated/server";
 import { TELEMETRY_OPERATIONS } from "../../shared/telemetry";
+import {
+  buildSignedWorkerOpUrl,
+  callFilesWorkerJson,
+  type FilesWorkerProcessImageResult,
+  isFilesWorkerConfigured,
+} from "../../storage/filesWorkerClient";
 import { resolveObjectUrl } from "../../storage/r2";
 import { withBackendSpan } from "../../telemetry/sentry";
 import { hasKnownTinyImageDimensions } from "../imageAnalysis";
@@ -119,6 +125,39 @@ export const extractPaletteFromImage = internalAction({
 
         if (!fileKeyForPalette) {
           return;
+        }
+
+        // Fast path: the worker decodes over its R2 binding and returns
+        // colors without the bytes ever transiting this action.
+        if (isFilesWorkerConfigured()) {
+          try {
+            const url = await buildSignedWorkerOpUrl({
+              op: "process-image",
+              key: fileKeyForPalette,
+            });
+            const outcome =
+              await callFilesWorkerJson<FilesWorkerProcessImageResult>(url);
+            if (outcome.kind === "ok") {
+              const { width: w, height: h, palette } = outcome.data;
+              if (
+                Array.isArray(palette) &&
+                palette.length > 0 &&
+                !hasKnownTinyImageDimensions({ width: w, height: h })
+              ) {
+                const colors = palette.map((hex) => ({ hex }));
+                await ctx.runMutation(
+                  internal.workflows.aiMetadata.mutations.updateCardColors,
+                  { cardId, colors }
+                );
+                return colors as any;
+              }
+              return;
+            }
+            // fallback → run the legacy in-action path below.
+          } catch {
+            // Network/server errors → legacy path keeps palette extraction
+            // best-effort instead of failing the workflow step.
+          }
         }
 
         const fileUrl = await resolveObjectUrl(fileKeyForPalette);

--- a/packages/convex/workflows/steps/renderables/generateFilePreview.ts
+++ b/packages/convex/workflows/steps/renderables/generateFilePreview.ts
@@ -4,8 +4,7 @@ import { v } from "convex/values";
 import { internal } from "../../../_generated/api";
 import { internalAction } from "../../../_generated/server";
 import { inferFileFormat } from "../../../shared/fileFormats";
-import { resolveObjectUrl } from "../../../storage/r2";
-import { buildFilePreviewFacts } from "../../fileProcessing";
+import { buildFilePreviewFactsForKey } from "../../fileProcessing";
 
 export const generateFilePreview = internalAction({
   args: { cardId: v.id("cards") },
@@ -29,13 +28,8 @@ export const generateFilePreview = internalAction({
       return { generated: false, success: true };
     }
 
-    const fileUrl = await resolveObjectUrl(card.fileKey);
-    if (!fileUrl) {
-      return { generated: false, success: true };
-    }
-
     try {
-      const preview = await buildFilePreviewFacts(fileUrl, format);
+      const preview = await buildFilePreviewFactsForKey(card.fileKey, format);
       if (!preview) {
         return { generated: false, success: true };
       }

--- a/packages/convex/workflows/steps/renderables/generateThumbnail.ts
+++ b/packages/convex/workflows/steps/renderables/generateThumbnail.ts
@@ -11,12 +11,19 @@ import {
 import { v } from "convex/values";
 import { orientation } from "exifr";
 import { internal } from "../../../_generated/api";
-import { internalAction } from "../../../_generated/server";
+import { type ActionCtx, internalAction } from "../../../_generated/server";
+import {
+  buildSignedWorkerOpUrl,
+  callFilesWorkerJson,
+  type FilesWorkerProcessImageResult,
+  isFilesWorkerConfigured,
+} from "../../../storage/filesWorkerClient";
 import {
   buildR2ObjectKey,
   resolveObjectUrl,
   storeObject,
 } from "../../../storage/r2";
+import { hasKnownTinyImageDimensions } from "../../imageAnalysis";
 
 // Maximum thumbnail dimensions
 const THUMBNAIL_MAX_WIDTH = 500;
@@ -138,6 +145,80 @@ function applyExifOrientation(
 }
 
 /**
+ * Fast path: delegate decode/resize/encode to the files worker, which reads
+ * and writes the bucket directly over the R2 binding. Returns null when the
+ * worker signalled a permanent fallback condition (missing source, oversized
+ * input) or could not be reached for minting — callers then run the legacy
+ * action path below.
+ */
+export const generateViaFilesWorker = async (
+  ctx: ActionCtx,
+  cardId: string,
+  card: { userId: string; fileKey: string }
+): Promise<{
+  success: boolean;
+  generated: boolean;
+  thumbnailKey?: string;
+} | null> => {
+  if (!isFilesWorkerConfigured()) {
+    return null;
+  }
+  const destKey = buildR2ObjectKey({
+    userId: card.userId,
+    cardId,
+    role: "thumbnail",
+  });
+  let url: string;
+  try {
+    url = await buildSignedWorkerOpUrl({
+      op: "process-image",
+      key: card.fileKey,
+      params: { dest: destKey },
+    });
+  } catch {
+    return null;
+  }
+  const outcome = await callFilesWorkerJson<FilesWorkerProcessImageResult>(url);
+  if (outcome.kind === "fallback") {
+    return null;
+  }
+  const { width, height, thumbnailGenerated, thumbnailKey, palette } =
+    outcome.data;
+
+  if (thumbnailGenerated && thumbnailKey) {
+    await ctx.runMutation(
+      internal.workflows.steps.renderables.mutations.updateCardThumbnail,
+      {
+        cardId,
+        thumbnailKey,
+        originalWidth: width,
+        originalHeight: height,
+      }
+    );
+  } else {
+    await ctx.runMutation(
+      internal.workflows.steps.renderables.mutations.updateCardFileMetadata,
+      { cardId, width, height }
+    );
+  }
+
+  // The worker decodes once and returns both renderable and palette; store
+  // colors here so the palette step's early-return kicks in downstream.
+  if (palette.length > 0 && !hasKnownTinyImageDimensions({ width, height })) {
+    await ctx.runMutation(
+      internal.workflows.aiMetadata.mutations.updateCardColors,
+      { cardId, colors: palette.map((hex) => ({ hex })) }
+    );
+  }
+
+  return {
+    success: true,
+    generated: thumbnailGenerated,
+    thumbnailKey: thumbnailKey ?? undefined,
+  };
+};
+
+/**
  * Workflow-native thumbnail generation action.
  * Mirrors the previous tasks-based implementation so the renderables step owns its orchestration.
  */
@@ -181,6 +262,15 @@ export const generateThumbnail = internalAction({
           generated: false,
           thumbnailKey: card.thumbnailKey,
         };
+      }
+
+      // Preferred path: process on the files worker over the R2 binding.
+      const workerResult = await generateViaFilesWorker(ctx, args.cardId, {
+        userId: card.userId,
+        fileKey: card.fileKey,
+      });
+      if (workerResult) {
+        return workerResult;
       }
 
       const originalImageUrl = await resolveObjectUrl(card.fileKey);

--- a/packages/ui/src/components/cards/types.ts
+++ b/packages/ui/src/components/cards/types.ts
@@ -54,10 +54,10 @@ export interface CardWithUrls {
 
 export interface CardProps {
   card: CardWithUrls & Record<string, unknown>;
-  isSelected?: boolean;
-  isSelectionMode?: boolean;
   /** Above-the-fold card: its media loads eagerly with high priority. */
   isPriority?: boolean;
+  isSelected?: boolean;
+  isSelectionMode?: boolean;
   isTrashMode?: boolean;
   onAddTags?: (cardId: string) => void;
   onClick?: (card: CardWithUrls & Record<string, unknown>) => void;

--- a/packages/ui/src/components/grids/MasonryGrid.tsx
+++ b/packages/ui/src/components/grids/MasonryGrid.tsx
@@ -339,9 +339,9 @@ export function MasonryGrid({
       return (
         <Card
           card={card}
+          isPriority={item.isPriority === true}
           isSelected={selectedCardIds.has(card._id)}
           isSelectionMode={isSelectionMode}
-          isPriority={item.isPriority === true}
           isTrashMode={showTrashOnly}
           onAddTags={onAddTags}
           onClick={handleCardClick}


### PR DESCRIPTION
## Summary

Moves all byte-touching file workloads out of Convex actions into `apps/files-worker`, so objects stream between the worker's R2 binding and clients instead of round-tripping through action memory.

### Signed internal ops (foundation)
- New `op` param (`process-image` / `build-export` / `inspect`) signed with the existing `FILES_SIGNING_SECRET` using a distinct payload shape — download URLs are untouched and fully backwards compatible.
- Op URLs are short-lived (10 min mint TTL; worker rejects > 15 min remaining) and mirrored by fixed cross-runtime HMAC test vectors in both repos.
- Every Convex call site keeps its legacy in-action fallback for local dev (no `FILES_BASE`/`FILES_SIGNING_SECRET`) and permanent rejections.

### Image thumbnails + palette
- `process-image`: worker decodes the original over the R2 binding with `@cf-wasm/photon` running natively, applies EXIF orientation, writes a bounded WebP thumbnail back, and returns dimensions + dominant-color palette **in one pass** — replacing two separate full-image downloads through action memory.
- Idempotent across workflow retries; inputs > 30 MB return 413 and fall back to the legacy action path (worker memory ceiling).

### Export ZIP
- `build-export`: Convex serializes cards/entries into a small manifest object in R2; the worker streams entries through client-zip into a multipart upload with constant memory instead of pulling up to 5 GB through a Node action.
- Missing files are retried once then omitted, reported by path, and cards.json is rebuilt via one corrected second pass — preserving legacy omission semantics. Artifact download/deletion flows are unchanged.

### Bounded inspection
- `inspect`: zip/docx/pptx entry stats + text extraction (central-directory walker + fflate), CSS color-variable counting, and RTF-aware AI text extraction now read only bounded prefixes from R2 instead of downloading up to 25 MB objects into actions.

## Test plan
- [x] Worker unit tests (28): op payload/verification vectors incl. cross-runtime digest, image resize/skip/palette fixtures, manifest→zip assembly + omission + cap-abort, zip/css/text inspection fixtures
- [x] Convex test suite green (only pre-existing env-dependent failures remain, identical on clean tree)
- [x] `bun run typecheck`, `bun run lint`, `ultracite check` clean repo-wide
- [x] Full affected build passes via pre-commit hook