### PR TITLE
feat(files-worker): edge image/doc pipeline, ranged zip inspection, faster downloads

### DIFF
--- a/apps/files-worker/wrangler.jsonc
+++ b/apps/files-worker/wrangler.jsonc
@@ -6,7 +6,11 @@
   "rules": [
     {
       "type": "Data",
-      "globs": ["**/*.wasm"],
+      "globs": [
+        "**/heic_dec.wasm",
+        "**/resvg-wasm/index_bg.wasm",
+        "**/webp_enc_simd.wasm"
+      ],
       "fallthrough": true
     }
   ],


### PR DESCRIPTION
Worker:
- process-image now auto-detects HEIC (libheif) and SVG (resvg) inputs and
  decodes them at the edge, alongside rasters via photon
- thumbnails are encoded with libwebp lossy WebP (photon's WebP output was
  lossless and ignored the quality tiers), cutting derived sizes sharply
- single-pass preview derivative (~1600px) for oversized originals, thumbhash
  placeholder, and EXIF facts (capture time, camera, exposure, GPS)
- new process-pdf op renders PDF first pages via pdfium into thumbnails
- inspect gains a pdf mode (page count + bounded text) and zip mode now walks
  central directories via R2 ranged reads instead of buffering up to 64MB
- download path: HEAD support, If-None-Match -> 304, explicit Content-Length,
  nosniff, permissive CORS (URLs are bearer tokens), OPTIONS preflight
- unauthenticated /__health endpoint for uptime monitors
- HMAC CryptoKeys memoized per secret; WASM codecs bundled via Data rule

Convex:
- shared workerPipeline helpers used by image/HEIC/SVG/PDF renderable steps
  with legacy heic-convert and Kernel fallbacks preserved
- cards gain previewKey, placeholderHash, fileMetadata.exif, pageCount facts
- PDF text extraction wired through inspect for AI metadata

Tests: fixtures for HEIC/PDF/SVG paths, handler-level HTTP tests, ranged-read
zip tests. Bundle: 4.1MB gzipped (10MB limit).
