### PR TITLE
Restore Files Worker upload ETag header

### DIFF
--- a/apps/files-worker/src/upload.test.ts
+++ b/apps/files-worker/src/upload.test.ts
@@ -118,6 +118,7 @@ describe("signed single-file uploads", () => {
     expect(payload.data.key).toBe("users/u1/cards/file/abc-test.txt");
     expect(payload.data.size).toBe(bytes.byteLength);
     expect(payload.data.etag).toBeTruthy();
+    expect(response.headers.get("etag")).toBe(payload.data.etag);
     const stored = bucket.objects.get("users/u1/cards/file/abc-test.txt");
     expect(stored?.httpMetadata?.contentType).toBe("text/plain");
     expect(new TextDecoder().decode(stored?.bytes ?? new Uint8Array())).toBe(

--- a/apps/files-worker/src/upload.ts
+++ b/apps/files-worker/src/upload.ts
@@ -202,6 +202,7 @@ export const handleSignedUpload = async (
       },
       { headers: { "cache-control": "no-store" } }
     );
+    response.headers.set("ETag", stored.httpEtag);
     response.headers.set("Access-Control-Allow-Origin", "*");
     response.headers.set(
       "Access-Control-Expose-Headers",


### PR DESCRIPTION
## Summary
- restore the ETag response header on signed single-file uploads
- keep the JSON envelope and CORS exposure unchanged
- add a regression assertion for the response header

## Production evidence
Production E2E run 32932643414 showed successful uploads returning no ETag header, blocking API and MCP file-card creation. Worker tests, typecheck, and repository checks pass locally.