### PR TITLE
Fix Markdown BOM preservation in file uploads

### DIFF
--- a/apps/files-worker/src/index.test.ts
+++ b/apps/files-worker/src/index.test.ts
@@ -226,19 +226,21 @@ describe("files worker handler", () => {
     expect(response.status).toBe(403);
   });
 
-  test("streams a validated pending upload into its permanent key", async () => {
+  test("streams a validated pending upload and preserves a Markdown BOM", async () => {
     const env_ = env();
     const bucket = env_.BUCKET as unknown as FakeBucket;
-    const sourceKey = "users/u1/cards/upload-pending-v2/file/design..final.txt";
-    const destinationKey = "users/u1/cards/stored/file/design..final.txt";
+    const sourceKey = "users/u1/cards/upload-pending-v2/file/design..final.md";
+    const destinationKey = "users/u1/cards/stored/file/design..final.md";
+    const markdown = "\uFEFFHello worker";
+    const bytes = new TextEncoder().encode(markdown);
     bucket.objects.set(sourceKey, {
-      bytes: new TextEncoder().encode("Hello worker"),
-      httpMetadata: { contentType: "text/plain" },
+      bytes,
+      httpMetadata: { contentType: "text/markdown" },
     });
     const response = await worker.fetch(
       await signedOpRequest("finalize-upload", {
         destinationKey,
-        expectedSize: 12,
+        expectedSize: bytes.byteLength,
         readText: true,
         sourceKey,
       }),
@@ -247,15 +249,17 @@ describe("files worker handler", () => {
     );
     expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({
-      data: { content: "Hello worker", destinationKey, storedFileSize: 12 },
+      data: {
+        content: markdown,
+        destinationKey,
+        storedFileSize: bytes.byteLength,
+      },
       ok: true,
     });
     // Convex deletes the pending object only after its card mutation succeeds,
     // so a failed database write can safely retry finalization.
     expect(bucket.objects.has(sourceKey)).toBe(true);
-    expect(new TextDecoder().decode(bucket.storedBytes(destinationKey)!)).toBe(
-      "Hello worker"
-    );
+    expect(bucket.storedBytes(destinationKey)).toEqual(bytes);
   });
 
   test("uploads and idempotently completes a signed multipart upload", async () => {

--- a/apps/files-worker/src/ops.ts
+++ b/apps/files-worker/src/ops.ts
@@ -107,7 +107,7 @@ const finalizeUpload = async (
     try {
       content = new TextDecoder("utf-8", {
         fatal: true,
-        ignoreBOM: false,
+        ignoreBOM: true,
       }).decode(bytes);
     } catch {
       throw new Error("invalid_utf8");


### PR DESCRIPTION
## Summary
- preserve a leading UTF-8 BOM when the files Worker reads Markdown uploads
- cover the signed finalize-upload boundary with an exact byte/content regression test

## Verification
- `bunx bun@1.3.14 run check`
- `bunx bun@1.3.14 run typecheck`
- `bunx bun@1.3.14 run test`

This fixes the production E2E failures observed after #336 without changing the public changelog.