### PR TITLE
Fix Cloudflare upload and image AI edge cases

### DIFF
--- a/apps/docs/content/changelog/august-2026.mdx
+++ b/apps/docs/content/changelog/august-2026.mdx
@@ -27,3 +27,4 @@ changelog:
 - Exports can resume after temporary failures, missing image previews repair automatically, and document cards show richer facts such as word, line, heading, slide, and archive counts.
 - Image cards now use private, device-sized previews in modern formats for the grid and full-card view, while downloads keep the unchanged original.
 - Image cards once again receive automatic summaries and searchable tags after processing.
+- File uploads now finish reliably across the web app, browser extension, API, CLI, and MCP.

--- a/apps/files-worker/src/imageMetadata.ts
+++ b/apps/files-worker/src/imageMetadata.ts
@@ -126,12 +126,18 @@ export const generateImageMetadataForOp = async (
   now = Math.floor(Date.now() / 1000),
   imageFetch: typeof fetch = fetch as typeof fetch
 ): Promise<ImageMetadataResult> => {
-  // The detail rendition is what the previous Convex path analyzed.
+  // Keep the canonical detail dimensions, but give the model one broadly
+  // supported raster frame even when the private original is animated or uses
+  // a format Workers AI cannot decode directly.
   const renditionResponse = await fetchPrivateImageSource(
     env,
     origin,
     sourceKey,
-    buildImageTransformOptions("detail"),
+    {
+      ...buildImageTransformOptions("detail"),
+      anim: false,
+      format: "jpeg",
+    },
     imageFetch as never,
     now
   );

--- a/apps/files-worker/src/upload.test.ts
+++ b/apps/files-worker/src/upload.test.ts
@@ -440,8 +440,9 @@ describe("additive files ops", () => {
       url: "data:image/jpeg;base64,AQID",
     });
     expect(capturedTransform).toEqual({
-      anim: true,
+      anim: false,
       fit: "scale-down",
+      format: "jpeg",
       height: 1600,
       metadata: "none",
       quality: 85,

--- a/packages/convex/__tests__/card/uploadCard.test.ts
+++ b/packages/convex/__tests__/card/uploadCard.test.ts
@@ -43,6 +43,19 @@ describe("worker-backed card upload finalization", () => {
     ).toThrow("Uploaded file key does not belong to the current user");
   });
 
+  test("normalizes weak Cloudflare ETags before finalization", () => {
+    const fileKey = buildR2ObjectKey({ userId, role: "file" });
+    expect(
+      validateFinalizeUpload(userId, {
+        fileEtag: 'W/"etag-1"',
+        fileKey,
+        fileName: "photo.png",
+        fileSize: 128,
+        fileType: "image/png",
+      }).fileEtag
+    ).toBe('"etag-1"');
+  });
+
   test("rejects malformed etags and oversized files before storage work", () => {
     const fileKey = buildR2ObjectKey({ userId, role: "file" });
     expect(() =>

--- a/packages/convex/card/uploadCardAction.ts
+++ b/packages/convex/card/uploadCardAction.ts
@@ -85,6 +85,7 @@ export const validateFinalizeUpload = (
   userId: string,
   args: FinalizeArgs
 ): {
+  fileEtag?: string;
   fileName: string;
   markdown: boolean;
   requestedMimeType?: string;
@@ -104,9 +105,12 @@ export const validateFinalizeUpload = (
       "Uploaded file key does not belong to the current user"
     );
   }
+  const fileEtag = args.fileEtag?.startsWith("W/")
+    ? args.fileEtag.slice(2)
+    : args.fileEtag;
   if (
-    args.fileEtag !== undefined &&
-    !/^"?[A-Za-z0-9+/=_-]{1,128}"?$/u.test(args.fileEtag)
+    fileEtag !== undefined &&
+    !/^"?[A-Za-z0-9+/=_-]{1,128}"?$/u.test(fileEtag)
   ) {
     return throwUploadError("INVALID_INPUT", "Uploaded file ETag is invalid");
   }
@@ -132,7 +136,7 @@ export const validateFinalizeUpload = (
     }
     throw error;
   }
-  return { fileName, markdown, requestedMimeType };
+  return { fileEtag, fileName, markdown, requestedMimeType };
 };
 
 const finalizeForUser = async (
@@ -154,7 +158,7 @@ const finalizeForUser = async (
     op: "finalize-upload",
     params: {
       destinationKey,
-      expectedEtag: args.fileEtag,
+      expectedEtag: validated.fileEtag,
       expectedSize: args.fileSize,
       readText: validated.markdown,
       sourceKey: args.fileKey,


### PR DESCRIPTION
## Summary
- normalize Cloudflare weak ETags before upload finalization
- convert private image detail renditions to a model-safe JPEG before Workers AI analysis
- add focused regressions and user-facing release notes

## Verification
- bun test apps/files-worker/src/upload.test.ts packages/convex/__tests__/card/uploadCard.test.ts
- bun run typecheck
- bun run lint
- pre-commit affected typecheck, lint, and build