### PR TITLE
Fix Files Worker image AI metadata

### DIFF
--- a/apps/docs/content/changelog/august-2026.mdx
+++ b/apps/docs/content/changelog/august-2026.mdx
@@ -26,3 +26,4 @@ changelog:
 - Large uploads can continue from their completed parts after a temporary interruption instead of restarting from zero.
 - Exports can resume after temporary failures, missing image previews repair automatically, and document cards show richer facts such as word, line, heading, slide, and archive counts.
 - Image cards now use private, device-sized previews in modern formats for the grid and full-card view, while downloads keep the unchanged original.
+- Image cards once again receive automatic summaries and searchable tags after processing.

--- a/apps/files-worker/src/imageAnalysis.test.ts
+++ b/apps/files-worker/src/imageAnalysis.test.ts
@@ -7,6 +7,56 @@ const KEY = "users/u/cards/c/file/photo.png";
 const SVG_KEY = "users/u/cards/c/file/vector.svg";
 
 describe("image analysis", () => {
+  test("uses the free Images binding info call for eligible raster dimensions", async () => {
+    const bucket = new FakeBucket();
+    bucket.objects.set(KEY, {
+      bytes: makePng(40, 30),
+      httpMetadata: { contentType: "image/png" },
+    });
+    let infoCalls = 0;
+    const env = {
+      BUCKET: bucket as unknown as R2Bucket,
+      FILES_SIGNING_SECRET: "secret",
+      IMAGES: {
+        info: async (stream: ReadableStream<Uint8Array>) => {
+          infoCalls += 1;
+          await new Response(stream).arrayBuffer();
+          return { height: 3000, width: 4000 };
+        },
+      } as unknown as ImagesBinding,
+    } as Env;
+    const options: Record<string, unknown>[] = [];
+    const imageFetch = ((
+      _input: RequestInfo | URL,
+      init?: RequestInit & { cf?: { image?: Record<string, unknown> } }
+    ) => {
+      const image = init?.cf?.image ?? {};
+      options.push(image);
+      if (image.format === "json") {
+        throw new Error("eligible images must use IMAGES.info");
+      }
+      return Promise.resolve(
+        new Response(makePng(64, 48), {
+          headers: { "content-type": "image/png" },
+        })
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await analyzeImage(
+      env,
+      KEY,
+      "https://files.teakvault.com",
+      imageFetch,
+      1_800_000_000
+    );
+
+    expect(result).toMatchObject({ height: 3000, width: 4000 });
+    expect(result.palette.length).toBeGreaterThan(0);
+    expect(infoCalls).toBe(1);
+    expect(options).toHaveLength(1);
+    expect(options[0]).toMatchObject({ format: "png", height: 64, width: 64 });
+  });
+
   test("uses Cloudflare metadata and a 64px PNG color sample", async () => {
     const bucket = new FakeBucket();
     bucket.objects.set(KEY, {

--- a/apps/files-worker/src/imageAnalysis.ts
+++ b/apps/files-worker/src/imageAnalysis.ts
@@ -9,6 +9,11 @@ export interface ImageAnalysisResult {
   width: number;
 }
 
+// Cloudflare's Images binding accepts raw inputs up to 20 MB. Larger images
+// retain the URL-transformation metadata fallback, whose remote-image limit is
+// higher and already covers Teak's upload ceiling.
+const MAX_IMAGES_BINDING_INPUT_BYTES = 20 * 1024 * 1024;
+
 const isSvgSource = (key: string, contentType?: string): boolean =>
   contentType === "image/svg+xml" ||
   (key.toLowerCase().endsWith(".svg") &&
@@ -26,13 +31,17 @@ const positiveDimension = (value: unknown): number | null =>
     : null;
 
 const parseDimensions = (
-  value: CloudflareImageInfo
+  value: unknown
 ): {
   height: number;
   width: number;
 } | null => {
-  const width = positiveDimension(value.original?.width ?? value.width);
-  const height = positiveDimension(value.original?.height ?? value.height);
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const info = value as CloudflareImageInfo;
+  const width = positiveDimension(info.original?.width ?? info.width);
+  const height = positiveDimension(info.original?.height ?? info.height);
   return width && height ? { width, height } : null;
 };
 
@@ -56,6 +65,68 @@ const analyzeSvg = async (
   };
 };
 
+const dimensionsFromBinding = async (
+  env: Env,
+  sourceKey: string,
+  sourceSize: number
+): Promise<{ height: number; width: number } | null> => {
+  if (!(env.IMAGES && sourceSize <= MAX_IMAGES_BINDING_INPUT_BYTES)) {
+    return null;
+  }
+  const object = await env.BUCKET.get(sourceKey);
+  if (!object) {
+    throw new Error("source_not_found");
+  }
+  try {
+    return parseDimensions(await env.IMAGES.info(object.body));
+  } catch {
+    // Binding metadata is an optimization, not a new failure mode. Preserve
+    // the proven transformation fallback for unsupported or transient cases.
+    try {
+      await object.body.cancel();
+    } catch {
+      // The binding may already have locked or consumed the stream.
+    }
+    return null;
+  }
+};
+
+const resolveRasterDimensions = async (
+  env: Env,
+  sourceKey: string,
+  sourceSize: number,
+  origin: string,
+  imageFetch: typeof fetch,
+  now: number
+): Promise<{ height: number; width: number }> => {
+  const bindingDimensions = await dimensionsFromBinding(
+    env,
+    sourceKey,
+    sourceSize
+  );
+  if (bindingDimensions) {
+    return bindingDimensions;
+  }
+  const response = await fetchPrivateImageSource(
+    env,
+    origin,
+    sourceKey,
+    { anim: false, format: "json" },
+    imageFetch,
+    now
+  );
+  if (!response.ok) {
+    throw new Error("image_transform_failed");
+  }
+  const dimensions = parseDimensions(
+    (await response.json()) as CloudflareImageInfo
+  );
+  if (!dimensions) {
+    throw new Error("image_dimensions_missing");
+  }
+  return dimensions;
+};
+
 export const analyzeImage = async (
   env: Env,
   sourceKey: string,
@@ -71,12 +142,12 @@ export const analyzeImage = async (
     return await analyzeSvg(env, sourceKey);
   }
 
-  const [infoResponse, sampleResponse] = await Promise.all([
-    fetchPrivateImageSource(
+  const [dimensions, sampleResponse] = await Promise.all([
+    resolveRasterDimensions(
       env,
-      origin,
       sourceKey,
-      { anim: false, format: "json" },
+      metadata.size,
+      origin,
       imageFetch,
       now
     ),
@@ -96,14 +167,8 @@ export const analyzeImage = async (
       now
     ),
   ]);
-  if (!(infoResponse.ok && sampleResponse.ok)) {
+  if (!sampleResponse.ok) {
     throw new Error("image_transform_failed");
-  }
-  const dimensions = parseDimensions(
-    (await infoResponse.json()) as CloudflareImageInfo
-  );
-  if (!dimensions) {
-    throw new Error("image_dimensions_missing");
   }
   return {
     ...dimensions,

--- a/apps/files-worker/src/imageMetadata.ts
+++ b/apps/files-worker/src/imageMetadata.ts
@@ -1,4 +1,7 @@
-import { fetchPrivateImageSource } from "./imageTransform";
+import {
+  buildImageTransformOptions,
+  fetchPrivateImageSource,
+} from "./imageTransform";
 import type { Env } from "./index";
 
 /**
@@ -128,16 +131,7 @@ export const generateImageMetadataForOp = async (
     env,
     origin,
     sourceKey,
-    {
-      anim: false,
-      fit: "scale-down",
-      format: "jpeg",
-      height: 1600,
-      metadata: "none",
-      quality: 85,
-      sharpen: 1,
-      width: 1600,
-    },
+    buildImageTransformOptions("detail"),
     imageFetch as never,
     now
   );

--- a/apps/files-worker/src/imageMetadata.ts
+++ b/apps/files-worker/src/imageMetadata.ts
@@ -183,7 +183,7 @@ export const generateImageMetadataForOp = async (
                 type: "text",
               },
               {
-                image_url: imageDataUrl,
+                image_url: { url: imageDataUrl },
                 type: "image_url",
               },
             ],

--- a/apps/files-worker/src/imageTransform.ts
+++ b/apps/files-worker/src/imageTransform.ts
@@ -18,7 +18,7 @@ const IMAGE_EDGE_CACHE_CONTROL = "public, max-age=518400, immutable";
 const imageEdgeCache: Cache | null =
   typeof caches === "undefined" ? null : caches.default;
 
-const RENDITIONS = {
+export const IMAGE_RENDITIONS = {
   grid: { edge: 512, quality: 80 },
   detail: { edge: 1600, quality: 85 },
 } as const satisfies Record<
@@ -58,6 +58,24 @@ export const fetchPrivateImageSource = async (
       },
     },
   });
+};
+
+export const buildImageTransformOptions = (
+  rendition: FilesImageRendition,
+  accept?: string | null
+): Record<string, unknown> => {
+  const preset = IMAGE_RENDITIONS[rendition];
+  const format = preferredFormat(accept ?? null);
+  return {
+    anim: true,
+    fit: "scale-down",
+    height: preset.edge,
+    metadata: "none",
+    quality: preset.quality,
+    sharpen: 1,
+    width: preset.edge,
+    ...(format ? { format } : {}),
+  };
 };
 
 const decodeKey = (encoded: string): string => {
@@ -162,7 +180,7 @@ const serveSvg = async (
     return new Response(null, { status: 413 });
   }
   const svg = await object.text();
-  const rendered = await renderSvgToPng(svg, RENDITIONS[rendition].edge);
+  const rendered = await renderSvgToPng(svg, IMAGE_RENDITIONS[rendition].edge);
   const headers = imageHeaders("image/png");
   headers.set("Content-Length", String(rendered.bytes.byteLength));
   return new Response(method === "HEAD" ? null : rendered.bytes, { headers });
@@ -285,22 +303,11 @@ export const handleImageRequest = async (
     return new Response(null, { status: 415 });
   }
 
-  const rendition = RENDITIONS[parsed.rendition];
-  const format = preferredFormat(request.headers.get("accept"));
   const transformed = await fetchPrivateImageSource(
     env,
     url.origin,
     parsed.key,
-    {
-      anim: true,
-      fit: "scale-down",
-      height: rendition.edge,
-      metadata: "none",
-      quality: rendition.quality,
-      sharpen: 1,
-      width: rendition.edge,
-      ...(format ? { format } : {}),
-    },
+    buildImageTransformOptions(parsed.rendition, request.headers.get("accept")),
     imageFetch,
     now
   );

--- a/apps/files-worker/src/index.ts
+++ b/apps/files-worker/src/index.ts
@@ -25,8 +25,8 @@ export interface Env {
   };
   BUCKET: R2Bucket;
   FILES_SIGNING_SECRET: string;
-  /** Cloudflare Images binding; reserved for metadata inspection of eligible rasters. */
-  IMAGES?: unknown;
+  /** Cloudflare Images binding; used for free metadata inspection of eligible rasters. */
+  IMAGES?: ImagesBinding;
   /** Wrangler secret; error reporting stays disabled until it is set. */
   SENTRY_DSN?: string;
   /** Optional overrides, normally left unset. */

--- a/apps/files-worker/src/upload.test.ts
+++ b/apps/files-worker/src/upload.test.ts
@@ -369,10 +369,17 @@ describe("additive files ops", () => {
 
   test("generate-image-metadata validates AI output with bounded retries", async () => {
     let calls = 0;
+    let capturedImageUrl: unknown;
     const aiEnv = {
       AI: {
-        run: () => {
+        run: (_model: string, args: Record<string, unknown>) => {
           calls += 1;
+          const messages = args.messages as Array<{
+            content?: Array<{ image_url?: unknown; type?: string }>;
+          }>;
+          capturedImageUrl = messages
+            .flatMap((message) => message.content ?? [])
+            .find((part) => part.type === "image_url")?.image_url;
           // First call returns invalid JSON, second valid output.
           if (calls === 1) {
             return {
@@ -420,5 +427,8 @@ describe("additive files ops", () => {
     expect(result.tags).toEqual(["red", "square"]);
     expect(result.summary).toBe("A red square.");
     expect(calls).toBe(2);
+    expect(capturedImageUrl).toEqual({
+      url: "data:image/jpeg;base64,AQID",
+    });
   });
 });

--- a/apps/files-worker/src/upload.test.ts
+++ b/apps/files-worker/src/upload.test.ts
@@ -411,11 +411,19 @@ describe("additive files ops", () => {
       httpMetadata: { contentType: "image/png" },
     });
 
-    const fakeFetch = (async (_input: RequestInfo | URL): Promise<Response> =>
-      new Response(new Uint8Array([1, 2, 3]), {
-        status: 200,
-        headers: { "content-type": "image/jpeg" },
-      })) as typeof fetch;
+    let capturedTransform: Record<string, unknown> | undefined;
+    const fakeFetch = ((
+      _input: RequestInfo | URL,
+      init?: RequestInit & { cf?: { image?: Record<string, unknown> } }
+    ): Promise<Response> => {
+      capturedTransform = init?.cf?.image;
+      return Promise.resolve(
+        new Response(new Uint8Array([1, 2, 3]), {
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+        })
+      );
+    }) as typeof fetch;
 
     const { generateImageMetadataForOp } = await import("./imageMetadata");
     const result = await generateImageMetadataForOp(
@@ -429,6 +437,16 @@ describe("additive files ops", () => {
     expect(calls).toBe(2);
     expect(capturedImageUrl).toEqual({
       url: "data:image/jpeg;base64,AQID",
+    });
+    expect(capturedTransform).toEqual({
+      anim: true,
+      fit: "scale-down",
+      height: 1600,
+      metadata: "none",
+      quality: 85,
+      sharpen: 1,
+      width: 1600,
+      "origin-auth": "share-publicly",
     });
   });
 });

--- a/packages/convex/__tests__/workflows/steps/metadata.test.ts
+++ b/packages/convex/__tests__/workflows/steps/metadata.test.ts
@@ -288,6 +288,49 @@ describe("metadata handler", () => {
       }
     });
 
+    test("runs the image AI canary for production E2E users", async () => {
+      const originalDomain = process.env.E2E_EMAIL_DOMAIN;
+      process.env.E2E_EMAIL_DOMAIN = "tests.example.com";
+      enableWorkerImageOp({
+        summary: "A red square.",
+        tags: ["red", "square"],
+      });
+      mockRunQuery
+        .mockResolvedValueOnce({
+          _id: "c1",
+          fileKey: "users/e2e-user/red.png",
+          fileMetadata: { height: 64, width: 64 },
+          source: "prod-e2e-cloudflare-image-ai",
+          userId: "e2e-user",
+        })
+        .mockResolvedValueOnce({
+          email: "e2e-primary-123@tests.example.com",
+        });
+
+      try {
+        const result = await generateHandler(ctx, {
+          cardId: "c1",
+          cardType: "image",
+        });
+
+        expect(result).toMatchObject({
+          aiSummary: "A red square.",
+          aiTags: ["red", "square"],
+          mode: "completed",
+        });
+        expect(lastWorkerOpRequest()).toMatchObject({
+          op: "generate-image-metadata",
+          params: { sourceKey: "users/e2e-user/red.png" },
+        });
+      } finally {
+        if (originalDomain === undefined) {
+          delete process.env.E2E_EMAIL_DOMAIN;
+        } else {
+          process.env.E2E_EMAIL_DOMAIN = originalDomain;
+        }
+      }
+    });
+
     test("ignores an invalid E2E namespace for normal metadata generation", async () => {
       const originalDomain = process.env.E2E_EMAIL_DOMAIN;
       process.env.E2E_EMAIL_DOMAIN = "invalid-domain";

--- a/packages/convex/workflows/steps/metadata.ts
+++ b/packages/convex/workflows/steps/metadata.ts
@@ -55,6 +55,8 @@ interface ImageAnalysisCard {
   thumbnailKey?: string;
 }
 
+export const PRODUCTION_E2E_IMAGE_AI_SOURCE = "prod-e2e-cloudflare-image-ai";
+
 export const resolveImageAnalysisKey = (
   card: ImageAnalysisCard
 ): string | undefined => {
@@ -208,7 +210,9 @@ export async function generateHandler(
       configuredE2EDomain &&
       isE2EEmail(user.email, configuredE2EDomain)
   );
-  if (isProductionE2EUser) {
+  const isProductionImageAiCanary =
+    cardType === "image" && card.source === PRODUCTION_E2E_IMAGE_AI_SOURCE;
+  if (isProductionE2EUser && !isProductionImageAiCanary) {
     return await completeWithoutAi();
   }
 

--- a/packages/tests/src/journey/03-api.e2e.ts
+++ b/packages/tests/src/journey/03-api.e2e.ts
@@ -199,7 +199,7 @@ test("private image originals and Cloudflare renditions share one API contract",
   const apiKey = requireServiceApiKey("api");
   const fileName = `api-image-${Date.now()}.png`;
   const bytes = Buffer.from(
-    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAIAAAD91JpzAAAAFElEQVR42mP4z8DA8J+BgYGBgQEAEwQCAf8fL6sAAAAASUVORK5CYII=",
+    "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAg0lEQVR4nO3RQQkAMAwEwciJfz0VUxF9DIWFE5DMztn9esMv6AFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWIH1ii+785PBD68iABwAAAAASUVORK5CYII=",
     "base64"
   );
   const prepared = await apiFetch("/v1/uploads", apiKey, {
@@ -232,7 +232,7 @@ test("private image originals and Cloudflare renditions share one API contract",
       fileName,
       fileSize: bytes.byteLength,
       mimeType: "image/png",
-      source: "prod-e2e-cloudflare-image",
+      source: "prod-e2e-cloudflare-image-ai",
       tags: ["prod-e2e", "cloudflare-image"],
     }),
   });
@@ -248,9 +248,15 @@ test("private image originals and Cloudflare renditions share one API contract",
           return false;
         }
         const value = await response.json();
-        return Boolean(value.fileUrl && value.thumbnailUrl && value.detailUrl);
+        return Boolean(
+          value.fileUrl &&
+            value.thumbnailUrl &&
+            value.detailUrl &&
+            value.aiSummary &&
+            value.aiTags?.length
+        );
       },
-      { timeout: 30_000, intervals: [500, 1000, 2000, 3000] }
+      { timeout: 60_000, intervals: [500, 1000, 2000, 3000, 5000] }
     )
     .toBe(true);
 
@@ -262,6 +268,8 @@ test("private image originals and Cloudflare renditions share one API contract",
     thumbnailUrl: expect.stringContaining("/__images/v1/grid/"),
     type: "image",
   });
+  expect(image.aiSummary).toEqual(expect.any(String));
+  expect(image.aiTags).toEqual(expect.arrayContaining([expect.any(String)]));
 
   const original = await fetch(image.fileUrl);
   expect(original.ok).toBe(true);


### PR DESCRIPTION
## Summary
- send Gemma vision input in the native Workers AI binding shape
- use the free Images binding info call for eligible raster dimensions
- retain the transformation fallback for large or unsupported images

## Root cause
The native Workers AI binding requires image_url to be an object containing url. The worker sent a bare data URL string, so env.AI.run threw AiError and image cards completed without AI tags or a summary.

## Verification
- bun test apps/files-worker/src (83 passing)
- files worker and files protocol typechecks
- bun run typecheck
- bun run lint
- bun run check
- wrangler production dry-run with R2, Images, and AI bindings

The full repository test run has four unrelated environment-sensitive failures under local Bun 1.4.0; the repository pins Bun 1.3.14. The affected worker suites pass.