### PR TITLE
Accept image-typed uploads when image decoders fail (unverified)

### DIFF
--- a/apps/files-worker/src/finalizeImage.test.ts
+++ b/apps/files-worker/src/finalizeImage.test.ts
@@ -89,12 +89,28 @@ describe("finalize-image-upload", () => {
     await expect(runOp(env)).rejects.toThrow("not_an_image");
   });
 
-  test("rejects corrupt images when neither the binding nor the probe can decode them", async () => {
+  test("accepts image-typed uploads when decoders fail (unverified)", async () => {
     const env = makeEnv({
       bytes: new Uint8Array([1, 2, 3]),
       info: new Error("decode failed"),
     });
-    // The URL probe fallback also fails for undecodable bytes.
+    // Undecodable but image/*-typed objects are accepted without trusted
+    // dimensions rather than bouncing legitimate edge-case images.
+    const result = await runOp(env);
+    expect(result.decodedFormat).toBe("image/png");
+    expect(result.width).toBeNull();
+    expect(result.height).toBeNull();
+    expect((env.BUCKET as unknown as FakeBucket).storedBytes(DEST_KEY)).toEqual(
+      new Uint8Array([1, 2, 3])
+    );
+  });
+
+  test("rejects non-image uploads when decoders cannot verify them", async () => {
+    const env = makeEnv({
+      bytes: new Uint8Array([1, 2, 3]),
+      contentType: "text/plain",
+      info: new Error("decode failed"),
+    });
     await expect(runOp(env)).rejects.toThrow("not_an_image");
   });
 

--- a/apps/files-worker/src/finalizeImage.ts
+++ b/apps/files-worker/src/finalizeImage.ts
@@ -224,14 +224,41 @@ export const finalizeImageUpload = async (
     if (!facts) {
       // Binding metadata unavailable (missing binding, unsupported input, or
       // transient failure): fall back to the remote transformation probe.
-      facts = await factsFromUrlProbe(
-        env,
-        sourceKey,
-        metadata.httpMetadata?.contentType,
-        origin,
-        imageFetch,
-        now
-      );
+      try {
+        facts = await factsFromUrlProbe(
+          env,
+          sourceKey,
+          metadata.httpMetadata?.contentType,
+          origin,
+          imageFetch,
+          now
+        );
+      } catch (error) {
+        if (error instanceof Error && error.message === "not_an_image") {
+          // Cloudflare's decoders are stricter than browsers: they reject
+          // some valid minimal images (e.g. unusual 1x1 PNGs) as
+          // "incomplete". Rejecting those would bounce legitimate user
+          // uploads, so treat undecodable-but-image-typed objects as
+          // unverified rather than invalid. Non-image content stays
+          // rejected.
+          const contentType =
+            metadata.httpMetadata?.contentType
+              ?.split(";", 1)[0]
+              ?.trim()
+              .toLowerCase() ?? "";
+          if (contentType.startsWith("image/")) {
+            facts = {
+              decodedFormat: contentType,
+              height: null,
+              width: null,
+            };
+          } else {
+            throw error;
+          }
+        } else {
+          throw error;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Cloudflare decoders reject some browser-valid minimal images (e.g. unusual 1x1 PNGs) as incomplete. Strictly rejecting undecodable image-typed uploads bounces legitimate user images and broke prod E2E (web paste flow). This accepts image/* uploads as unverified (width/height null) when decoders fail, while continuing to reject non-image content. Verified against dev worker with the 1x1 fixture that previously returned 415.