### PR TITLE
Make image and video grids faster and resilient

### DIFF
--- a/.github/workflows/prod-e2e.yml
+++ b/.github/workflows/prod-e2e.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile --filter @teak/tests --filter teak-cli --filter @teak/convex
-      - run: bun run build:cli
+      - run: bun --filter teak-cli run build
       - run: npm install --prefix "$RUNNER_TEMP/teak-npm" teak-cli@latest
       - run: bunx playwright install --with-deps --only-shell chromium
       - run: bun run --cwd packages/tests e2e:prod:journey

--- a/apps/docs/content/changelog/august-2026.mdx
+++ b/apps/docs/content/changelog/august-2026.mdx
@@ -8,7 +8,7 @@ changelog:
 ---
 
 - Image and video cards now load noticeably faster, with your library reusing what it has already downloaded instead of fetching everything again.
-- Small cards and mobile grids now use lighter previews, and images show a quick placeholder while their preview loads.
+- Image-heavy libraries now open with fewer requests, recover a failed preview without reloading the page, and keep video files idle until you interact with them.
 - Image uploads are now verified before saving, so broken or mislabeled image files are rejected with a clear error instead of creating a card that never shows a preview.
 - iPhone photos and SVG graphics now prepare their previews and colors at the edge, so new cards finish processing noticeably sooner.
 - Large image cards gain a mid-size preview, so opening a card no longer downloads the full original.

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -25,6 +25,8 @@ export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        <link href="//files.teakvault.com" rel="dns-prefetch" />
+        <link href="https://files.teakvault.com" rel="preconnect" />
         <JsonLd
           schema={[
             organizationSchema,

--- a/packages/convex/__tests__/card/getFileUrl.test.ts
+++ b/packages/convex/__tests__/card/getFileUrl.test.ts
@@ -4,10 +4,14 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 const resolveObjectUrlMock = mock((key?: string) =>
   Promise.resolve(key ? "https://file" : null)
 );
+const resolveImageUrlMock = mock((key?: string, rendition?: string) =>
+  Promise.resolve(key && rendition ? `https://file/${rendition}` : null)
+);
 
 mock.module("../../storage/r2", () => ({
   deleteObject: mock(() => Promise.resolve()),
   resolveObjectUrl: resolveObjectUrlMock,
+  resolveImageUrl: resolveImageUrlMock,
 }));
 
 describe("card/getFileUrl.ts", () => {
@@ -44,5 +48,55 @@ describe("card/getFileUrl.ts", () => {
     const result = await handler(ctx, { key: "f1", cardId: "c1" });
     expect(result).toBe("https://file");
     expect(resolveObjectUrlMock).toHaveBeenCalledWith("f1", "payload.html");
+  });
+
+  test("refreshes an authorized image rendition", async () => {
+    const refreshCardMediaUrl = (await import("../../card/getFileUrl"))
+      .refreshCardMediaUrl;
+    const handler = (refreshCardMediaUrl as any).handler ?? refreshCardMediaUrl;
+    const ctx = {
+      runQuery: mock().mockResolvedValue({ fileName: null }),
+    } as any;
+
+    await expect(
+      handler(ctx, { cardId: "c1", key: "f1", rendition: "grid" })
+    ).resolves.toEqual({ url: "https://file/grid" });
+    expect(resolveImageUrlMock).toHaveBeenCalledWith("f1", "grid");
+  });
+
+  test("rejects a refresh when the media is not authorized", async () => {
+    const refreshCardMediaUrl = (await import("../../card/getFileUrl"))
+      .refreshCardMediaUrl;
+    const handler = (refreshCardMediaUrl as any).handler ?? refreshCardMediaUrl;
+    const ctx = { runQuery: mock().mockResolvedValue(null) } as any;
+
+    await expect(
+      handler(ctx, { cardId: "c1", key: "not-owned", rendition: "grid" })
+    ).rejects.toThrow("Unauthorized media refresh");
+  });
+
+  test("grid hydration omits original, detail, and tiny image URLs", async () => {
+    resolveObjectUrlMock.mockClear();
+    const { attachGridFileUrls } = await import("../../card/queryUtils");
+    const [card] = await attachGridFileUrls({} as any, [
+      {
+        _id: "c-grid",
+        _creationTime: 1,
+        userId: "u1",
+        type: "image",
+        fileKey: "image-key",
+        content: "Grid image",
+        isDeleted: undefined,
+        createdAt: 1,
+        updatedAt: 1,
+      } as any,
+    ]);
+
+    expect(card?.fileUrl).toBeUndefined();
+    expect(card?.detailUrl).toBeUndefined();
+    expect(card?.placeholderUrl).toBeUndefined();
+    expect(card?.compactUrl).toBe("https://file/compact");
+    expect(card?.thumbnailUrl).toBe("https://file/grid");
+    expect(resolveObjectUrlMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/convex/__tests__/shared/search/mediaPageSize.test.ts
+++ b/packages/convex/__tests__/shared/search/mediaPageSize.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+import { SEARCH_DEFAULT_CARD_LIMIT } from "../../../shared/search/constants";
+
+describe("media grid page size", () => {
+  test("bounds the initial media request fan-out", () => {
+    expect(SEARCH_DEFAULT_CARD_LIMIT).toBe(30);
+  });
+});

--- a/packages/convex/__tests__/workflows/steps/renderables.test.ts
+++ b/packages/convex/__tests__/workflows/steps/renderables.test.ts
@@ -334,6 +334,31 @@ describe("renderables step", () => {
       expect(result.thumbnailGenerated).toBe(false);
     });
 
+    test("throws retryable video thumbnail failures to the workflow", async () => {
+      const mockCtx = {
+        runQuery: createMockFn<[any, any], any>(async () => ({
+          _id: "vid-retry",
+          type: "video",
+          fileKey: "retry-file",
+          processingStatus: {},
+        })),
+        runAction: createMockFn<[any, any], any>(async () => ({
+          success: false,
+          generated: false,
+          error: "kernel_execution_failed",
+          retryable: true,
+        })),
+        runMutation: createMockFn<[any, any], null>(async () => null),
+      };
+
+      await expect(
+        generateHandler(mockCtx, {
+          cardId: "vid-retry",
+          cardType: "video",
+        })
+      ).rejects.toThrow("video_thumbnail_retryable:kernel_execution_failed");
+    });
+
     test("skips video thumbnail when no fileKey", async () => {
       const runMutation = createMockFn<[any, any], null>(async () => null);
       const mockCtx = {

--- a/packages/convex/card/getCards.ts
+++ b/packages/convex/card/getCards.ts
@@ -11,6 +11,7 @@ import {
 import {
   attachCardSummaryUrls,
   attachFileUrls,
+  attachGridFileUrls,
   ensureValidRange,
   isCreatedAtInRange,
 } from "./queryUtils";
@@ -468,11 +469,14 @@ type SearchCardsPaginatedArgs = Infer<typeof searchCardsPaginatedArgsValidator>;
 export const searchCardsPaginatedHandler = async (
   ctx: QueryCtx,
   args: SearchCardsPaginatedArgs,
-  options: { summariesOnly?: boolean } = {}
+  options: { gridOnly?: boolean; summariesOnly?: boolean } = {}
 ) => {
-  const attachListUrls = options.summariesOnly
-    ? attachCardSummaryUrls
-    : attachFileUrls;
+  let attachListUrls = attachFileUrls;
+  if (options.summariesOnly) {
+    attachListUrls = attachCardSummaryUrls;
+  } else if (options.gridOnly) {
+    attachListUrls = attachGridFileUrls;
+  }
   const user = await ctx.auth.getUserIdentity();
   if (!user) {
     return { page: [], isDone: true, continueCursor: null };
@@ -809,5 +813,6 @@ export const searchCardsPaginatedHandler = async (
 export const searchCardsPaginated = query({
   args: searchCardsPaginatedArgsValidator.fields,
   returns: paginationResultValidator,
-  handler: (ctx, args) => searchCardsPaginatedHandler(ctx, args),
+  handler: (ctx, args) =>
+    searchCardsPaginatedHandler(ctx, args, { gridOnly: true }),
 });

--- a/packages/convex/card/getFileUrl.ts
+++ b/packages/convex/card/getFileUrl.ts
@@ -1,6 +1,39 @@
+import type { FilesImageRendition } from "@teak/files-protocol";
 import { v } from "convex/values";
-import { query } from "../_generated/server";
-import { resolveObjectUrl } from "../storage/r2";
+import { internal } from "../_generated/api";
+import { action, internalQuery, query } from "../_generated/server";
+import { resolveImageUrl, resolveObjectUrl } from "../storage/r2";
+
+const mediaRenditionValidator = v.union(
+  v.literal("tiny"),
+  v.literal("compact"),
+  v.literal("grid"),
+  v.literal("detail")
+);
+
+const cardOwnsMediaKey = (
+  card: {
+    fileKey?: string;
+    thumbnailKey?: string;
+    metadata?: {
+      linkPreview?: {
+        imageStorageKey?: string;
+        screenshotStorageKey?: string;
+        media?: Array<{ storageKey?: string; posterStorageKey?: string }>;
+      };
+    };
+  },
+  key: string
+): boolean =>
+  card.fileKey === key ||
+  card.thumbnailKey === key ||
+  card.metadata?.linkPreview?.screenshotStorageKey === key ||
+  card.metadata?.linkPreview?.imageStorageKey === key ||
+  Boolean(
+    card.metadata?.linkPreview?.media?.some(
+      (item) => item.storageKey === key || item.posterStorageKey === key
+    )
+  );
 
 export const getFileUrl = query({
   args: {
@@ -23,17 +56,7 @@ export const getFileUrl = query({
       throw new Error("Unauthorized access to file");
     }
 
-    const matchesFile =
-      card.fileKey === args.key ||
-      card.thumbnailKey === args.key ||
-      card.metadata?.linkPreview?.screenshotStorageKey === args.key ||
-      card.metadata?.linkPreview?.imageStorageKey === args.key ||
-      card.metadata?.linkPreview?.media?.some(
-        (item) =>
-          item.storageKey === args.key || item.posterStorageKey === args.key
-      );
-
-    if (!matchesFile) {
+    if (!cardOwnsMediaKey(card, args.key)) {
       throw new Error("File does not belong to the specified card");
     }
 
@@ -43,5 +66,58 @@ export const getFileUrl = query({
         ? (card.fileMetadata?.fileName ?? null)
         : undefined
     );
+  },
+});
+
+export const getAuthorizedMedia = internalQuery({
+  args: { key: v.string(), cardId: v.id("cards") },
+  returns: v.union(
+    v.object({ fileName: v.union(v.string(), v.null()) }),
+    v.null()
+  ),
+  handler: async (ctx, args) => {
+    const user = await ctx.auth.getUserIdentity();
+    if (!user) {
+      throw new Error("Unauthenticated media refresh");
+    }
+    const card = await ctx.db.get("cards", args.cardId);
+    if (!(card && card.userId === user.subject)) {
+      return null;
+    }
+    if (!cardOwnsMediaKey(card, args.key)) {
+      throw new Error("File does not belong to the specified card");
+    }
+    return {
+      fileName:
+        card.fileKey === args.key
+          ? (card.fileMetadata?.fileName ?? null)
+          : null,
+    };
+  },
+});
+
+/** Mint a fresh signed URL after a browser-visible media request fails. */
+export const refreshCardMediaUrl = action({
+  args: {
+    key: v.string(),
+    cardId: v.id("cards"),
+    rendition: v.optional(mediaRenditionValidator),
+  },
+  returns: v.object({ url: v.string() }),
+  handler: async (ctx, args): Promise<{ url: string }> => {
+    const media: { fileName: string | null } | null = await ctx.runQuery(
+      (internal as any).card.getFileUrl.getAuthorizedMedia,
+      { cardId: args.cardId, key: args.key }
+    );
+    if (!media) {
+      throw new Error("Unauthorized media refresh");
+    }
+    const url: string | null = args.rendition
+      ? await resolveImageUrl(args.key, args.rendition as FilesImageRendition)
+      : await resolveObjectUrl(args.key, media.fileName);
+    if (!url) {
+      throw new Error("Media URL unavailable");
+    }
+    return { url };
   },
 });

--- a/packages/convex/card/queryUtils.ts
+++ b/packages/convex/card/queryUtils.ts
@@ -60,7 +60,8 @@ const resolveImageRenditions = async (
 
 export const attachFileUrls = async (
   _ctx: any,
-  cards: Doc<"cards">[]
+  cards: Doc<"cards">[],
+  options: { gridOnly?: boolean } = {}
 ): Promise<CardWithUrls[]> => {
   const storageKeys = new Set<string>();
   const gridImageKeys = new Set<string>();
@@ -86,16 +87,16 @@ export const attachFileUrls = async (
   for (const card of cards) {
     const ids: CardStorageIds = {};
     if (card.fileKey) {
-      storageKeys.add(card.fileKey);
+      if (!(options.gridOnly && card.type === "image")) {
+        storageKeys.add(card.fileKey);
+      }
       ids.fileKey = card.fileKey;
     }
     if (card.thumbnailKey) {
-      storageKeys.add(card.thumbnailKey);
       gridImageKeys.add(card.thumbnailKey);
       ids.thumbnailKey = card.thumbnailKey;
     }
     if (card.metadata?.linkPreview?.imageStorageKey) {
-      storageKeys.add(card.metadata.linkPreview.imageStorageKey);
       gridImageKeys.add(card.metadata.linkPreview.imageStorageKey);
       ids.linkPreviewImageKey = card.metadata.linkPreview.imageStorageKey;
     }
@@ -104,9 +105,10 @@ export const attachFileUrls = async (
         if (!item.storageKey) {
           return null;
         }
-        storageKeys.add(item.storageKey);
+        if (item.type === "video") {
+          storageKeys.add(item.storageKey);
+        }
         if (item.posterStorageKey) {
-          storageKeys.add(item.posterStorageKey);
           gridImageKeys.add(item.posterStorageKey);
         }
         if (item.type === "image") {
@@ -129,7 +131,6 @@ export const attachFileUrls = async (
       ids.linkPreviewMedia = hydratedMedia;
     }
     if (card.metadata?.linkPreview?.screenshotStorageKey) {
-      storageKeys.add(card.metadata.linkPreview.screenshotStorageKey);
       gridImageKeys.add(card.metadata.linkPreview.screenshotStorageKey);
       ids.screenshotKey = card.metadata.linkPreview.screenshotStorageKey;
     }
@@ -169,12 +170,12 @@ export const attachFileUrls = async (
         }
         return [
           card._id,
-          await resolveImageRenditions(fileKey, [
-            "compact",
-            "detail",
-            "tiny",
-            "grid",
-          ]),
+          await resolveImageRenditions(
+            fileKey,
+            options.gridOnly
+              ? ["compact", "grid"]
+              : ["compact", "detail", "tiny", "grid"]
+          ),
         ] as const;
       })
     )
@@ -216,7 +217,10 @@ export const attachFileUrls = async (
     const imageUrls = imageRenditions.get(card._id);
     return {
       ...card,
-      fileUrl: ids.fileKey ? (urlMap.get(ids.fileKey) ?? undefined) : undefined,
+      fileUrl:
+        ids.fileKey && !(options.gridOnly && card.type === "image")
+          ? (urlMap.get(ids.fileKey) ?? undefined)
+          : undefined,
       detailUrl: imageUrls?.detail ?? undefined,
       thumbnailUrl:
         imageUrls?.grid ??
@@ -235,6 +239,11 @@ export const attachFileUrls = async (
     };
   });
 };
+
+export const attachGridFileUrls = async (
+  ctx: unknown,
+  cards: Doc<"cards">[]
+): Promise<CardWithUrls[]> => attachFileUrls(ctx, cards, { gridOnly: true });
 
 export const attachCardSummaryUrls = async (
   _ctx: unknown,

--- a/packages/convex/shared/search/constants.ts
+++ b/packages/convex/shared/search/constants.ts
@@ -1,4 +1,4 @@
-export const SEARCH_DEFAULT_CARD_LIMIT = 100;
+export const SEARCH_DEFAULT_CARD_LIMIT = 30;
 export const SEARCH_LOCAL_SEARCH_CACHE_LIMIT = 1000;
 
 /**

--- a/packages/convex/workflows/cardProcessing.ts
+++ b/packages/convex/workflows/cardProcessing.ts
@@ -266,16 +266,36 @@ export const cardProcessingWorkflow: any = workflow.define({
     // palette extraction and vision metadata.
     let metadataResult: any = null;
     let renderablesResult: any = null;
+    const runRenderablesStep = async () => {
+      try {
+        return await timeStage("renderables", classification.type, () =>
+          step.runAction(
+            internalWorkflow["workflows/steps/renderables"].generate,
+            { cardId, cardType: classification.type },
+            { retry: RENDERABLES_STEP_RETRY }
+          )
+        );
+      } catch (error) {
+        console.error(`${PIPELINE_LOG_PREFIX} Renderables exhausted retries`, {
+          cardId,
+          error,
+        });
+        await step.runMutation(
+          internalWorkflow["workflows/steps/renderables/mutations"]
+            .markCardRenderablesFailed,
+          { cardId, error: "thumbnail_generation_failed" }
+        );
+        return {
+          mode: "completed" as const,
+          success: false,
+          thumbnailGenerated: false,
+        };
+      }
+    };
 
     if (["image", "video"].includes(classification.type)) {
       renderablesResult = classification.shouldGenerateRenderables
-        ? await timeStage("renderables", classification.type, () =>
-            step.runAction(
-              internalWorkflow["workflows/steps/renderables"].generate,
-              { cardId, cardType: classification.type },
-              { retry: RENDERABLES_STEP_RETRY }
-            )
-          )
+        ? await runRenderablesStep()
         : null;
 
       if (classification.type === "image") {
@@ -320,13 +340,7 @@ export const cardProcessingWorkflow: any = workflow.define({
         : Promise.resolve(null);
 
       const renderablesPromise = classification.shouldGenerateRenderables
-        ? timeStage("renderables", classification.type, () =>
-            step.runAction(
-              internalWorkflow["workflows/steps/renderables"].generate,
-              { cardId, cardType: classification.type },
-              { retry: RENDERABLES_STEP_RETRY }
-            )
-          )
+        ? runRenderablesStep()
         : Promise.resolve(null);
 
       [metadataResult, renderablesResult] = await Promise.all([

--- a/packages/convex/workflows/steps/renderables.ts
+++ b/packages/convex/workflows/steps/renderables.ts
@@ -71,6 +71,7 @@ export async function generateHandler(
     success: boolean;
     generated: boolean;
     error?: string;
+    retryable?: boolean;
   }) => {
     if (!result.success) {
       renderablesSucceeded = false;
@@ -110,6 +111,11 @@ export async function generateHandler(
         .generateVideoThumbnail,
       { cardId }
     );
+    if (!result.success && result.retryable) {
+      throw new Error(
+        `video_thumbnail_retryable:${result.error ?? "thumbnail_generation_failed"}`
+      );
+    }
     handleResult(result);
   }
 

--- a/packages/convex/workflows/steps/renderables/generateVideoThumbnail.ts
+++ b/packages/convex/workflows/steps/renderables/generateVideoThumbnail.ts
@@ -30,6 +30,7 @@ export const generateVideoThumbnail = internalAction({
     generated: v.boolean(),
     thumbnailKey: v.optional(v.string()),
     error: v.optional(v.string()),
+    retryable: v.optional(v.boolean()),
   }),
   handler: async (ctx, args) => {
     try {
@@ -44,6 +45,7 @@ export const generateVideoThumbnail = internalAction({
           success: false,
           generated: false,
           error: "card_not_found",
+          retryable: false,
         };
       }
 
@@ -79,6 +81,7 @@ export const generateVideoThumbnail = internalAction({
           success: false,
           generated: false,
           error: "missing_storage_url",
+          retryable: true,
         };
       }
 
@@ -257,6 +260,7 @@ export const generateVideoThumbnail = internalAction({
             success: false,
             generated: false,
             error: "kernel_execution_failed",
+            retryable: true,
           };
         }
 
@@ -271,6 +275,10 @@ export const generateVideoThumbnail = internalAction({
             success: false,
             generated: false,
             error: result.error || "thumbnail_generation_failed",
+            retryable:
+              typeof result.error === "string" &&
+              (result.error.includes("timeout") ||
+                result.error.startsWith("upload_failed_")),
           };
         }
 
@@ -292,6 +300,7 @@ export const generateVideoThumbnail = internalAction({
             success: false,
             generated: false,
             error: "thumbnail_upload_verification_failed",
+            retryable: true,
           };
         }
 
@@ -343,6 +352,7 @@ export const generateVideoThumbnail = internalAction({
         success: false,
         generated: false,
         error: error instanceof Error ? error.message : "unknown_error",
+        retryable: true,
       };
     }
   },

--- a/packages/convex/workflows/steps/renderables/mutations.ts
+++ b/packages/convex/workflows/steps/renderables/mutations.ts
@@ -1,6 +1,31 @@
 import { v } from "convex/values";
 import { internalMutation } from "../../../_generated/server";
+import { stageFailed } from "../../../card/processingStatus";
 import { filePreviewFactsValidator } from "../../../schema";
+
+export const markCardRenderablesFailed = internalMutation({
+  args: { cardId: v.id("cards"), error: v.string() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const card = await ctx.db.get("cards", args.cardId);
+    if (!card) {
+      return null;
+    }
+    const now = Date.now();
+    await ctx.db.patch("cards", args.cardId, {
+      processingStatus: {
+        ...(card.processingStatus ?? {}),
+        renderables: stageFailed(
+          now,
+          args.error,
+          card.processingStatus?.renderables
+        ),
+      },
+      updatedAt: now,
+    });
+    return null;
+  },
+});
 
 /**
  * Update only the fileMetadata dimensions (width/height) for a card.

--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -413,12 +413,21 @@ test("web uploads and paste-created files complete", async ({
   await page.goto("/");
   const compactPath = new URL(uploadedImage?.compactUrl ?? "").pathname;
   const placeholderPath = new URL(uploadedImage?.placeholderUrl ?? "").pathname;
-  await expect(page.locator(`main img[src*="${compactPath}"]`)).toBeVisible({
+  const uploadedPreview = page
+    .locator(`main img[srcset*="${compactPath}"]`)
+    .first();
+  await expect(uploadedPreview).toBeVisible({
     timeout: 30_000,
   });
-  await expect(
-    page.locator(`main img[src*="${placeholderPath}"]`)
-  ).toBeAttached();
+  await expect(uploadedPreview).toHaveJSProperty("complete", true);
+  expect(
+    await uploadedPreview.evaluate(
+      (image) => (image as HTMLImageElement).naturalWidth
+    )
+  ).toBeGreaterThan(0);
+  await expect(page.locator(`main img[src*="${placeholderPath}"]`)).toHaveCount(
+    0
+  );
 });
 
 test("web bulk actions, restore, and empty states stay coherent", async ({

--- a/packages/ui/src/components/card-modal/ConnectedCardModal.tsx
+++ b/packages/ui/src/components/card-modal/ConnectedCardModal.tsx
@@ -40,7 +40,7 @@ export function ConnectedCardModal({
   const [showNotesEditModal, setShowNotesEditModal] = useState(false);
   const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
   const canHydrateCard = Boolean(
-    cardId && !cardData && !isAuthLoading && isAuthenticated
+    cardId && open && !isAuthLoading && isAuthenticated
   );
 
   const hydratedCard = useQuery(
@@ -48,7 +48,7 @@ export function ConnectedCardModal({
     canHydrateCard ? { id: cardId as string } : "skip"
   );
 
-  const resolvedCard = cardData ?? hydratedCard ?? null;
+  const resolvedCard = hydratedCard ?? cardData ?? null;
 
   const setTagManagementModalOpen = useCallback(
     (nextOpen: boolean) => {

--- a/packages/ui/src/components/cards/Card.tsx
+++ b/packages/ui/src/components/cards/Card.tsx
@@ -1,3 +1,5 @@
+import { api } from "@teak/convex";
+import type { Id } from "@teak/convex/_generated/dataModel";
 import { inferFileFormat } from "@teak/convex/shared/file-formats";
 import { sanitizeExternalUrl } from "@teak/convex/shared/utils/safeUrl";
 import { CardContent, Card as UICard } from "@teak/ui/components/ui/card";
@@ -9,6 +11,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@teak/ui/components/ui/context-menu";
+import { useAction } from "convex/react";
 import {
   CheckSquare,
   Copy,
@@ -35,6 +38,34 @@ import { isOptimisticCard } from "./types";
 
 export type { CardProps, CardWithUrls, LinkPreviewMetadata } from "./types";
 
+export async function resolveImageCopyUrl({
+  cardId,
+  fallbackUrl,
+  fileKey,
+  refresh,
+}: {
+  cardId: string;
+  fallbackUrl: string;
+  fileKey?: string;
+  refresh: (args: {
+    cardId: Id<"cards">;
+    key: string;
+  }) => Promise<{ url: string }>;
+}): Promise<string> {
+  if (!fileKey) {
+    return fallbackUrl;
+  }
+  try {
+    const { url } = await refresh({
+      cardId: cardId as Id<"cards">,
+      key: fileKey,
+    });
+    return url;
+  } catch {
+    return fallbackUrl;
+  }
+}
+
 export const Card = memo(function Card({
   card,
   onClick,
@@ -50,6 +81,9 @@ export const Card = memo(function Card({
   onEnterSelectionMode,
   onToggleSelection,
 }: CardProps) {
+  const refreshCardMediaUrl = useAction(
+    api.card.getFileUrl.refreshCardMediaUrl
+  );
   const isOptimistic = isOptimisticCard(card._id);
   const fileName = card.fileMetadata?.fileName;
   const fileFormat =
@@ -126,7 +160,7 @@ export const Card = memo(function Card({
     onAddTags?.(card._id);
   };
 
-  const handleCopyImage = () => {
+  const handleCopyImage = async () => {
     if (isOptimistic) {
       return;
     }
@@ -134,7 +168,13 @@ export const Card = memo(function Card({
     let isImage = false;
     if (card.type === "image") {
       isImage = true;
-      contentToCopy = card.fileUrl ?? card.thumbnailUrl ?? "";
+      const fallbackUrl = card.fileUrl ?? card.thumbnailUrl ?? "";
+      contentToCopy = await resolveImageCopyUrl({
+        cardId: card._id,
+        fallbackUrl,
+        fileKey: card.fileKey,
+        refresh: refreshCardMediaUrl,
+      });
     } else if (card.type === "text") {
       contentToCopy = card.content ?? "";
     } else if (card.type === "link" && card.url) {
@@ -506,7 +546,7 @@ export const Card = memo(function Card({
             card.type === "link" ||
             (card.type === "image" &&
               card.fileMetadata?.mimeType !== "image/svg+xml")) && (
-            <ContextMenuItem onClick={handleCopyImage}>
+            <ContextMenuItem onClick={() => void handleCopyImage()}>
               <Copy />
               {copyMenuLabel}
             </ContextMenuItem>

--- a/packages/ui/src/components/cards/Card.tsx
+++ b/packages/ui/src/components/cards/Card.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react";
 import type { SyntheticEvent } from "react";
 import { memo, useState } from "react";
+import { toast } from "sonner";
 import { markdownToPlainText } from "../../lib/markdownToPlainText";
 import { prefetchCardModalMedia } from "../../lib/prefetchCardMedia";
 import { prefetchFileTextPreview } from "../card-previews/fileTextPreviewCache";
@@ -55,15 +56,11 @@ export async function resolveImageCopyUrl({
   if (!fileKey) {
     return fallbackUrl;
   }
-  try {
-    const { url } = await refresh({
-      cardId: cardId as Id<"cards">,
-      key: fileKey,
-    });
-    return url;
-  } catch {
-    return fallbackUrl;
-  }
+  const { url } = await refresh({
+    cardId: cardId as Id<"cards">,
+    key: fileKey,
+  });
+  return url;
 }
 
 export const Card = memo(function Card({
@@ -169,12 +166,17 @@ export const Card = memo(function Card({
     if (card.type === "image") {
       isImage = true;
       const fallbackUrl = card.fileUrl ?? card.thumbnailUrl ?? "";
-      contentToCopy = await resolveImageCopyUrl({
-        cardId: card._id,
-        fallbackUrl,
-        fileKey: card.fileKey,
-        refresh: refreshCardMediaUrl,
-      });
+      try {
+        contentToCopy = await resolveImageCopyUrl({
+          cardId: card._id,
+          fallbackUrl,
+          fileKey: card.fileKey,
+          refresh: refreshCardMediaUrl,
+        });
+      } catch {
+        toast.error("Failed to copy image");
+        return;
+      }
     } else if (card.type === "text") {
       contentToCopy = card.content ?? "";
     } else if (card.type === "link" && card.url) {

--- a/packages/ui/src/components/cards/Card.tsx
+++ b/packages/ui/src/components/cards/Card.tsx
@@ -9,7 +9,6 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@teak/ui/components/ui/context-menu";
-import { Image } from "antd";
 import {
   CheckSquare,
   Copy,
@@ -30,6 +29,7 @@ import { AudioWavePreview } from "./previews/AudioWavePreview";
 import { GridDocumentPreview } from "./previews/GridDocumentPreview";
 import { GridImagePreview } from "./previews/GridImagePreview";
 import { GridVideoPreview } from "./previews/GridVideoPreview";
+import { ResilientMediaImage } from "./previews/ResilientMediaImage";
 import type { CardProps, LinkPreviewMetadata } from "./types";
 import { isOptimisticCard } from "./types";
 
@@ -163,6 +163,9 @@ export const Card = memo(function Card({
     card.metadata?.linkPreview?.status === "success"
       ? (card.metadata.linkPreview as LinkPreviewMetadata)
       : undefined;
+  const storedLinkMedia = Array.isArray(card.metadata?.linkPreview?.media)
+    ? (card.metadata.linkPreview.media as Record<string, unknown>[])
+    : [];
   const linkCardTitle =
     linkPreview?.title || card.metadataTitle || card.url || "Link";
   const primaryAttachedMedia =
@@ -174,6 +177,18 @@ export const Card = memo(function Card({
     primaryAttachedMedia?.type === "image"
       ? primaryAttachedMedia.url
       : (primaryAttachedMedia?.posterUrl ?? card.linkPreviewImageUrl);
+  const primaryStoredMedia =
+    storedLinkMedia.find((item) => item.type === "image") ??
+    storedLinkMedia.find(
+      (item) =>
+        item.type === "video" && typeof item.posterStorageKey === "string"
+    );
+  const primaryLinkImageKey =
+    primaryStoredMedia?.type === "image"
+      ? primaryStoredMedia.storageKey
+      : (primaryStoredMedia?.posterStorageKey ??
+        card.metadata?.linkPreview?.imageStorageKey);
+  const screenshotStorageKey = card.metadata?.linkPreview?.screenshotStorageKey;
   const resolvedScreenshotUrl =
     typeof card.screenshotUrl === "string" ? card.screenshotUrl : undefined;
   const [useFallbackImage, setUseFallbackImage] = useState(false);
@@ -228,6 +243,9 @@ export const Card = memo(function Card({
   const displayLinkImageSize = shouldUseFallback
     ? fallbackDisplaySize
     : primaryDisplaySize;
+  const displayLinkImageKey = shouldUseFallback
+    ? screenshotStorageKey
+    : primaryLinkImageKey;
 
   const legacyPrimaryImage = linkCardImage;
   const legacyFallbackImage = resolvedScreenshotUrl;
@@ -289,13 +307,17 @@ export const Card = memo(function Card({
                   displayLinkImageSize.width / displayLinkImageSize.height,
               }}
             >
-              <Image
+              <ResilientMediaImage
                 alt={linkCardTitle}
+                cardId={card._id}
                 className="h-full w-full object-cover"
-                onError={handleLinkImageError}
-                preview={false}
-                rootClassName="h-full w-full"
+                onPermanentError={handleLinkImageError}
                 src={displayLinkImage}
+                storageKey={
+                  typeof displayLinkImageKey === "string"
+                    ? displayLinkImageKey
+                    : undefined
+                }
               />
             </div>
             <div className="px-4 py-3">
@@ -309,13 +331,21 @@ export const Card = memo(function Card({
         return (
           <div className="divide-y overflow-hidden rounded-xl border bg-card">
             <div className="h-28 min-h-28 overflow-hidden">
-              <Image
+              <ResilientMediaImage
                 alt={linkCardTitle}
+                cardId={card._id}
                 className="h-full w-full object-cover"
-                onError={handleLinkImageError}
-                preview={false}
-                rootClassName="h-full w-full"
+                onPermanentError={handleLinkImageError}
                 src={legacyDisplayImage}
+                storageKey={
+                  typeof (useFallbackImage
+                    ? screenshotStorageKey
+                    : primaryLinkImageKey) === "string"
+                    ? ((useFallbackImage
+                        ? screenshotStorageKey
+                        : primaryLinkImageKey) as string)
+                    : undefined
+                }
               />
             </div>
             <div className="px-4 py-3">
@@ -336,12 +366,15 @@ export const Card = memo(function Card({
       return (
         <GridImagePreview
           altText={card.content}
+          cardId={card._id}
+          compactUrl={card.compactUrl}
           height={card.fileMetadata?.height}
           imageUrl={
-            card.compactUrl ?? card.thumbnailUrl ?? card.fileUrl ?? undefined
+            card.thumbnailUrl ?? card.compactUrl ?? card.fileUrl ?? undefined
           }
           isPriority={isPriority}
-          placeholderUrl={card.placeholderUrl}
+          placeholderColor={card.colors?.[0]?.hex}
+          storageKey={card.fileKey}
           width={card.fileMetadata?.width}
         />
       );
@@ -353,10 +386,13 @@ export const Card = memo(function Card({
         (card.fileMetadata?.fileName?.toLowerCase().endsWith(".gif") ?? false);
       return (
         <GridVideoPreview
+          cardId={card._id}
           height={card.fileMetadata?.height}
           isGif={isGif}
           isPriority={isPriority}
+          thumbnailKey={card.thumbnailKey}
           thumbnailUrl={card.thumbnailUrl ?? undefined}
+          videoKey={card.fileKey}
           videoUrl={card.fileUrl ?? undefined}
           width={card.fileMetadata?.width}
         />
@@ -370,9 +406,11 @@ export const Card = memo(function Card({
     if (card.type === "document") {
       return (
         <GridDocumentPreview
+          cardId={card._id}
           fileName={card.fileMetadata?.fileName || card.content}
           height={card.fileMetadata?.height}
           isPriority={isPriority}
+          thumbnailKey={card.thumbnailKey}
           thumbnailUrl={card.thumbnailUrl ?? undefined}
           width={card.fileMetadata?.width}
         />

--- a/packages/ui/src/components/cards/__tests__/Card.test.tsx
+++ b/packages/ui/src/components/cards/__tests__/Card.test.tsx
@@ -94,7 +94,7 @@ describe("Cards/Card", () => {
     });
   });
 
-  test("keeps copy available if refreshing the original URL fails", async () => {
+  test("does not substitute a preview if refreshing the original URL fails", async () => {
     await expect(
       resolveImageCopyUrl({
         cardId: "card_123",
@@ -102,7 +102,7 @@ describe("Cards/Card", () => {
         fileKey: "original-key",
         refresh: mock().mockRejectedValue(new Error("refresh failed")),
       })
-    ).resolves.toBe("https://files.teakvault.com/grid.jpg");
+    ).rejects.toThrow("refresh failed");
   });
 
   test("prefers attached X image media over screenshot in masonry preview", () => {

--- a/packages/ui/src/components/cards/__tests__/Card.test.tsx
+++ b/packages/ui/src/components/cards/__tests__/Card.test.tsx
@@ -2,6 +2,14 @@ import { describe, expect, mock, test } from "bun:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
+mock.module("@teak/convex", () => ({
+  api: { card: { getFileUrl: { refreshCardMediaUrl: {} } } },
+}));
+
+mock.module("convex/react", () => ({
+  useAction: () => mock(),
+}));
+
 mock.module("antd", () => ({
   Image: ({ src, alt, className, ...props }: any) =>
     React.createElement("img", { src, alt, className, ...props }),

--- a/packages/ui/src/components/cards/__tests__/Card.test.tsx
+++ b/packages/ui/src/components/cards/__tests__/Card.test.tsx
@@ -61,7 +61,7 @@ mock.module("../previews/GridVideoPreview", () => ({
   GridVideoPreview: () => React.createElement("div"),
 }));
 
-const { Card } = await import("../Card");
+const { Card, resolveImageCopyUrl } = await import("../Card");
 
 const createLinkCard = (overrides?: Record<string, unknown>) => ({
   _id: "card_123",
@@ -76,6 +76,35 @@ const createLinkCard = (overrides?: Record<string, unknown>) => ({
 });
 
 describe("Cards/Card", () => {
+  test("mints the original image URL only when copying", async () => {
+    const refresh = mock().mockResolvedValue({
+      url: "https://files.teakvault.com/original.jpg",
+    });
+    await expect(
+      resolveImageCopyUrl({
+        cardId: "card_123",
+        fallbackUrl: "https://files.teakvault.com/grid.jpg",
+        fileKey: "original-key",
+        refresh,
+      })
+    ).resolves.toBe("https://files.teakvault.com/original.jpg");
+    expect(refresh).toHaveBeenCalledWith({
+      cardId: "card_123",
+      key: "original-key",
+    });
+  });
+
+  test("keeps copy available if refreshing the original URL fails", async () => {
+    await expect(
+      resolveImageCopyUrl({
+        cardId: "card_123",
+        fallbackUrl: "https://files.teakvault.com/grid.jpg",
+        fileKey: "original-key",
+        refresh: mock().mockRejectedValue(new Error("refresh failed")),
+      })
+    ).resolves.toBe("https://files.teakvault.com/grid.jpg");
+  });
+
   test("prefers attached X image media over screenshot in masonry preview", () => {
     const markup = renderToStaticMarkup(
       <Card

--- a/packages/ui/src/components/cards/previews/GridDocumentPreview.tsx
+++ b/packages/ui/src/components/cards/previews/GridDocumentPreview.tsx
@@ -1,10 +1,12 @@
-import { Image } from "antd";
 import { File } from "lucide-react";
+import { ResilientMediaImage } from "./ResilientMediaImage";
 
 interface GridDocumentPreviewProps {
+  cardId?: string;
   fileName?: string;
   height?: number;
   isPriority?: boolean;
+  thumbnailKey?: string;
   thumbnailUrl?: string;
   width?: number;
 }
@@ -14,11 +16,13 @@ interface GridDocumentPreviewProps {
 const FALLBACK_ASPECT_RATIO = 3 / 4;
 
 export function GridDocumentPreview({
+  cardId,
   thumbnailUrl,
   fileName,
   width,
   height,
   isPriority = false,
+  thumbnailKey,
 }: GridDocumentPreviewProps) {
   if (thumbnailUrl) {
     return (
@@ -30,15 +34,15 @@ export function GridDocumentPreview({
               width && height ? width / height : FALLBACK_ASPECT_RATIO,
           }}
         >
-          <Image
+          <ResilientMediaImage
             alt={`Preview of ${fileName || "document"}`}
+            cardId={cardId}
             className="h-full w-full bg-muted object-contain"
             decoding="async"
             fetchPriority={isPriority ? "high" : undefined}
             loading={isPriority ? "eager" : "lazy"}
-            preview={false}
-            rootClassName="h-full w-full"
             src={thumbnailUrl}
+            storageKey={thumbnailKey}
             style={{ objectFit: "contain" }}
           />
         </div>

--- a/packages/ui/src/components/cards/previews/GridImagePreview.tsx
+++ b/packages/ui/src/components/cards/previews/GridImagePreview.tsx
@@ -1,51 +1,55 @@
-import { Image } from "antd";
+import { ResilientMediaImage } from "./ResilientMediaImage";
 
 interface GridImagePreviewProps {
   altText?: string;
+  cardId?: string;
+  compactUrl?: string;
   height?: number;
   imageUrl?: string;
   isPriority?: boolean;
-  placeholderUrl?: string;
+  placeholderColor?: string;
+  storageKey?: string;
   width?: number;
 }
 
 export function GridImagePreview({
   imageUrl,
+  compactUrl,
   altText,
+  cardId,
   width,
   height,
   isPriority = false,
-  placeholderUrl,
+  placeholderColor,
+  storageKey,
 }: GridImagePreviewProps) {
   return (
     <div
       className="relative h-full w-full overflow-hidden rounded-xl border bg-card"
-      style={{ aspectRatio: width && height ? width / height : 4 / 3 }}
+      style={{
+        aspectRatio: width && height ? width / height : 4 / 3,
+        backgroundColor: placeholderColor,
+      }}
     >
       {imageUrl ? (
-        <>
-          {placeholderUrl ? (
-            <img
-              alt=""
-              aria-hidden
-              className="absolute inset-0 h-full w-full scale-110 object-cover blur-md"
-              height={48}
-              src={placeholderUrl}
-              width={48}
-            />
-          ) : null}
-          <Image
-            alt={altText ?? "Image"}
-            className="h-full w-full object-cover"
-            decoding="async"
-            fetchPriority={isPriority ? "high" : undefined}
-            loading={isPriority ? "eager" : "lazy"}
-            preview={false}
-            rootClassName="relative h-full w-full"
-            src={imageUrl}
-            style={{ objectFit: "cover" }}
-          />
-        </>
+        <ResilientMediaImage
+          alt={altText ?? "Image"}
+          cardId={cardId}
+          className="h-full w-full object-cover"
+          decoding="async"
+          fetchPriority={isPriority ? "high" : undefined}
+          height={height ?? 512}
+          loading={isPriority ? "eager" : "lazy"}
+          sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 256px"
+          src={imageUrl}
+          srcSet={
+            compactUrl && compactUrl !== imageUrl
+              ? `${compactUrl} 256w, ${imageUrl} 512w`
+              : undefined
+          }
+          storageKey={storageKey}
+          width={width ?? 512}
+        />
       ) : (
         <div aria-hidden className="h-full w-full bg-muted" />
       )}

--- a/packages/ui/src/components/cards/previews/GridVideoPreview.tsx
+++ b/packages/ui/src/components/cards/previews/GridVideoPreview.tsx
@@ -1,12 +1,15 @@
-import { Image } from "antd";
 import { Play } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { ResilientMediaImage } from "./ResilientMediaImage";
 
 interface GridVideoPreviewProps {
+  cardId?: string;
   height?: number;
   isGif?: boolean;
   isPriority?: boolean;
+  thumbnailKey?: string;
   thumbnailUrl?: string;
+  videoKey?: string;
   videoUrl?: string;
   width?: number;
 }
@@ -23,20 +26,24 @@ function PlayOverlay() {
 
 function HoverVideoPreview({
   aspectRatio,
+  cardId,
   isPriority,
+  thumbnailKey,
   thumbnailUrl,
   videoUrl,
 }: {
   aspectRatio: number;
+  cardId?: string;
   isPriority?: boolean;
+  thumbnailKey?: string;
   thumbnailUrl?: string;
   videoUrl: string;
 }) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [isHovering, setIsHovering] = useState(false);
-  // Defer mounting the video until first hover when a thumbnail can cover idle.
-  // Without a thumbnail, mount immediately so the card still shows a frame.
-  const [shouldLoadVideo, setShouldLoadVideo] = useState(!thumbnailUrl);
+  // Never fetch video bytes before intent; the poster or neutral placeholder
+  // keeps an idle grid lightweight.
+  const [shouldLoadVideo, setShouldLoadVideo] = useState(false);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -76,15 +83,15 @@ function HoverVideoPreview({
     >
       {thumbnailUrl ? (
         <div className={isHovering ? "invisible" : undefined}>
-          <Image
+          <ResilientMediaImage
             alt="Video thumbnail"
+            cardId={cardId}
             className="h-full w-full object-cover"
             decoding="async"
             fetchPriority={isPriority ? "high" : undefined}
             loading={isPriority ? "eager" : "lazy"}
-            preview={false}
-            rootClassName="h-full w-full"
             src={thumbnailUrl}
+            storageKey={thumbnailKey}
             style={{ objectFit: "cover" }}
           />
         </div>
@@ -114,10 +121,13 @@ function HoverVideoPreview({
 }
 
 export function GridVideoPreview({
+  cardId,
   height,
   isGif,
   isPriority,
+  thumbnailKey,
   thumbnailUrl,
+  videoKey,
   videoUrl,
   width,
 }: GridVideoPreviewProps) {
@@ -129,14 +139,16 @@ export function GridVideoPreview({
         className="relative h-full w-full overflow-hidden rounded-xl border bg-card"
         style={{ aspectRatio }}
       >
-        <img
+        <ResilientMediaImage
           alt="GIF preview"
+          cardId={cardId}
           className="h-full w-full object-cover"
           decoding="async"
           fetchPriority={isPriority ? "high" : undefined}
           height={height ?? 480}
           loading={isPriority ? "eager" : "lazy"}
           src={videoUrl}
+          storageKey={videoKey}
           width={width ?? 640}
         />
       </div>
@@ -147,7 +159,9 @@ export function GridVideoPreview({
     return (
       <HoverVideoPreview
         aspectRatio={aspectRatio}
+        cardId={cardId}
         isPriority={isPriority}
+        thumbnailKey={thumbnailKey}
         thumbnailUrl={thumbnailUrl}
         videoUrl={videoUrl}
       />
@@ -160,15 +174,15 @@ export function GridVideoPreview({
         className="relative h-full w-full overflow-hidden rounded-xl border bg-card"
         style={{ aspectRatio }}
       >
-        <Image
+        <ResilientMediaImage
           alt="Video thumbnail"
+          cardId={cardId}
           className="h-full w-full object-cover"
           decoding="async"
           fetchPriority={isPriority ? "high" : undefined}
           loading={isPriority ? "eager" : "lazy"}
-          preview={false}
-          rootClassName="h-full w-full"
           src={thumbnailUrl}
+          storageKey={thumbnailKey}
           style={{ objectFit: "cover" }}
         />
         <PlayOverlay />

--- a/packages/ui/src/components/cards/previews/ResilientMediaImage.tsx
+++ b/packages/ui/src/components/cards/previews/ResilientMediaImage.tsx
@@ -1,0 +1,100 @@
+import { api } from "@teak/convex";
+import type { Id } from "@teak/convex/_generated/dataModel";
+import { recordClientOutcome } from "@teak/convex/shared/client-telemetry";
+import { useAction } from "convex/react";
+import type { CSSProperties, ImgHTMLAttributes, SyntheticEvent } from "react";
+import { useEffect, useState } from "react";
+import {
+  appendMediaRetryParam,
+  canRetryMedia,
+  getMediaRenditionFromUrl,
+} from "./mediaRecovery";
+
+interface ResilientMediaImageProps
+  extends Omit<ImgHTMLAttributes<HTMLImageElement>, "alt" | "onError" | "src"> {
+  alt: string;
+  cardId?: string;
+  fallbackStyle?: CSSProperties;
+  onPermanentError?: (event: SyntheticEvent<HTMLImageElement>) => void;
+  src: string;
+  storageKey?: string;
+}
+
+export function ResilientMediaImage({
+  alt,
+  cardId,
+  fallbackStyle,
+  height = 512,
+  onPermanentError,
+  src,
+  srcSet,
+  storageKey,
+  width = 512,
+  ...imageProps
+}: ResilientMediaImageProps) {
+  const refreshMediaUrl = useAction(api.card.getFileUrl.refreshCardMediaUrl);
+  const [displaySrc, setDisplaySrc] = useState(src);
+  const [displaySrcSet, setDisplaySrcSet] = useState(srcSet);
+  const [retryCount, setRetryCount] = useState(0);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    setDisplaySrc(src);
+    setDisplaySrcSet(srcSet);
+    setRetryCount(0);
+    setFailed(false);
+  }, [src, srcSet]);
+
+  const handleError = async (event: SyntheticEvent<HTMLImageElement>) => {
+    const attemptedUrl = event.currentTarget.currentSrc || displaySrc;
+    if (!(cardId && storageKey && canRetryMedia(attemptedUrl, retryCount))) {
+      setFailed(true);
+      onPermanentError?.(event);
+      return;
+    }
+    setRetryCount(1);
+    const rendition = getMediaRenditionFromUrl(attemptedUrl);
+    try {
+      const { url } = await refreshMediaUrl({
+        cardId: cardId as Id<"cards">,
+        key: storageKey,
+        rendition,
+      });
+      setDisplaySrcSet(undefined);
+      setDisplaySrc(appendMediaRetryParam(url));
+      recordClientOutcome({
+        attributes: { "media.rendition": rendition ?? "original" },
+        category: "media",
+        message: "Media URL recovered",
+        outcome: "success",
+      });
+    } catch {
+      setFailed(true);
+      recordClientOutcome({
+        attributes: { "media.rendition": rendition ?? "original" },
+        category: "media",
+        message: "Media URL recovery failed",
+        outcome: "failure",
+      });
+      onPermanentError?.(event);
+    }
+  };
+
+  if (failed) {
+    return (
+      <span aria-hidden className="block h-full w-full" style={fallbackStyle} />
+    );
+  }
+  return (
+    // biome-ignore lint/a11y/noNoninteractiveElementInteractions: load errors recover the non-interactive media URL
+    <img
+      {...imageProps}
+      alt={alt}
+      height={height}
+      onError={(event) => void handleError(event)}
+      src={displaySrc}
+      srcSet={displaySrcSet}
+      width={width}
+    />
+  );
+}

--- a/packages/ui/src/components/cards/previews/__tests__/GridImagePreview.test.tsx
+++ b/packages/ui/src/components/cards/previews/__tests__/GridImagePreview.test.tsx
@@ -17,4 +17,11 @@ describe("GridImagePreview", () => {
     expect(source).toContain('fetchPriority={isPriority ? "high" : undefined}');
     expect(source).toContain('decoding="async"');
   });
+
+  test("uses responsive renditions without a second placeholder request", () => {
+    expect(source).toContain("srcSet=");
+    expect(source).toContain('sizes="(max-width: 640px) 50vw');
+    expect(source).not.toContain("placeholderUrl");
+    expect(source).toContain("ResilientMediaImage");
+  });
 });

--- a/packages/ui/src/components/cards/previews/__tests__/GridVideoPreview.test.tsx
+++ b/packages/ui/src/components/cards/previews/__tests__/GridVideoPreview.test.tsx
@@ -15,9 +15,9 @@ describe("GridVideoPreview", () => {
     expect(source).toContain("style={{ aspectRatio }}");
   });
 
-  test("defers video mount until hover when a thumbnail can cover idle", () => {
+  test("defers every video mount until hover", () => {
     expect(source).toContain(
-      "const [shouldLoadVideo, setShouldLoadVideo] = useState(!thumbnailUrl)"
+      "const [shouldLoadVideo, setShouldLoadVideo] = useState(false)"
     );
     expect(source).toContain("setShouldLoadVideo(true)");
     expect(source).toContain("setIsHovering(true)");

--- a/packages/ui/src/components/cards/previews/__tests__/mediaRecovery.test.ts
+++ b/packages/ui/src/components/cards/previews/__tests__/mediaRecovery.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import {
+  appendMediaRetryParam,
+  canRetryMedia,
+  getMediaRenditionFromUrl,
+} from "../mediaRecovery";
+
+const signedGridUrl =
+  "https://files.teakvault.com/__images/v1/grid/user/card/file.jpg?exp=123&sig=secret";
+
+describe("media recovery", () => {
+  test("preserves signed parameters while adding a single retry marker", () => {
+    const retried = new URL(appendMediaRetryParam(signedGridUrl));
+    expect(retried.searchParams.get("exp")).toBe("123");
+    expect(retried.searchParams.get("sig")).toBe("secret");
+    expect(retried.searchParams.get("teak_retry")).toBe("1");
+  });
+
+  test("only retries Teak media once", () => {
+    expect(canRetryMedia(signedGridUrl, 0)).toBe(true);
+    expect(canRetryMedia(signedGridUrl, 1)).toBe(false);
+    expect(canRetryMedia("https://example.com/image.jpg", 0)).toBe(false);
+    expect(canRetryMedia(appendMediaRetryParam(signedGridUrl), 0)).toBe(false);
+  });
+
+  test("recognizes only allowlisted image renditions", () => {
+    expect(getMediaRenditionFromUrl(signedGridUrl)).toBe("grid");
+    expect(
+      getMediaRenditionFromUrl(
+        "https://files.teakvault.com/__images/v1/arbitrary/key?sig=x"
+      )
+    ).toBeUndefined();
+    expect(
+      getMediaRenditionFromUrl("https://example.com/__images/v1/grid/key")
+    ).toBeUndefined();
+  });
+});

--- a/packages/ui/src/components/cards/previews/mediaRecovery.ts
+++ b/packages/ui/src/components/cards/previews/mediaRecovery.ts
@@ -1,0 +1,41 @@
+const FILES_HOST = "files.teakvault.com";
+const RENDITIONS = new Set(["tiny", "compact", "grid", "detail"] as const);
+
+export type MediaRendition = "tiny" | "compact" | "grid" | "detail";
+
+export function appendMediaRetryParam(url: string): string {
+  const parsed = new URL(url);
+  parsed.searchParams.set("teak_retry", "1");
+  return parsed.toString();
+}
+
+export function canRetryMedia(url: string, retryCount: number): boolean {
+  if (retryCount > 0) {
+    return false;
+  }
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.hostname === FILES_HOST && !parsed.searchParams.has("teak_retry")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function getMediaRenditionFromUrl(
+  url: string
+): MediaRendition | undefined {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== FILES_HOST) {
+      return undefined;
+    }
+    const candidate = parsed.pathname.match(/^\/__images\/v1\/([^/]+)\//)?.[1];
+    return candidate && RENDITIONS.has(candidate as MediaRendition)
+      ? (candidate as MediaRendition)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/ui/src/components/cards/types.ts
+++ b/packages/ui/src/components/cards/types.ts
@@ -50,6 +50,7 @@ export interface CardWithUrls {
   metadataTitle?: string;
   placeholderUrl?: string;
   screenshotUrl?: string;
+  thumbnailKey?: string;
   thumbnailUrl?: string;
   type?: string;
   url?: string;

--- a/packages/ui/src/lib/prefetchCardMedia.ts
+++ b/packages/ui/src/lib/prefetchCardMedia.ts
@@ -15,6 +15,7 @@ const warmImage = (url: string | null | undefined): void => {
 };
 
 interface PrefetchableMedia {
+  detailUrl?: string | null;
   fileUrl?: string | null;
   thumbnailUrl?: string | null;
   type?: string | null;
@@ -27,7 +28,7 @@ interface PrefetchableMedia {
  */
 export const prefetchCardModalMedia = (card: PrefetchableMedia): void => {
   if (card.type === "image") {
-    warmImage(card.fileUrl ?? card.thumbnailUrl);
+    warmImage(card.detailUrl ?? card.thumbnailUrl);
     return;
   }
   if (card.type === "video") {


### PR DESCRIPTION
## Summary
- reduce the initial grid page from 100 to 30 cards and mint only grid-needed image renditions
- replace one-shot media elements with responsive native images that refresh an authorized signed URL once after failure
- keep videos unloaded until interaction and retry transient poster generation three times before recording failure
- hydrate full media only when opening a card and add production E2E coverage

## Validation
- `bun run pre-commit` (19/19 affected typecheck, lint, and build tasks)
- `bun run check`
- 46 focused media/backend regression tests
- full package suite: changed packages pass; five unrelated Convex tests that mutate shared process env still fail only in the all-tests concurrent run (OAuth metadata, Polar default, admin config)