### PR TITLE
Release 1.0.65

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak-cli",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "description": "Command-line client for Teak, the personal knowledge hub for saving and rediscovering ideas.",
   "keywords": [
     "teak",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/desktop",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "private": true,
   "type": "module",
   "main": ".vite/build/main.js",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/docs",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "scripts": {
     "audit": "bun run build:site && blume audit --fail-on error",
     "build": "bun run build:site && blume audit --fail-on error",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/extension",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "description": "Teak - Your Personal Knowledge Hub. Save, organize, and rediscover web content, text selections, and ideas effortlessly.",
   "homepage": "https://teakvault.com",
   "author": "Praveen Juge (hi@praveenjuge.com)",

--- a/apps/files-worker/package.json
+++ b/apps/files-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/files-worker",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "private": true,
   "scripts": {
     "cf-typegen": "wrangler types",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/mobile",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "main": "expo-router/entry",
   "scripts": {
     "android": "expo run:android",

--- a/apps/raycast/package-lock.json
+++ b/apps/raycast/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teak-raycast",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teak-raycast",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.104.19",

--- a/apps/raycast/package.json
+++ b/apps/raycast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak-raycast",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "private": true,
   "description": "Save ideas fast, search your Teak cards, and access favorites directly from Raycast.",
   "categories": [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/web",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "apps/cli": {
       "name": "teak-cli",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "bin": {
         "teak": "./dist/index.js",
       },
@@ -30,7 +30,7 @@
     },
     "apps/desktop": {
       "name": "@teak/desktop",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "dependencies": {
         "@sentry/electron": "7.16.0",
         "@tailwindcss/vite": "^4.3.3",
@@ -64,7 +64,7 @@
     },
     "apps/docs": {
       "name": "@teak/docs",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "dependencies": {
         "@teak/convex": "workspace:*",
         "blume": "^1.4.1",
@@ -77,7 +77,7 @@
     },
     "apps/extension": {
       "name": "@teak/extension",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "dependencies": {
         "@convex-dev/better-auth": "0.12.5",
         "@tailwindcss/vite": "^4.3.3",
@@ -100,7 +100,7 @@
     },
     "apps/files-worker": {
       "name": "@teak/files-worker",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "dependencies": {
         "@cf-wasm/photon": "^0.4.0",
         "@resvg/resvg-wasm": "^2.6.2",
@@ -115,7 +115,7 @@
     },
     "apps/mobile": {
       "name": "@teak/mobile",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "dependencies": {
         "@better-auth/expo": "1.6.23",
         "@convex-dev/better-auth": "0.12.5",
@@ -173,7 +173,7 @@
     },
     "apps/raycast": {
       "name": "teak-raycast",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "dependencies": {
         "@raycast/api": "^1.104.24",
         "@raycast/utils": "^2.3.0",
@@ -187,7 +187,7 @@
     },
     "apps/web": {
       "name": "@teak/web",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "dependencies": {
         "@convex-dev/better-auth": "^0.12.5",
         "@polar-sh/checkout": "^0.4.0",
@@ -224,7 +224,7 @@
     },
     "packages/convex": {
       "name": "@teak/convex",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^3.0.35",
         "@aws-sdk/client-s3": "3.1106.0",
@@ -267,14 +267,14 @@
     },
     "packages/files-protocol": {
       "name": "@teak/files-protocol",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "devDependencies": {
         "typescript": "^5.9.3",
       },
     },
     "packages/tests": {
       "name": "@teak/tests",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "dependencies": {
         "@axe-core/playwright": "^4.12.1",
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -293,7 +293,7 @@
     },
     "packages/ui": {
       "name": "@teak/ui",
-      "version": "1.0.64",
+      "version": "1.0.65",
       "dependencies": {
         "@codemirror/commands": "6.10.4",
         "@codemirror/lang-markdown": "6.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teak",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/convex",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "type": "module",
   "exports": {
     ".": "./index.ts",

--- a/packages/files-protocol/package.json
+++ b/packages/files-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/files-protocol",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/tests",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teak/ui",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "private": true,
   "exports": {
     "./logo": "./src/logo.tsx",


### PR DESCRIPTION
## Summary
- bump every monorepo package to 1.0.65 in lockstep
- synchronize Bun and Raycast npm lockfiles
- trigger the canonical coordinated desktop, Chrome extension, CLI/npm, iOS, and Safari release after merge

## Verification
- exact next-patch validation from 1.0.64
- lockstep manifest and npm lock validation
- Bun 1.3.5 install and frozen-lockfile install
- pre-commit affected typecheck, lint, and build: 24/24 tasks