### PR TITLE
fix(files-worker): use build-time wasm modules; harden thumbnail fallback

### DIFF
--- a/apps/files-worker/src/wasm-modules.d.ts
+++ b/apps/files-worker/src/wasm-modules.d.ts
@@ -1,9 +1,10 @@
 // Ambient declarations for .wasm imports. Resolution differs per runtime:
-//  - Wrangler (deployed worker): the Data rule in wrangler.jsonc hands each
-//    import through as an ArrayBuffer of the file contents.
+//  - Wrangler (deployed worker): statically imported .wasm files are compiled
+//    at build time and handed over as ready-to-use WebAssembly.Modules
+//    (workerd forbids runtime code generation).
 //  - Bun (unit tests): the import resolves to the file's absolute path, which
-//    src/wasm.ts reads from disk. That branch never runs in production.
+//    src/wasm.ts reads and compiles. That branch never runs in production.
 declare module "*.wasm" {
-  const contents: ArrayBuffer | string;
+  const contents: WebAssembly.Module | string;
   export default contents;
 }

--- a/apps/files-worker/src/wasm.ts
+++ b/apps/files-worker/src/wasm.ts
@@ -1,10 +1,11 @@
 // Edge codec loaders for the formats photon cannot handle natively (HEIC,
 // SVG) and the lossy WebP encoder used for all derived images.
 //
-// Every codec's WASM module is imported statically so Wrangler bundles it via
-// the Data rule in wrangler.jsonc; initialization happens lazily on first use
-// and is memoized per isolate. See wasm-modules.d.ts for how .wasm imports
-// resolve in each runtime.
+// Every codec's WASM module is imported statically. Wrangler precompiles
+// .wasm imports into WebAssembly.Modules at build time (workerd forbids
+// runtime code generation), while Bun resolves them to file paths for tests.
+// Initialization happens lazily on first use and is memoized per isolate.
+// See wasm-modules.d.ts for how .wasm imports resolve in each runtime.
 
 import heicDecWasm from "@discourse/heic/codec/dec/heic_dec.wasm";
 import webpEncWasm from "@jsquash/webp/codec/enc/webp_enc_simd.wasm";
@@ -17,18 +18,23 @@ const wasmCompile = (
   }
 ).compile;
 
-type WasmImport = ArrayBuffer | string;
+type WasmImport = WebAssembly.Module | string;
 
-const wasmBytesCache = new Map<WasmImport, Promise<ArrayBuffer>>();
+const wasmModuleCache = new Map<WasmImport, Promise<WebAssembly.Module>>();
 
