### PR TITLE
chore(files-worker): enable wrangler observability for queryable logs

### DIFF
--- a/apps/files-worker/wrangler.jsonc
+++ b/apps/files-worker/wrangler.jsonc
@@ -14,5 +14,9 @@
       "binding": "BUCKET",
       "bucket_name": "teak-files-prod"
     }
-  ]
+  ],
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
+  }
 }


### PR DESCRIPTION
## Summary

Follow-up #2 from the 2026-08-24 production incident (fix shipped in #329). During that incident the process-image op in `apps/files-worker` returned 500 on every request, and worker errors were only visible through a live `wrangler tail` session because Workers observability was not enabled.

This enables Workers observability for `apps/files-worker` so worker logs and error responses are queryable from the Cloudflare dashboard after the fact — future incidents won't require a live tail to diagnose.

```jsonc
"observability": {
  "enabled": true,
  "head_sampling_rate": 1
}
```

- Field names validated against `node_modules/wrangler/config-schema.json` (`observability.enabled`, `observability.head_sampling_rate`).
- `head_sampling_rate: 1` is fine at this traffic level.
- Verified with `bunx wrangler deploy --dry-run` from `apps/files-worker` (config validates cleanly).

## Scope

Small, focused config-only change — no other worker code touched (Sentry work is tracked separately to avoid overlapping edits).

Internal operational change only: no public changelog entry per repo rules.

## Test plan

- [x] `bunx wrangler deploy --dry-run` passes from `apps/files-worker`
- [x] Pre-commit hook (`turbo run typecheck lint build --affected`) green
- [ ] After merge + deploy, confirm logs appear under Workers → teak-files-proxy → Logs in the Cloudflare dashboard