### PR TITLE
Use a valid Cloudflare image AI canary

### DIFF
--- a/packages/tests/src/journey/03-api.e2e.ts
+++ b/packages/tests/src/journey/03-api.e2e.ts
@@ -199,7 +199,7 @@ test("private image originals and Cloudflare renditions share one API contract",
   const apiKey = requireServiceApiKey("api");
   const fileName = `api-image-${Date.now()}.png`;
   const bytes = Buffer.from(
-    "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAg0lEQVR4nO3RQQkAMAwEwciJfz0VUxF9DIWFE5DMztn9esMv6AFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWAFNWIH1ii+785PBD68iABwAAAAASUVORK5CYII=",
+    "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAAnklEQVRoge2SUQkAQBSDFsf+eRbmQtyHPBgYwMlSOE10g24AesXuQtwlukE3AL1idyHuEt2gG4BesbsQd4lu0A1Ar9hdiLtEN+gGoFfsLsRdoht0A9ArdhfiLtENugHoFbsLcZfoBt0A9IrdhbhLdINuAHrF7kLcJbpBNwC9Ynch7hLdoBuAXrG7EHeJbtANQK/YXYi7RDfoBqBX/OEB85PBD8A6yIQAAAAASUVORK5CYII=",
     "base64"
   );
   const prepared = await apiFetch("/v1/uploads", apiKey, {


### PR DESCRIPTION
## Summary
- replace the malformed production image-AI fixture with a valid 64×64 PNG

## Verification
- decoded fixture with sharp as PNG 64×64
- replayed the exact bytes through production signed upload, image analysis, Workers AI metadata, and deletion; all returned 200
- bun run --cwd packages/tests typecheck
- bun run --cwd packages/tests lint