-const resolveWasmBytes = (mod: WasmImport): Promise<ArrayBuffer> => {
-  const cached = wasmBytesCache.get(mod);
+/**
+ * Wrangler hands statically imported .wasm through as ready-to-use
+ * WebAssembly.Modules; Bun (tests) resolves them to file paths, which are
+ * read and compiled there — runtime codegen is fine under Bun, just not on
+ * the Workers runtime.
+ */
+const resolveWasmModule = (mod: WasmImport): Promise<WebAssembly.Module> => {
+  const cached = wasmModuleCache.get(mod);
   if (cached) {
     return cached;
   }
   const promise = (async () => {
     if (typeof mod === "string") {
-      // Bun resolves .wasm imports to a file path; read it from disk.
       const bunFile = (
         globalThis as {
           Bun?: {
@@ -41,11 +47,11 @@ const resolveWasmBytes = (mod: WasmImport): Promise<ArrayBuffer> => {
       if (!bunFile) {
         throw new Error("wasm_module_unresolvable");
       }
-      return await bunFile.file(mod).arrayBuffer();
+      return await wasmCompile(await bunFile.file(mod).arrayBuffer());
     }
     return mod;
   })();
-  wasmBytesCache.set(mod, promise);
+  wasmModuleCache.set(mod, promise);
   return promise;
 };
 
@@ -74,7 +80,7 @@ type JsquashEncoderFn = (
 
 const loadWebpEncoder = memoize(async (): Promise<JsquashEncoderFn> => {
   const encoder = await import("@jsquash/webp/encode.js");
-  await encoder.init(await wasmCompile(await resolveWasmBytes(webpEncWasm)));
+  await encoder.init(await resolveWasmModule(webpEncWasm));
   return encoder.default as unknown as JsquashEncoderFn;
 });
 
@@ -108,7 +114,7 @@ type JsquashDecoderFn = (
 
 const loadHeicDecoder = memoize(async (): Promise<JsquashDecoderFn> => {
   const decoder = await import("@discourse/heic/decode.js");
-  await decoder.init(await wasmCompile(await resolveWasmBytes(heicDecWasm)));
+  await decoder.init(await resolveWasmModule(heicDecWasm));
   return decoder.default as unknown as JsquashDecoderFn;
 });
 
@@ -133,7 +139,7 @@ const MAX_SVG_RENDER_EDGE = 2048;
 
 const ensureResvg = memoize(async () => {
   const resvg = await import("@resvg/resvg-wasm");
-  await resvg.initWasm(await resolveWasmBytes(resvgWasm));
+  await resvg.initWasm(await resolveWasmModule(resvgWasm));
 });
 
 export const renderSvgToPng = async (

--- a/apps/files-worker/wrangler.jsonc
+++ b/apps/files-worker/wrangler.jsonc
@@ -3,17 +3,6 @@
   "name": "teak-files-proxy",
   "main": "src/index.ts",
   "compatibility_date": "2026-08-01",
-  "rules": [
-    {
-      "type": "Data",
-      "globs": [
-        "**/heic_dec.wasm",
-        "**/resvg-wasm/index_bg.wasm",
-        "**/webp_enc_simd.wasm"
-      ],
-      "fallthrough": true
-    }
-  ],
   "routes": [
     {
       "pattern": "files.teakvault.com",

--- a/packages/convex/workflows/steps/renderables/generateThumbnail.ts
+++ b/packages/convex/workflows/steps/renderables/generateThumbnail.ts
@@ -185,16 +185,29 @@ export const generateThumbnail = internalAction({
       }
 
       // Preferred path: process on the files worker over the R2 binding.
-      const workerResult = await generateImageViaFilesWorker(ctx, args.cardId, {
-        userId: card.userId,
-        fileKey: card.fileKey,
-      });
-      if (workerResult) {
-        return {
-          success: true,
-          generated: workerResult.generated,
-          thumbnailKey: workerResult.thumbnailKey,
-        };
+      // Worker network/5xx errors fall through to the legacy in-action path
+      // below so an edge outage degrades instead of failing the card.
+      try {
+        const workerResult = await generateImageViaFilesWorker(
+          ctx,
+          args.cardId,
+          {
+            userId: card.userId,
+            fileKey: card.fileKey,
+          }
+        );
+        if (workerResult) {
+          return {
+            success: true,
+            generated: workerResult.generated,
+            thumbnailKey: workerResult.thumbnailKey,
+          };
+        }
+      } catch (workerError) {
+        console.error(
+          `[renderables] files worker path failed for card ${args.cardId}, falling back to in-action processing:`,
+          workerError
+        );
       }
 
       const originalImageUrl = await resolveObjectUrl(card.fileKey);


### PR DESCRIPTION
workerd forbids runtime WebAssembly code generation, so compiling the
Data-rule-imported codec bytes at request time threw
"WebAssembly.compile(): Wasm code generation disallowed by embedder" and
every process-image op returned 500 — no thumbnails, colors, or previews
for uploads while the worker was broken.

- drop the Data rule: statically imported .wasm files now arrive as
  precompiled WebAssembly.Modules (wrangler native handling) and are passed
  straight to the codec init() calls; the Bun/test path still reads paths
  and compiles there
- generateThumbnail now falls back to the legacy in-action path when the
  worker throws (network/5xx), not only on permanent fallback responses,
  so an edge outage degrades instead of failing the card

Verified in production: process-image returns Ok via wrangler tail, and
the three affected cards were reprocessed successfully.
