### PR TITLE
fix(release): align files-worker package version to repo lockstep

### DIFF
--- a/apps/files-worker/package.json
+++ b/apps/files-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/files-worker",
-  "version": "0.1.0",
+  "version": "1.0.64",
   "private": true,
   "scripts": {
     "deploy": "wrangler deploy",

--- a/bun.lock
+++ b/bun.lock
@@ -100,7 +100,7 @@
     },
     "apps/files-worker": {
       "name": "@teak/files-worker",
-      "version": "0.1.0",
+      "version": "1.0.64",
       "dependencies": {
         "@cf-wasm/photon": "^0.4.0",
         "client-zip": "^2.4.5",


### PR DESCRIPTION
## Summary

`apps/files-worker` was introduced at version `0.1.0`, but the release pipeline requires every package manifest to match the repo-wide lockstep version (`1.0.64`). This has failed the **Version Tag** workflow on every `main` push since the worker landed (Aug 22), silently blocking the release pipeline.

This PR aligns the worker's manifest and lockfile to `1.0.64`.

## Impact

- `scripts/release-version.mjs lockstep 1.0.64` passes.
- Root version is unchanged → the Version Tag workflow detects no version change and **does not create a tag or trigger any releases**; it just returns to green.

## Test plan
- [x] `node scripts/release-version.mjs lockstep 1.0.64` passes locally
- [x] No functional code changes