### PR TITLE
Fix production multipart uploads to R2

### DIFF
--- a/apps/files-worker/src/index.test.ts
+++ b/apps/files-worker/src/index.test.ts
@@ -262,7 +262,11 @@ describe("files worker handler", () => {
       )
     );
     const response = await worker.fetch(
-      new Request(url, { body: new Blob(["hello"]), method: "PUT" }),
+      new Request(url, {
+        body: new Blob(["hello"]),
+        headers: { "content-length": "5" },
+        method: "PUT",
+      }),
       env_,
       { waitUntil: () => undefined } as never
     );
@@ -314,6 +318,51 @@ describe("files worker handler", () => {
         requestId: expect.any(String),
         retryable: false,
       },
+      ok: false,
+      version: FILES_PROTOCOL_VERSION,
+    });
+  });
+
+  test("requires a fixed-length multipart request body", async () => {
+    const env_ = env();
+    const bucket = env_.BUCKET as unknown as FakeBucket;
+    const key = "users/u1/cards/upload/stream.bin";
+    const multipart = bucket.createMultipartUpload(key);
+    const partNumber = 1;
+    const expiresAt = String(Math.floor(Date.now() / 1000) + 600);
+    const url = new URL(
+      `https://files.teakvault.com/__uploads/v1/${multipart.uploadId}/${partNumber}`
+    );
+    url.searchParams.set("key", key);
+    url.searchParams.set("exp", expiresAt);
+    url.searchParams.set(
+      "sig",
+      await hmacSha256Hex(
+        SECRET,
+        buildMultipartPartSigningPayload({
+          expiresAt,
+          key,
+          partNumber,
+          uploadId: multipart.uploadId,
+        })
+      )
+    );
+    const response = await worker.fetch(
+      new Request(url, {
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("hello"));
+            controller.close();
+          },
+        }),
+        method: "PUT",
+      }),
+      env_,
+      { waitUntil: () => undefined } as never
+    );
+    expect(response.status).toBe(411);
+    expect(await response.json()).toMatchObject({
+      error: { code: "INVALID_INPUT", retryable: false },
       ok: false,
       version: FILES_PROTOCOL_VERSION,
     });

--- a/apps/files-worker/src/index.ts
+++ b/apps/files-worker/src/index.ts
@@ -163,11 +163,15 @@ const handleMultipartPart = async (
     request.headers.get("content-length") ?? "",
     10
   );
-  if (
-    !request.body ||
-    (Number.isSafeInteger(contentLength) &&
-      (contentLength <= 0 || contentLength > MULTIPART_MAX_PART_BYTES))
-  ) {
+  if (!(request.body && Number.isSafeInteger(contentLength))) {
+    return multipartError(
+      requestId,
+      "INVALID_INPUT",
+      "Multipart part Content-Length is required",
+      411
+    );
+  }
+  if (contentLength <= 0 || contentLength > MULTIPART_MAX_PART_BYTES) {
     return multipartError(
       requestId,
       "PAYLOAD_TOO_LARGE",
@@ -176,29 +180,19 @@ const handleMultipartPart = async (
     );
   }
   try {
-    let bytesRead = 0;
-    const limitedBody = request.body.pipeThrough(
-      new TransformStream<Uint8Array, Uint8Array>({
-        transform(chunk, controller) {
-          bytesRead += chunk.byteLength;
-          if (bytesRead > MULTIPART_MAX_PART_BYTES) {
-            controller.error(new Error("multipart_part_too_large"));
-            return;
-          }
-          controller.enqueue(chunk);
-        },
-      })
-    );
+    // Pass the original fixed-length request stream to R2. Wrapping it in a
+    // TransformStream discards the runtime's known-length metadata and makes
+    // R2 reject otherwise-valid multipart parts in production.
     const uploaded = await env.BUCKET.resumeMultipartUpload(
       key,
       uploadId
-    ).uploadPart(partNumber, limitedBody);
+    ).uploadPart(partNumber, request.body);
     const headers = new Headers({ ETag: uploaded.etag });
     withCorsHeaders(headers);
     return new Response(null, { status: 204, headers });
   } catch (error) {
     console.error("[files-worker] multipart part upload failed", {
-      error,
+      error: error instanceof Error ? error.message : String(error),
       partNumber,
     });
     return multipartError(


### PR DESCRIPTION
## Summary

- preserve the fixed-length request stream when forwarding multipart parts to R2
- reject multipart requests without a reliable Content-Length before touching storage
- make production multipart failures log a useful error message

## Root cause

Chrome production validation showed every 8 MiB part returning HTTP 500. Cloudflare logs confirmed R2 rejected the transformed stream. The TransformStream wrapper discarded the request body's known-length metadata; the Worker now validates the original Content-Length and forwards request.body directly, matching Cloudflare's documented Workers multipart API pattern.

## Verification

- 64 Worker tests pass
- Worker typecheck passes
- Ultracite passes across 972 files
- affected pre-commit checks pass
- Wrangler dry run succeeds at 2,163.95 KiB gzip, below the 3 MiB Free plan limit