### PR TITLE
feat(files-worker): report op failures to Sentry

### DIFF
--- a/apps/files-worker/README.md
+++ b/apps/files-worker/README.md
@@ -37,8 +37,8 @@ sides in lockstep):
 Convex keeps orchestration; every op has a legacy in-action fallback for
 local dev (no `FILES_BASE`/`FILES_SIGNING_SECRET`) and permanent rejections.
 
-WASM modules are bundled through the Data rule in `wrangler.jsonc`; loaders
-live in `src/wasm.ts`.
+WASM modules are statically imported and arrive as build-time compiled
+`WebAssembly.Module`s under wrangler (see `src/wasm.ts`).
 
 ## Commands
 
@@ -55,6 +55,14 @@ bun run deploy      # wrangler deploy (creates files.teakvault.com custom domain
 - `FILES_SIGNING_SECRET` — must match the `FILES_SIGNING_SECRET` env var on the
   Convex production deployment. Set with:
   `bunx wrangler secret put FILES_SIGNING_SECRET`
+- `SENTRY_DSN` — DSN for error reporting (`@sentry/cloudflare`, errors only).
+  Reporting stays disabled until this is set. Set with:
+  `bunx wrangler secret put SENTRY_DSN`
+
+Handled op failures (the 500 path) are reported explicitly with op/route,
+HTTP method + path, and card/role identifiers parsed from the object key
+(`src/sentry.ts`); anything that escapes the handler uncaught is captured
+automatically. `SENTRY_ENVIRONMENT` / `SENTRY_RELEASE` are optional vars.
 
 ## Rollback
 

--- a/apps/files-worker/package.json
+++ b/apps/files-worker/package.json
@@ -13,6 +13,7 @@
     "@discourse/heic": "^1.0.0",
     "@jsquash/webp": "^1.5.0",
     "@resvg/resvg-wasm": "^2.6.2",
+    "@sentry/cloudflare": "10.69.0",
     "client-zip": "^2.4.5",
     "exifr": "^7.1.3",
     "fflate": "^0.8.2",

