### PR TITLE
Prevent derivative repair queue starvation

### DIFF
--- a/packages/convex/__tests__/workflows/derivativeRepair.test.ts
+++ b/packages/convex/__tests__/workflows/derivativeRepair.test.ts
@@ -1,0 +1,42 @@
+// @ts-nocheck
+import { describe, expect, mock, test } from "bun:test";
+import { repairImageDerivativesHandler } from "../../workflows/derivativeRepair";
+
+describe("derivative repair", () => {
+  test("advances candidates before scheduling so one failure cannot starve the queue", async () => {
+    const events: string[] = [];
+    const cardIds = ["card-a", "card-b"];
+    const result = await repairImageDerivativesHandler({
+      runQuery: mock(async () => cardIds),
+      runMutation: mock((_reference, args) => {
+        events.push(`marked:${args.cardIds.join(",")}`);
+      }),
+      scheduler: {
+        runAfter: mock((_delay, _reference, args) => {
+          events.push(`scheduled:${args.cardId}`);
+        }),
+      },
+    });
+
+    expect(result).toEqual({ scheduled: 2 });
+    expect(events).toEqual([
+      "marked:card-a,card-b",
+      "scheduled:card-a",
+      "scheduled:card-b",
+    ]);
+  });
+
+  test("does not write or schedule when no candidates need repair", async () => {
+    const runMutation = mock();
+    const runAfter = mock();
+    expect(
+      await repairImageDerivativesHandler({
+        runQuery: mock(async () => []),
+        runMutation,
+        scheduler: { runAfter },
+      })
+    ).toEqual({ scheduled: 0 });
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(runAfter).not.toHaveBeenCalled();
+  });
+});

--- a/packages/convex/workflows/derivativeRepair.ts
+++ b/packages/convex/workflows/derivativeRepair.ts
@@ -1,6 +1,11 @@
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
-import { internalAction, internalQuery } from "../_generated/server";
+import {
+  type ActionCtx,
+  internalAction,
+  internalMutation,
+  internalQuery,
+} from "../_generated/server";
 
 const REPAIR_BATCH_SIZE = 10;
 const REPAIR_SCAN_SIZE = 50;
@@ -23,21 +28,48 @@ export const oldestImageCandidates = internalQuery({
   },
 });
 
+export const markCandidatesChecked = internalMutation({
+  args: { cardIds: v.array(v.id("cards")) },
+  returns: v.null(),
+  handler: async (ctx, { cardIds }) => {
+    const checkedAt = Date.now();
+    for (const cardId of cardIds) {
+      const card = await ctx.db.get("cards", cardId);
+      if (card?.type === "image" && !card.isDeleted && card.fileKey) {
+        await ctx.db.patch("cards", cardId, { derivativeCheckedAt: checkedAt });
+      }
+    }
+    return null;
+  },
+});
+
+export const repairImageDerivativesHandler = async (
+  ctx: Pick<ActionCtx, "runMutation" | "runQuery" | "scheduler">
+): Promise<{ scheduled: number }> => {
+  const cardIds = await ctx.runQuery(
+    internal.workflows.derivativeRepair.oldestImageCandidates,
+    {}
+  );
+  if (cardIds.length > 0) {
+    // Advance every attempted card before scheduling. A permanently invalid
+    // source can then retry in a later rotation without starving newer cards.
+    await ctx.runMutation(
+      internal.workflows.derivativeRepair.markCandidatesChecked,
+      { cardIds }
+    );
+  }
+  for (const cardId of cardIds) {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.workflows.steps.renderables.generate,
+      { cardId, cardType: "image" }
+    );
+  }
+  return { scheduled: cardIds.length };
+};
+
 export const repairImageDerivatives = internalAction({
   args: {},
   returns: v.object({ scheduled: v.number() }),
-  handler: async (ctx) => {
-    const cardIds = await ctx.runQuery(
-      internal.workflows.derivativeRepair.oldestImageCandidates,
-      {}
-    );
-    for (const cardId of cardIds) {
-      await ctx.scheduler.runAfter(
-        0,
-        internal.workflows.steps.renderables.generate,
-        { cardId, cardType: "image" }
-      );
-    }
-    return { scheduled: cardIds.length };
-  },
+  handler: repairImageDerivativesHandler,
 });


### PR DESCRIPTION
## Summary

- advance every valid derivative-repair candidate's derivativeCheckedAt before scheduling regeneration
- prevent a permanently failing early image from starving later cards in the hourly queue
- keep failed cards eligible for a later retry after the queue rotates

## Verification

- targeted derivative-repair tests pass
- full test suite passes (1,455 Convex tests)
- full typecheck passes
- Ultracite check passes
- affected build, typecheck, and lint pass

Fixes the issue raised in https://github.com/praveenjuge/teak/pull/332#discussion_r3843434797