### PR TITLE
Test documented API delete response

### DIFF
--- a/packages/tests/src/journey/12-file-roundtrip.e2e.ts
+++ b/packages/tests/src/journey/12-file-roundtrip.e2e.ts
@@ -97,7 +97,7 @@ test("REST file upload round-trips through the Files Worker and deletion is dura
   const deleted = await apiFetch(`/v1/cards/${cardId}`, apiKey, {
     method: "DELETE",
   });
-  expect(deleted.status).toBe(200);
+  expect(deleted.status).toBe(204);
 
   await expect
     .poll(async () => {


### PR DESCRIPTION
## Summary
- align the file round-trip production journey with the documented 204 delete response

## Verification
- bun run --cwd packages/tests typecheck
- bun run --cwd packages/tests lint