--- a/apps/files-worker/src/index.ts
+++ b/apps/files-worker/src/index.ts
@@ -1,3 +1,4 @@
+import { withSentry } from "@sentry/cloudflare";
 import {
   buildExportIntoBucket,
   ExportManifestInvalid,
@@ -12,10 +13,16 @@ import {
   verifySignedFileRequest,
   verifySignedOpRequest,
 } from "./lib";
+import { reportFilesOpFailure, resolveSentryOptions } from "./sentry";
 
 export interface Env {
   BUCKET: R2Bucket;
   FILES_SIGNING_SECRET: string;
+  /** Wrangler secret; error reporting stays disabled until it is set. */
+  SENTRY_DSN?: string;
+  /** Optional overrides, normally left unset. */
+  SENTRY_ENVIRONMENT?: string;
+  SENTRY_RELEASE?: string;
 }
 
 const decodeObjectKey = (pathname: string): string => {
@@ -64,6 +71,7 @@ const corsPreflight = (): Response => {
 const handleOp = async (
   env: Env,
   url: URL,
+  httpMethod: string,
   key: string,
   op: string
 ): Promise<Response> => {
@@ -163,6 +171,13 @@ const handleOp = async (
       return json({ error: message }, 422);
     }
     console.error(`[files-worker] op ${op} failed`, error);
+    // Handled 500s never reach withSentry's automatic capture, so report them
+    // here; without this an op outage is invisible outside wrangler tail.
+    reportFilesOpFailure(op, error, {
+      httpMethod,
+      httpPath: url.pathname,
+      objectKey: key,
+    });
     return json({ error: "internal_error" }, 500);
   }
 };
@@ -247,7 +262,7 @@ const applyObjectHeaders = (
 const edgeCache: Cache | null =
   typeof caches === "undefined" ? null : caches.default;
 
-export default {
+const handler = {
   async fetch(request, env, ctx): Promise<Response> {
     const requestMethod = request.method.toUpperCase();
 
@@ -272,7 +287,7 @@ export default {
 
     const op = url.searchParams.get("op");
     if (op) {
-      return await handleOp(env, url, key, op);
+      return await handleOp(env, url, requestMethod, key, op);
     }
 
     const verification = await verifySignedFileRequest(
@@ -432,3 +447,11 @@ export default {
     return new Response(object.body, { status: 206, headers });
   },
 } satisfies ExportedHandler<Env>;
+
+export default withSentry<Env>(
+  // Secrets exist only on env at request time, so the SDK initializes per
+  // request; without SENTRY_DSN this resolves to undefined and Sentry stays
+  // disabled. See src/sentry.ts.
+  (env) => resolveSentryOptions(env),
+  handler
+);

--- a/apps/files-worker/src/sentry.test.ts
+++ b/apps/files-worker/src/sentry.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test";
+import worker, { type Env } from "./index";
+import { buildOpSigningPayload, hmacSha256Hex } from "./lib";
+import {
+  parseFileKeyIdentifiers,
+  reportFilesOpFailure,
+  resolveSentryOptions,
+} from "./sentry";
+
+const SECRET = "test-secret";
+
+// Mirrors OP_PARAM_ORDER in packages/convex/storage/filesWorkerClient.ts.
+const OP_FIELD_NAMES: Record<string, string[]> = {
+  "process-image": ["dest", "preview"],
+  "build-export": ["artifact", "name"],
+  inspect: ["mode", "mb", "rtf", "fmt"],
+};
+
+const signedOpUrl = async (
+  key: string,
+  op: string,
+  params: Record<string, string> = {}
+): Promise<string> => {
+  const exp = String(Math.floor(Date.now() / 1000) + 600);
+  const fields = (OP_FIELD_NAMES[op] ?? []).map((name) => params[name] ?? "");
+  const sig = await hmacSha256Hex(
+    SECRET,
+    buildOpSigningPayload({ op, key, fields, exp })
+  );
+  const url = new URL(`https://files.teakvault.com/${key}`);
+  url.searchParams.set("op", op);
+  url.searchParams.set("exp", exp);
+  url.searchParams.set("sig", sig);
+  for (const [name, value] of Object.entries(params)) {
+    if (value) {
+      url.searchParams.set(name, value);
+    }
+  }
+  return url.toString();
+};
+
+describe("resolveSentryOptions", () => {
+  test("stays disabled without a DSN (tests, local dev, secret unset)", () => {
+    expect(resolveSentryOptions({})).toBeUndefined();
+    expect(resolveSentryOptions({ SENTRY_DSN: "   " })).toBeUndefined();
+  });
+
+  test("resolves a trimmed DSN without extra fields", () => {
+    expect(
+      resolveSentryOptions({ SENTRY_DSN: " https://k@example.invalid/1 " })
+    ).toEqual({
+      dsn: "https://k@example.invalid/1",
+      sendDefaultPii: false,
+    });
+  });
+
+  test("passes optional environment/release overrides through", () => {
+    expect(
+      resolveSentryOptions({
+        SENTRY_DSN: "https://k@example.invalid/1",
+        SENTRY_ENVIRONMENT: "production",
+        SENTRY_RELEASE: "teak-files-worker@1.0.64+abcdef0",
+      })
+    ).toEqual({
+      dsn: "https://k@example.invalid/1",
+      environment: "production",
+      release: "teak-files-worker@1.0.64+abcdef0",
+      sendDefaultPii: false,
+    });
+  });
+
+  test("never enables default PII", () => {
+    const resolved = [
+      resolveSentryOptions({ SENTRY_DSN: "https://k@example.invalid/1" }),
+      resolveSentryOptions({
+        SENTRY_DSN: "https://k@example.invalid/1",
+        SENTRY_RELEASE: "r",
+      }),
+    ];
+    expect(resolved).not.toContain(undefined);
+    for (const options of resolved) {
+      expect(options?.sendDefaultPii).toBe(false);
+    }
+  });
+});
+
+describe("parseFileKeyIdentifiers", () => {
+  test("extracts card id and role from buildR2ObjectKey-shaped keys", () => {
+    expect(
+      parseFileKeyIdentifiers(
+        "users/9f8a/cards/c123/file/00000000-0000-4000-8000-000000000000-photo.png"
+      )
+    ).toEqual({ cardId: "c123", role: "file" });
+    expect(
+      parseFileKeyIdentifiers("users/9f8a/cards/c123/thumbnail/t.webp")
+    ).toEqual({ cardId: "c123", role: "thumbnail" });
+  });
+
+  test("omits pending-upload and unknown identifiers instead of guessing", () => {
+    expect(
+      parseFileKeyIdentifiers("users/9f8a/cards/pending/file/x.png")
+    ).toEqual({ role: "file" });
+    expect(parseFileKeyIdentifiers("some/other/key.png")).toEqual({});
+    expect(parseFileKeyIdentifiers("")).toEqual({});
+  });
+});
+
+describe("reportFilesOpFailure", () => {
+  test("is a safe no-op while the SDK is uninitialized", () => {
+    expect(() =>
+      reportFilesOpFailure("process-image", new Error("wasm compile failed"), {
+        httpMethod: "get",
+        httpPath: "/users/9f8a/cards/c123/file/photo.png",
+        objectKey: "users/9f8a/cards/c123/file/photo.png",
+      })
+    ).not.toThrow();
+    expect(() =>
+      reportFilesOpFailure("inspect", "not-an-error-instance", {
+        httpMethod: "GET",
+        httpPath: "/x",
+        objectKey: "",
+      })
+    ).not.toThrow();
+  });
+});
+
+describe("files worker error reporting", () => {
+  test("unexpected op failures still return the handled 500 with Sentry wired", async () => {
+    const env_ = {
+      // processImage's first R2 read rejects; nothing classifies this error,
+      // so it lands on the console.error + captureException + 500 path.
+      BUCKET: { get: () => Promise.reject(new Error("r2_unavailable")) },
+      FILES_SIGNING_SECRET: SECRET,
+    } as unknown as Env;
+    const response = await worker.fetch(
+      new Request(
+        await signedOpUrl(
+          "users/9f8a/cards/c123/file/photo.png",
+          "process-image"
+        )
+      ),
+      env_,
+      { waitUntil: () => undefined } as never
+    );
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "internal_error" });
+  });
+
+  test("expected op rejections stay unreported client-style statuses", async () => {
+    const env_ = {
+      BUCKET: { get: () => Promise.resolve(null) },
+      FILES_SIGNING_SECRET: SECRET,
+    } as unknown as Env;
+    const response = await worker.fetch(
+      new Request(
+        await signedOpUrl(
+          "users/9f8a/cards/c123/file/gone.png",
+          "process-image"
+        )
+      ),
+      env_,
+      { waitUntil: () => undefined } as never
+    );
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "source_not_found" });
+  });
+});

--- a/apps/files-worker/src/sentry.ts
+++ b/apps/files-worker/src/sentry.ts
@@ -1,0 +1,110 @@
+// Error reporting for the files worker, mirroring the web app's Sentry setup
+// (apps/web/src/lib/sentry-config.ts) at a scale appropriate for a hot file
+// proxy: errors only — no tracing or log sampling.
+//
+// This module is intentionally self-contained (no @teak/convex dependency) so
+// the deployed worker bundle stays free of backend code. The DSN is supplied
+// as a wrangler secret rather than anything committed to the repo:
+//
+//   bunx wrangler secret put SENTRY_DSN
+//
+// Because secrets only exist on `env` at request time, initialization happens
+// per request via withSentry's options callback; without a DSN (tests, local
+// dev, before the secret is set) the SDK runs with a disabled client and every
+// capture call below degrades to a no-op.
+
+import type { CloudflareOptions } from "@sentry/cloudflare";
+import { captureException } from "@sentry/cloudflare";
+
+/** Env vars backing error reporting; SENTRY_DSN is a wrangler secret. */
+export interface SentryEnvVars {
+  SENTRY_DSN?: string;
+  SENTRY_ENVIRONMENT?: string;
+  SENTRY_RELEASE?: string;
+}
+
+export const resolveSentryOptions = (
+  env: SentryEnvVars
+): CloudflareOptions | undefined => {
+  const dsn = env.SENTRY_DSN?.trim();
+  if (!dsn) {
+    return undefined;
+  }
+  const environment = env.SENTRY_ENVIRONMENT?.trim();
+  const release = env.SENTRY_RELEASE?.trim();
+  return {
+    dsn,
+    ...(environment ? { environment } : {}),
+    ...(release ? { release } : {}),
+    // Requests are HMAC-signed URLs and internal ops; never attach PII.
+    sendDefaultPii: false,
+  };
+};
+
+export interface FileKeyIdentifiers {
+  cardId?: string;
+  role?: string;
+}
+
+/**
+ * Best-effort card/role extraction from an R2 object key. Keys minted by
+ * buildR2ObjectKey (packages/convex/storage/r2.ts) look like
+ * users/<user-hash>/cards/<cardId|pending>/<role>/<uuid>-<name>; anything
+ * else parses to no identifiers instead of guessing.
+ */
+export const parseFileKeyIdentifiers = (key: string): FileKeyIdentifiers => {
+  const segments = key.split("/");
+  if (
+    segments.length < 5 ||
+    segments[0] !== "users" ||
+    segments[2] !== "cards"
+  ) {
+    return {};
+  }
+  const [cardId, role] = [segments[3], segments[4]];
+  return {
+    ...(cardId && cardId !== "pending" ? { cardId } : {}),
+    ...(role ? { role } : {}),
+  };
+};
+
+export interface FilesOpFailureContext {
+  httpMethod: string;
+  httpPath: string;
+  objectKey: string;
+}
+
+const MAX_CONTEXT_STRING_LENGTH = 256;
+
+const bounded = (value: string): string =>
+  value.length <= MAX_CONTEXT_STRING_LENGTH
+    ? value
+    : value.slice(0, MAX_CONTEXT_STRING_LENGTH);
+
+/**
+ * Explicit capture for op failures that handleOp already converted into 500
+ * responses — they never propagate out of fetch(), so withSentry's automatic
+ * unhandled-error capture cannot see them (this is exactly how the
+ * 2026-08-24 process-image outage stayed invisible).
+ */
+export const reportFilesOpFailure = (
+  op: string,
+  error: unknown,
+  { httpMethod, httpPath, objectKey }: FilesOpFailureContext
+): void => {
+  const { cardId, role } = parseFileKeyIdentifiers(objectKey);
+  captureException(error, {
+    tags: {
+      "files.op": op,
+    },
+    contexts: {
+      files_op: {
+        ...(cardId ? { "card.id": cardId } : {}),
+        "http.method": httpMethod.toUpperCase(),
+        "http.path": bounded(httpPath),
+        "object.key": bounded(objectKey),
+        ...(role ? { "object.role": role } : {}),
+      },
+    },
+  });
+};

--- a/apps/files-worker/wrangler.jsonc
+++ b/apps/files-worker/wrangler.jsonc
@@ -3,6 +3,8 @@
   "name": "teak-files-proxy",
   "main": "src/index.ts",
   "compatibility_date": "2026-08-01",
+  // Required by @sentry/cloudflare (AsyncLocalStorage-based request context).
+  "compatibility_flags": ["nodejs_compat"],
   "routes": [
     {
       "pattern": "files.teakvault.com",

--- a/bun.lock
+++ b/bun.lock
@@ -106,6 +106,7 @@
         "@discourse/heic": "^1.0.0",
         "@jsquash/webp": "^1.5.0",
         "@resvg/resvg-wasm": "^2.6.2",
+        "@sentry/cloudflare": "10.69.0",
         "client-zip": "^2.4.5",
         "exifr": "^7.1.3",
         "fflate": "^0.8.2",
@@ -1618,6 +1619,8 @@
     "@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@3.6.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-niUPoxN8p7jWrkvC0ekgpcIYEJNb5YxmuXRjUnOJrArwQs+4OPzRM+3e6JIYRXe7RDoUP63j1voYakEncuxioQ=="],
 
     "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@3.6.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Xg6ieuJr/1Ewtdpm9Kudb029lJxnfs3Ae/fLZNAOnvWOie/V4V/X+tgZ+lETC3lU+7yz7Gb0f25gKnU6sPBKVg=="],
+
+    "@sentry/cloudflare": ["@sentry/cloudflare@10.69.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@sentry/core": "10.69.0", "@sentry/server-utils": "10.69.0", "magic-string": "~0.30.21" }, "peerDependencies": { "@cloudflare/workers-types": "^4.x || ^5.x", "wrangler": "^4.x" }, "optionalPeers": ["@cloudflare/workers-types", "wrangler"] }, "sha512-CO6Tr74cw3Wx2DyWSfBCxR6EDcNfBjn52hxWacxHsLurpdfQ7Bp/J32m1KxzezR5CZXngfBTmemK3iZsMgt5uQ=="],
 
     "@sentry/conventions": ["@sentry/conventions@0.16.0", "", {}, "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ=="],
 


### PR DESCRIPTION
## Follow-up #1 — 2026-08-24 files-worker outage (fix: #329)

During the incident, the worker returned **500 on every `process-image` op** (`CompileError: WebAssembly.compile(): Wasm code generation disallowed by embedder`) and it was completely invisible in Sentry because this worker had no SDK — only `console.error`. This PR wires error reporting into the worker so the next outage pages instead of silently degrading thumbnails.

## What

- Add `@sentry/cloudflare@10.69.0` (pinned to match `@sentry/nextjs` / `@sentry/node`) and wrap the exported handler with `withSentry`.
- The DSN is resolved **per request from a `SENTRY_DSN` wrangler secret** (secrets only exist on `env`, never committed to the repo). Without the secret — local dev, tests, or before rollout — the SDK runs with a disabled client and all capture calls are safe no-ops.
- Handled op failures never propagate out of `fetch()`, so `withSentry`'s automatic capture can't see them. The 500 path in `handleOp` now reports explicitly via `reportFilesOpFailure()` with:
  - `files.op` tag (`process-image` / `build-export` / `inspect`)
  - HTTP method + path
  - card id / role parsed from the R2 object key when it matches the `users/<hash>/cards/<cardId>/<role>/...` shape
  - the original object key (bounded), so failures tie back to a card/file
- Anything that escapes the handler uncaught (e.g. download-path R2 errors) is captured automatically by `withSentry`.
- Errors-only configuration (`sendDefaultPii: false`, no tracing/log sampling) to keep per-request overhead negligible on the hot file-proxy path. Mirrors the web app's patterns (`instrumentation.ts` / `SentryUserManager` philosophy: pseudonymous, PII-free).
- Adds the `nodejs_compat` compatibility flag, which the SDK requires for its AsyncLocalStorage-based request context.

## Not touched

- Static `.wasm` imports from #329 are untouched — verified they still arrive as precompiled `WebAssembly.Module`s in a dry-run bundle.
- `wrangler.jsonc` `observability` block is left alone (handled separately by #330).

Bundle size: 5674 KiB → 6151 KiB raw (**2057 → 2160 KiB gzip**, +103 KiB) — well within limits.

## ⚠️ Before error reporting goes live

The `SENTRY_DSN` secret must be set on the worker first:

```bash
bunx wrangler secret put SENTRY_DSN
```

Until then the SDK stays disabled and nothing is sent. Optional `SENTRY_ENVIRONMENT` / `SENTRY_RELEASE` vars are supported but not required.

## Tests

- New `src/sentry.test.ts`: option resolution (disabled without DSN, trimmed DSN, optional env/release, PII off), key identifier parsing, safe no-op while uninitialized, and handler-level checks that an unexpected op failure still returns the handled 500 JSON while expected 404s stay unreported.
- Full suite: 55/55 pass in the package; root `bun run lint && bun run typecheck && bun run test` run — the only failures are the 4 pre-existing `@teak/convex` flakes also failing on clean `main` (MCP metadata origin ×2, billing sandbox, admin email).

No public changelog entry per repo rules (internal operational change).