### PR TITLE
Streamline agent guidance and release runbooks

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -36,11 +36,25 @@ jobs:
         run: |
           version="${RELEASE_VERSION#v}"
           tag_name="v${version}"
-          expected_asset="Teak-${version}-arm64.dmg"
-          if gh release view "$tag_name" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' 2>/dev/null | grep -qx "$expected_asset"; then
-            echo "Release $tag_name already contains $expected_asset — skipping desktop release."
+          expected_assets=(
+            "latest-mac.yml"
+            "Teak-${version}-arm64.dmg"
+            "Teak-${version}-arm64.dmg.blockmap"
+            "Teak-${version}-arm64-mac.zip"
+            "Teak-${version}-arm64-mac.zip.blockmap"
+          )
+          existing_assets="$(gh release view "$tag_name" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' 2>/dev/null || true)"
+          missing_assets=()
+          for asset in "${expected_assets[@]}"; do
+            if ! grep -Fxq "$asset" <<< "$existing_assets"; then
+              missing_assets+=("$asset")
+            fi
+          done
+          if [ "${#missing_assets[@]}" -eq 0 ]; then
+            echo "Release $tag_name already contains all required desktop assets — skipping desktop release."
             echo "should_run=false" >> "$GITHUB_OUTPUT"
           else
+            printf 'Release %s is missing desktop asset(s): %s\n' "$tag_name" "${missing_assets[*]}"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,266 +1,61 @@
-Teak is a personal knowledge hub designed to help creative minds effortlessly collect, remember, and rediscover their most important ideas and inspirations.
-
-## Quick Commands
-
-```bash
-# Install dependencies
-bun install
-
-# Dev (web + convex backend)
-bun run dev
-
-# Dev (all services)
-bun run dev:all
-
-# Individual services
-bun run dev:web        # Next.js web + Convex
-bun run dev:convex     # Convex backend only
-bun run dev:mobile     # Expo mobile app
-bun run dev:desktop    # Electron desktop app
-bun run dev:extension  # Browser extension + Convex
-bun run dev:raycast    # Raycast extension
-bun run dev:docs       # Documentation site
-
-# Build/package extensions
-bun run build:extension
-bun run build:raycast
-bun run publish:raycast
-
-# Production build / start
-bun run build
-bun run start
-
-# Lint & Typecheck
-bun run lint
-bun run typecheck
-
-# Tests
-bun run test
-
-# Quality checks (Ultracite)
-bun run check
-bun run fix
-
-# Pre-commit (same as git hook)
-bun run pre-commit
-
-# Clear caches
-bun run clean
-
-# Manage deps (in specific workspace)
-bun add <package-name> --filter @teak/web
-bun add --dev <package-name> --filter @teak/convex
-```
-
-```
-teak/
-├── apps/
-│   ├── web/         # Next.js frontend (app router, shadcn/ui)
-│   ├── mobile/      # Expo RN mobile app
-│   ├── desktop/     # Electron desktop app (React)
-│   ├── extension/   # Chrome extension (Wxt)
-│   ├── safari-extension/ # Native macOS Safari extension app
-│   ├── raycast/     # Raycast extension
-│   ├── cli/         # npm command line client
-│   └── docs/        # Documentation site (Blume)
-├── .agents/
-│   └── skills/      # Agent Skills exposed through skills.sh-compatible repos
-├── packages/
-│   ├── convex/      # Convex backend, public API, MCP, SDK, functions, workflows, schema, shared utils
-│   └── ui/          # Shared UI package (components, hooks, screens, feedback)
-├── turbo.json       # Turborepo pipeline config
-└── package.json     # Root package + workspaces
-```
-
-## Client-Server Patterns
-
-- **Queries**: Real-time cached data via `convex-helpers/react/cache` `useQuery`, wrapped by `ConvexQueryCacheProvider`.
-- **Mutations**: Server actions through `useMutation` / `useAction` from `@teak/convex`.
-- **Auth context**: Better Auth sessions flow automatically to Convex with `@convex-dev/better-auth`.
-- **App wrapping**: `ConvexClientProvider` + `ConvexQueryCacheProvider` wrap trees (web, mobile, extension) to share auth + cached queries; real-time updates propagate automatically.
-- **Imports**: `import { api } from "@teak/convex"`, `import { Doc } from "@teak/convex/_generated/dataModel"`, `import { CARD_TYPES } from "@teak/convex/shared/constants"`.
-- **Card Types**: text, link, image, video, audio, document, palette, quote.
-
-## AI Processing Pipeline
-
-- Orchestrated in `packages/convex/workflows/cardProcessing.ts` using `@convex-dev/workflow` with per-step retries.
-- Sequence: classification (detect type + palette colors) → categorization (links; waits for metadata) → metadata (AI tags, summary, transcript) → renderables (media thumbnails; skips tiny originals; writes via internal mutations).
-- Helpers: `packages/convex/workflows/functionRefs.ts` + `packages/convex/ai`.
-- Link metadata: `packages/convex/workflows/linkMetadata.ts` via `startLinkMetadataWorkflow`;
-
-## App Surfaces
-
-- **Web (apps/web/)**: `src/app/(auth)/`, `src/app/(settings)/settings`, `src/globals.css`, `src/layout.tsx`, `src/page.tsx`; components include `ConvexClientProvider`, `SentryUserManager`, `JsonLd`, `GlobalFileDropProvider`; most UI components (card previews, grids, modals, forms, search, patterns) live in `@teak/ui`; Sentry error tracking via `instrumentation.ts`; config (`next.config.ts`, `eslint.config.mjs`, `components.json`).
-- **Mobile (apps/mobile/)**: `app/(auth)/`, `app/(tabs)/(home)/|add/|settings/`, `_layout.tsx`; components (Expo UI, `CardItem`, `CardsGrid`, `CardPreviewSheet`, `ErrorBoundary`, `Logo`); `lib/hooks`, `lib/share`, `lib/auth-client.ts`, `lib/recording.ts`; `package.json`.
-- **Desktop (apps/desktop/)**: Electron app with React frontend; `src/main/` for Electron main process; `src/preload/` for context bridge; `src/` for React renderer components; `src/pages/`, `src/hooks/`, `src/components/`, `src/lib/`; `forge.config.ts`, `vite.main.config.ts`, `vite.preload.config.ts`, `vite.renderer.config.ts`, `electron-builder.config.ts`.
-- **Extension (apps/extension/)**: Wxt-based Chrome extension; `entrypoints/background.ts`, `entrypoints/content.ts`, `entrypoints/content/`, `entrypoints/popup/`; hooks (`useAutoSaveUrl`, `useContextMenuSave`, `useWebAppSession`); types (`contextMenu.ts`, `messages.ts`, `social.ts`); `utils/`, `lib/`, `scripts/`; `style.css`; assets in `public/`; `wxt.config.ts`; `package.json`; `tsconfig.json`.
-- **Safari Extension (apps/safari-extension/)**: Native macOS Safari Web Extension app for the Mac App Store. Keep Apple identifiers such as `com.praveenjuge.teak-safari`, the App Group, native messaging id, and keychain service stable unless intentionally creating a new App Store identity.
-- **Raycast (apps/raycast/)**: Raycast extension with commands (`quick-save`, `save-clipboard-url`, `save-current-browser-tab`, `search-cards`, `favorites`), AI tools (`search-cards`, `get-card`, `save-card`), API client helpers, and extension metadata/changelog.
-- **Backend/API/MCP/SDK (packages/convex/)**: directories `_generated/`, `workflows/`, `ai/`, `card/`, `client/`, `mcp/`, `linkMetadata/`, `migrations/`, `packages/`, `shared/`, `storage/`, `types/`; key files `billing.ts`, `admin.ts`, `schema.ts`, `cards.ts`, `auth.config.ts`, `auth.ts`, `authDesktop.ts`, `http.ts`, `apiKeys.ts`, `publicApi.ts`, `publicApiHttp.ts`, `publicApiMeta.ts`, `publicApiOpenApi.ts`, `raycast.ts`, `idempotency.ts`, `crons.ts`, `convex.config.ts`, `vercel.json`, entrypoint `index.ts`; shared utils/constants/hooks under `shared/`; SDK exports live at `@teak/convex/sdk`.
-- **UI (packages/ui/)**: shared UI component library consumed by web, desktop, and extension; `src/components/` (cards, card-modal, card-previews, forms, grids, modals, patterns, search, selection, settings, ui); `src/feedback/` (skeletons, loading, error states, global file drop overlay, empty state); `src/screens/`, `src/hooks/`, `src/icons/`, `src/constants/`; `convexQueryCache.ts`, `convexQueryHooks.ts`, `logo.tsx`, `styles.css`.
-- **Docs (apps/docs/)**: Blume static site; `content/docs/` for documentation MDX; `content/changelog/` for release notes; `pages/` for marketing routes; `components/`, `layouts/`, `lib/`, `styles/`; `blume.config.ts`; `theme.css`; `package.json`.
-- **Repo**: Turborepo monorepo with workspaces in `apps/*` and `packages/*`; TypeScript paths point to `@teak/convex` aliases; turbo runs tasks with `--filter` for individual apps.
-- **Convex**: hot deployment on save; schema changes need migrations; define indexes in `schema.ts`; scheduled functions in `crons.ts`; config in `packages/convex/convex.config.ts`; workflows must keep `processingStatus` consistent; Polar integration depends on `components.polar` + env keys `POLAR_ACCESS_TOKEN`, `POLAR_SERVER`;
+# Teak agent guide
 
-## Docs Synchronization Rules
+Teak is a personal knowledge hub for collecting, remembering, and rediscovering ideas and inspiration.
 
-- Any API contract change in `packages/convex/http.ts`, `packages/convex/publicApiHttp.ts`, `packages/convex/publicApiMeta.ts`, or `packages/convex/publicApiOpenApi.ts` must update `apps/docs/content/docs/(developers)/api.mdx` in the same PR.
-- Any MCP endpoint change in `packages/convex/mcp/` must update `apps/docs/content/docs/(developers)/mcp.mdx` in the same PR.
-- Any Raycast command/auth change in `apps/raycast` must update `apps/docs/content/docs/(apps)/raycast.mdx` in the same PR.
-- Any CLI command/auth/publish change in `apps/cli` or `packages/convex/client/sdk.ts` must update `apps/docs/content/docs/(apps)/cli.mdx` when user-facing behavior changes.
-- Any public Agent Skill change in `.agents/skills` must update `apps/docs/content/docs/(developers)/skills.mdx` and `apps/docs/pages/apps.astro` when install or capability details change.
+## Start here
 
-## Git Commit Rules
+- Use Bun. Read the pinned version and available commands from `package.json`; do not duplicate that inventory here.
+- Read the nearest nested `AGENTS.md` before changing a workspace.
+- Inspect the current implementation and tests before choosing a pattern. Treat repository code and configuration as the source of truth.
+- Keep changes focused. Preserve unrelated work already in the tree.
 
-- Never use `--no-verify` when committing. Pre-commit hooks exist to catch lint and build errors before they land. If the hook fails, fix the underlying issue instead of bypassing it.
+## Architecture invariants
 
-## Release Notes Hygiene
+- This is a Turborepo monorepo. Applications live in `apps/*`; shared backend and UI code live in `packages/convex` and `packages/ui`.
+- Client reads use the cached Convex query hooks. Writes use Convex mutations or actions. Better Auth sessions provide Convex identity.
+- Import backend APIs from `@teak/convex`, generated data types from `@teak/convex/_generated/dataModel`, and shared constants from `@teak/convex/shared/constants`.
+- Shared web, desktop, and extension UI belongs in `packages/ui` unless the behavior is surface-specific.
+- Card processing is orchestrated by `packages/convex/workflows/cardProcessing.ts`. Preserve workflow retries and `processingStatus` consistency.
+- Supported card types are text, link, image, video, audio, document, palette, and quote.
 
-- Any user-visible feature change across web, mobile, desktop, extension, Raycast, API, or backend behavior must include a docs changelog update in `apps/docs/content/changelog/*.mdx`.
-- When adding a feature, write or update tests and make sure `bun run test` passes.
-- Add/extend tests for new features or bug fixes.
-- Update or add fixtures/test data so tests are deterministic.
-- Keep tests fast; avoid extra network calls unless the feature requires it.
-- End-to-end tests live in `packages/tests` (Playwright, run against live production surfaces: web, REST API, CLI, MCP, docs, browser matrix, extension). Whenever a change affects an end-to-end, user-observable flow across those surfaces, add or extend an e2e test there in the same PR. Match the existing journey structure in `packages/tests/src/journey` and reuse the helpers in `packages/tests/src/helpers`. See `packages/tests/README.md` for how to run the suite.
+## Convex work
 
-## Changelog Editorial Rules
+Before editing anything under `packages/convex`, read `packages/convex/_generated/ai/guidelines.md` completely. Its generated Convex rules override general guidance.
 
-These rules govern everything that lands in `apps/docs/content/changelog/*.mdx`. The changelog is a public, user-facing product surface — not a release log for engineers.
+Schema changes require explicit approval for any migration or backfill. Define indexes in `packages/convex/schema.ts` and scheduled jobs in `packages/convex/crons.ts`.
 
-- **Public entries describe user impact only.** If a user would not notice the change, do not publish it.
-- **Do not mention** package names, frameworks, libraries, build tooling, bundlers, loaders, ESM/CJS, schemas, data migrations, internal endpoints, refactors, tests, CI, signing/notarization, dependency bumps, or any implementation mechanics. That includes (non-exhaustive): Electron, Vite, Webpack, Forge, Next.js, Astro, Starlight, Blume, Expo, Wxt, Hono, Convex (as backend), Better Auth, Polar, `electron-updater`, `electron-builder`, oEmbed, `package.json`, `tsconfig`.
-- **Product-facing terms are fine** when users recognize them: desktop, mobile, web, browser extension, Raycast, API, MCP, sync, settings, import/export, updates, sign-in, macOS, Dock, notifications, keychain.
-- **If the change is only internal** (tooling, dependency work, refactor, tests, CI, cleanup, silent maintenance), do not add a public changelog entry. Update the code and move on.
-- **Format:** one frontmatter title plus 1–3 short bullets. No inline code (backticks), no fenced code blocks, no H2/H3 headers inside the entry.
-- **Each bullet is one user-observable outcome.** Keep bullets ~1–2 sentences each; trim aggressively.
-- **User action:** if the release requires the user to do something, state only the clear action they need to take, without the reason behind it.
-- **One entry per date.** Rewriting a historical entry is preferred over merging or deleting.
+## Verification
 
-## Mobile Release Process
+- Add or update deterministic tests for changed behavior. Run the narrowest relevant checks first, then the repository checks warranted by the change.
+- Test user-observable behavior rather than implementation details.
+- Cross-surface production journeys belong in `packages/tests`; read `packages/tests/README.md` before changing or running them.
+- Never bypass git hooks with `--no-verify`. Fix the failing check.
+- Verify user-facing work in the real interface when practical. A passing build alone is not proof of the experience.
 
-When asked to release the mobile app (cut a new App Store version, publish to iOS, submit to TestFlight/App Store, or similar), follow `apps/mobile/release.md`. The canonical release trigger is one next-patch lockstep `package.json` bump merged to `main`. The Version Tag workflow creates the tag and dispatches the GitHub Actions macOS build, mandatory Sentry Size Analysis upload, asc upload/validation, and direct App Review submission. Do not use hosted EAS Build, EAS Submit, or manually edit Expo/App Store marketing versions.
+## Documentation contract
 
-Do not invent a release flow. Read `apps/mobile/release.md` and run the commands listed there in order.
+Keep user documentation synchronized in the same change:
 
-## Desktop Release Process
+- Public API contracts in `packages/convex/http.ts`, `publicApiHttp.ts`, `publicApiMeta.ts`, or `publicApiOpenApi.ts` -> `apps/docs/content/docs/(developers)/api.mdx`
+- MCP behavior under `packages/convex/mcp` -> `apps/docs/content/docs/(developers)/mcp.mdx`
+- Raycast commands or authentication -> `apps/docs/content/docs/(apps)/raycast.mdx`
+- CLI or public SDK behavior under `apps/cli` or `packages/convex/client/sdk.ts` -> `apps/docs/content/docs/(apps)/cli.mdx`
+- Public skills under `.agents/skills` -> `apps/docs/content/docs/(developers)/skills.mdx` and `apps/docs/pages/apps.astro`
 
-The desktop app uses Electron with `electron-builder` and ships signed, notarized macOS builds via GitHub Releases.
+For a user-visible change, update the dated entry in `apps/docs/content/changelog`. The docs workspace `AGENTS.md` defines its editorial rules. Internal-only changes need no public entry.
 
-Releases are always a patch version bump (e.g. 1.0.55 → 1.0.56). Do not ask for confirmation — just increment the patch, bump, commit, tag, and push.
+## Release pointers
 
-To publish a new desktop release:
+Release runbooks are canonical; read the relevant file and follow it exactly:
 
-1. Bump the `version` field in **every** `package.json` across the monorepo (root + all workspaces under `apps/*` and `packages/*`).
-2. Commit and push to `main`.
-3. Create and push a version tag:
-   ```bash
-   git tag v<version>
-   git push origin v<version>
-   ```
-4. The `Desktop Release` workflow (`.github/workflows/desktop-release.yml`) triggers on the `v*` tag and automatically:
-   - Builds the renderer, main process, and preload via `vite build` (orchestrated by `bun run build`, driven by `@electron-forge/plugin-vite` configs) with production env vars.
-   - Imports signing credentials (Developer ID certificate + App Store Connect API key) from GitHub Actions secrets.
-   - Packages, code-signs, and notarizes the macOS ARM64 app via `electron-builder`.
-   - Verifies codesign (`codesign --verify --deep --strict`), Gatekeeper assessment (`spctl --assess`), and stapled notarization ticket.
-   - Publishes all artifacts (DMG, zip, blockmaps, `latest-mac.yml`) to a GitHub Release only after verification passes.
-5. Existing installs pick up the update via `electron-updater` on next launch (with notifications and prompts).
+- Mobile: `apps/mobile/release.md`
+- Desktop: `apps/desktop/RELEASE.md`
+- Browser extension: `apps/extension/release.md`
+- Safari extension: `apps/safari-extension/release.md`
+- CLI: `apps/cli/AGENTS.md`
 
-## Extension Release Process
+All package versions move in lockstep. Release tasks use the next patch version unless the canonical runbook says otherwise. Use `gh` for GitHub releases, pull requests, issues, and workflow inspection.
 
-The browser extension ships automatically to the Chrome Web Store (plus GitHub Releases) through `.github/workflows/extension-release.yml`. It uses the same tag flow as the desktop app.
+## Headless development
 
-To publish a new extension release:
-
-1. Bump the `version` field in **every** `package.json` across the monorepo (same step as the desktop release — one tag ships both).
-2. Commit, push, and tag `v<version>`.
-3. The `Extension Release` workflow triggers on the `v*` tag and automatically:
-   - Verifies the tag version matches `apps/extension/package.json` (WXT reads the manifest version from there; `wxt.config.ts` intentionally does not hardcode it).
-   - Runs `bun run zip` in `apps/extension` to build the production Chrome zip with the production env vars.
-   - Uploads the zip to the Chrome Web Store and calls publish via the Chrome Web Store Publish API using `chrome-webstore-upload-cli`.
-   - Uploads the same zip to the GitHub Release for the tag as `teak-extension-<version>-chrome.zip`.
-4. Google queues the new version for review. Approved updates roll out to users automatically.
-
-Required GitHub secrets: `CHROME_EXTENSION_ID`, `CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`, `CHROME_REFRESH_TOKEN`. See `apps/extension/release.md` for how to generate them.
-
-Only the Chrome Web Store is automated today. There is no Firefox / Edge publishing step.
-
-## CLI Release Process
-
-The npm package is `teak-cli` and the installed binary is `teak`.
-
-1. Bump the `version` field in every `package.json` across the monorepo.
-2. Merge the version change to `main`.
-3. The `Version Tag` workflow creates `v<version>` when all package versions match.
-4. The `CLI Release` workflow publishes `apps/cli` to npm as `teak-cli` on the same tag.
-5. The desktop, browser extension, iOS, and Safari release workflows also run from that tag.
-
-## Safari Extension Release Process
-
-Follow `apps/safari-extension/release.md`. Keep Apple-facing identifiers stable
-unless intentionally creating a new App Store identity.
-
-<!-- convex-ai-start -->
-
-This project uses [Convex](https://convex.dev) as its backend.
-
-When working on Convex code, **always read
-`convex/_generated/ai/guidelines.md` first** for important guidelines on
-how to correctly use Convex APIs and patterns. The file contains rules that
-override what you may have learned about Convex from training data.
-
-Convex agent skills for common tasks can be installed by running
-`npx convex ai-files install`.
-
-<!-- convex-ai-end -->
-
-## Cursor Cloud specific instructions
-
-### Runtime
-
-- Package manager: **Bun 1.3.5** (`packageManager` in root `package.json`). If `bun` is missing, install with `curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.5"` and ensure `~/.bun/bin` is on `PATH`.
-- Dependency refresh on startup: `bun install --frozen-lockfile` from the repo root (see VM update script).
-
-### Minimum dev stack (web + Convex)
-
-`bun run dev:web` uses `turbo watch`, which requires an interactive TUI. In headless/tmux Cloud VMs, either set `TURBO_UI=tui` or start services separately (recommended):
-
-1. **Convex** (tmux session `convex-dev`, cwd `packages/convex`):
-   ```bash
-   export CONVEX_AGENT_MODE=anonymous
-   bun run dev
-   ```
-   On first run, set required Convex env vars on the anonymous deployment (dummy values are fine for local dev):
-   ```bash
-   bunx convex env set GOOGLE_CLIENT_ID test
-   bunx convex env set GOOGLE_CLIENT_SECRET test
-   bunx convex env set SITE_URL http://localhost:4330
-   bunx convex env set JWKS '<JwksDoc JSON array — see @convex-dev/better-auth auth-config docs>'
-   ```
-   Generate `JWKS` with a short Bun script that exports an array of `{ id, publicKey, privateKey, createdAt, alg }` objects (RSA keys via `jose`).
-
-2. **Web** (tmux session `web-dev`, cwd `apps/web`):
-   ```bash
-   bunx portless app.teak next dev
-   ```
-   Portless prints the bound port (often `4330`). Create `apps/web/.env.local` from `packages/convex/.env.local`:
-   ```
-   NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3210
-   NEXT_PUBLIC_CONVEX_SITE_URL=http://127.0.0.1:3211
-   ```
-
-3. Open **`http://localhost:<port>/login`** (direct localhost, not `app.teak.localhost`, unless portless HTTPS is configured).
-
-### Auth gotcha (Cloud VMs)
-
-Better Auth validates the browser `Origin` against `SITE_URL` / trusted origins. If sign-up/login returns **Invalid origin**, set Convex `SITE_URL` to the exact origin you use in the browser (e.g. `http://localhost:4330`), then retry after Convex redeploys.
-
-Mark test users verified without email: `POST http://127.0.0.1:3210/api/internal/testSetup:markUserVerified` with `{"email":"..."}`.
-
-### Lint, typecheck, tests
-
-Standard commands from the repo root: `bun run lint`, `bun run typecheck`, `bun run test`. See **Quick Commands** above.
-
-### Optional services
-
-- Docs: `bun run dev:docs` (also needs portless/turbo TUI considerations).
-- Mobile/desktop/extension: see **Quick Commands**; they need Convex URLs in their own `.env.local` files and are not required for web-only work.
+When working in Cursor Cloud or another headless VM, read `docs/agents/headless-development.md`. Local development should use the scripts and environment already present in the repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ For a user-visible change, update the dated entry in `apps/docs/content/changelo
 
 ## Release pointers
 
-Release runbooks are canonical; read the relevant file and follow it exactly:
+Before any release, complete the shared preparation in `docs/agents/releases.md`. Then read the relevant product runbook and follow it exactly:
 
 - Mobile: `apps/mobile/release.md`
 - Desktop: `apps/desktop/RELEASE.md`

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -1,0 +1,13 @@
+# CLI release
+
+The npm package is `teak-cli`; the installed binary is `teak`.
+
+The canonical release trigger is the same next-patch lockstep `package.json` bump used by every Teak surface:
+
+1. Update every tracked `package.json` to the same next patch version and synchronize `bun.lock`.
+2. Merge the scoped version change to `main`.
+3. Let `.github/workflows/version-tag.yml` verify the patch and lockstep invariants, create `v<version>`, and dispatch `.github/workflows/cli-release.yml`.
+4. The CLI workflow tests and builds the package, verifies its version, and publishes it to npm with provenance.
+5. Verify the workflow succeeded and `npm view teak-cli@<version> version` returns the released version.
+
+Do not create or move the version tag manually during the normal release path.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -2,12 +2,11 @@
 
 The npm package is `teak-cli`; the installed binary is `teak`.
 
-The canonical release trigger is the same next-patch lockstep `package.json` bump used by every Teak surface:
+Complete the shared preparation in `../../docs/agents/releases.md`, then:
 
-1. Update every tracked `package.json` to the same next patch version and synchronize `bun.lock`.
-2. Merge the scoped version change to `main`.
-3. Let `.github/workflows/version-tag.yml` verify the patch and lockstep invariants, create `v<version>`, and dispatch `.github/workflows/cli-release.yml`.
-4. The CLI workflow tests and builds the package, verifies its version, and publishes it to npm with provenance.
-5. Verify the workflow succeeded and `npm view teak-cli@<version> version` returns the released version.
+1. Merge the scoped version change to `main`.
+2. Let `.github/workflows/version-tag.yml` verify the patch and lockstep invariants, create `v<version>`, and dispatch `.github/workflows/cli-release.yml`.
+3. The CLI workflow tests and builds the package, verifies its version, and publishes it to npm with provenance.
+4. Verify the workflow succeeded and `npm view teak-cli@<version> version` returns the released version.
 
 Do not create or move the version tag manually during the normal release path.

--- a/apps/desktop/RELEASE.md
+++ b/apps/desktop/RELEASE.md
@@ -1,79 +1,34 @@
-# Desktop Release Runbook
+# Desktop release runbook
 
-This runbook defines Teak desktop launch and incident response for macOS Apple Silicon releases.
+Teak desktop ships signed and notarized macOS Apple Silicon builds through `.github/workflows/desktop-release.yml`.
 
-## Ownership
+## Canonical release
 
-- Release owner: Desktop maintainer on duty
-- Backup owner: Platform maintainer on duty
-- Incident channel: `#desktop-release`
-- On-call window: first 72 hours after each production desktop release
+1. Update every tracked `package.json` to the same next patch version and synchronize `bun.lock`.
+2. Merge the scoped version change to `main`.
+3. `Version Tag` verifies the patch and lockstep invariants, creates `v<version>`, and dispatches every product release for that tag.
+4. `Desktop Release` builds, signs, notarizes, and verifies the app before publishing the DMG, zip, blockmaps, and `latest-mac.yml` to the matching GitHub Release.
+5. Install the published DMG on a test Mac. Verify launch, sign-in, sync, codesigning, Gatekeeper acceptance, and the stapled notarization ticket.
+6. From an older installation, verify the updater resolves and installs the new version using the published `latest-mac.yml`.
+7. Monitor authentication, sync, updater failures, crash reports, and support reports for 72 hours.
 
-## Promotion Procedure
+The release is complete only when the workflow is green, the published artifact passes the installed-app smoke test, and an older build can resolve the update.
 
-1. Bump the `version` field in **every** `package.json` across the monorepo (root + all workspaces under `apps/*` and `packages/*`).
-2. Commit and push to `main`.
-3. Create and push a version tag:
-   ```bash
-   git tag v<version>
-   git push origin v<version>
-   ```
-4. `Desktop Release` workflow (`.github/workflows/desktop-release.yml`) runs from that tag:
-   - Builds renderer, main, and preload via `vite build` (orchestrated through `bun run build`, driven by `@electron-forge/plugin-vite` configs)
-   - Imports signing credentials from GitHub Actions secrets
-   - Packages, signs, and notarizes the macOS Apple Silicon app via `electron-builder`
-   - Verifies codesign, Gatekeeper assessment, and the stapled notarization ticket
-   - Publishes GitHub Release assets including `latest-mac.yml` updater metadata only after verification passes
-5. Validate release gates:
-   - Codesign verification (`codesign --verify --deep --strict`)
-   - Gatekeeper assessment (`spctl --assess --type execute`)
-   - Smoke test install from DMG
-6. Verify updater metadata publish:
-   - `latest-mac.yml` is present in the GitHub Release assets
-   - `electron-updater` resolves the new version on a test machine
-7. Announce release in team channel with:
-   - Version
-   - Release URL
-   - Known issues (if any)
+## Retry and recovery
 
-## Rollback Procedure
+- Rerun the failed GitHub Actions job when the failure is transient.
+- If source or workflow changes are required after a tag exists, ship the fix as the next patch version. Keep published version tags immutable.
+- The workflow is idempotent: it skips a version whose primary DMG already exists on the matching GitHub Release.
+- For a critical regression, mark the affected GitHub Release as a prerelease or add a warning, direct users to the last known good build, and ship a corrected patch. Do not silently replace a published tag or artifact.
 
-Use rollback when critical regressions impact launch, auth, sync, or update safety.
+## Required repository secrets
 
-1. Identify last known good release tag.
-2. Edit the GitHub Release for the bad version: mark as pre-release or add a warning note.
-3. Re-publish the last good version's `latest-mac.yml` as a new GitHub Release so `electron-updater` picks it up.
-4. Update `/apps` and support communications to steer users to stable build.
-5. Post-incident notes:
-   - impact window
-   - root cause
-   - corrective actions
+- `CSC_LINK`
+- `CSC_KEY_PASSWORD`
+- `APPLE_API_KEY_ID`
+- `APPLE_API_KEY_P8`
+- `APPLE_API_ISSUER`
+- `SENTRY_AUTH_TOKEN`
+- `SENTRY_DESKTOP_DSN`
 
-## 72-Hour Launch Monitoring Checklist
-
-- Auth success/failure rates are stable.
-- Updater success/failure rates are stable.
-- Crash reports and support tickets are reviewed at least twice daily.
-- New regressions are triaged with owner and ETA.
-
-## Release Artifacts
-
-- DMG installer for manual install.
-- Zip archive for auto-update delivery via `electron-updater`.
-- `latest-mac.yml` metadata for `electron-updater` version resolution.
-- GitHub Release description is intentionally left empty by the release workflow.
-
-## Required CI Secrets
-
-- `CSC_LINK` — Base64-encoded Developer ID Application `.p12` signing certificate
-- `CSC_KEY_PASSWORD` — Password for the signing certificate
-- `APPLE_API_KEY_ID` — App Store Connect API key ID for notarization
-- `APPLE_API_KEY_P8` — Raw `.p8` App Store Connect API private key content for notarization
-- `APPLE_API_ISSUER` — App Store Connect API issuer UUID for notarization
-- `GH_TOKEN` — GitHub token for publishing releases (provided automatically by `secrets.GITHUB_TOKEN`)
-
-### Build-Time Environment Variables (hardcoded in workflow)
-
-- `VITE_WEB_URL` — Production web app URL
-- `VITE_PUBLIC_CONVEX_URL` — Production Convex deployment URL
-- `VITE_PUBLIC_CONVEX_SITE_URL` — Production Convex site URL
+GitHub supplies the release token. Treat every signing and service credential as runtime-only secret material.

--- a/apps/desktop/RELEASE.md
+++ b/apps/desktop/RELEASE.md
@@ -4,13 +4,12 @@ Teak desktop ships signed and notarized macOS Apple Silicon builds through `.git
 
 ## Canonical release
 
-1. Update every tracked `package.json` to the same next patch version and synchronize `bun.lock`.
-2. Merge the scoped version change to `main`.
-3. `Version Tag` verifies the patch and lockstep invariants, creates `v<version>`, and dispatches every product release for that tag.
-4. `Desktop Release` builds, signs, notarizes, and verifies the app before publishing the DMG, zip, blockmaps, and `latest-mac.yml` to the matching GitHub Release.
-5. Install the published DMG on a test Mac. Verify launch, sign-in, sync, codesigning, Gatekeeper acceptance, and the stapled notarization ticket.
-6. From an older installation, verify the updater resolves and installs the new version using the published `latest-mac.yml`.
-7. Monitor authentication, sync, updater failures, crash reports, and support reports for 72 hours.
+1. Complete the shared preparation in `../../docs/agents/releases.md` and merge the scoped version change to `main`.
+2. `Version Tag` verifies the patch and lockstep invariants, creates `v<version>`, and dispatches every product release for that tag.
+3. `Desktop Release` builds, signs, notarizes, and verifies the app before publishing the DMG, zip, blockmaps, and `latest-mac.yml` to the matching GitHub Release.
+4. Install the published DMG on a test Mac. Verify launch, sign-in, sync, codesigning, Gatekeeper acceptance, and the stapled notarization ticket.
+5. From an older installation, verify the updater resolves and installs the new version using the published `latest-mac.yml`.
+6. Monitor authentication, sync, updater failures, crash reports, and support reports for 72 hours.
 
 The release is complete only when the workflow is green, the published artifact passes the installed-app smoke test, and an older build can resolve the update.
 
@@ -18,7 +17,7 @@ The release is complete only when the workflow is green, the published artifact 
 
 - Rerun the failed GitHub Actions job when the failure is transient.
 - If source or workflow changes are required after a tag exists, ship the fix as the next patch version. Keep published version tags immutable.
-- The workflow is idempotent: it skips a version whose primary DMG already exists on the matching GitHub Release.
+- The workflow skips a completed version only when all five required release assets exist. A rerun rebuilds and safely replaces the asset set when any artifact is missing.
 - For a critical regression, mark the affected GitHub Release as a prerelease or add a warning, direct users to the last known good build, and ship a corrected patch. Do not silently replace a published tag or artifact.
 
 ## Required repository secrets

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -1,0 +1,14 @@
+# Documentation conventions
+
+## Changelog entries
+
+`content/changelog` is a public product surface. Write for Teak users, not maintainers.
+
+- Add an entry only when users can observe the change. Internal maintenance, dependencies, refactors, tests, CI, schemas, migrations, and build or release mechanics do not belong there.
+- Describe the outcome in product language. Names users recognize, such as web, desktop, mobile, browser extension, Raycast, API, MCP, sync, settings, and sign-in, are appropriate.
+- Keep one entry per date. Prefer updating the existing dated entry over creating a second one.
+- Use one frontmatter title and one to three short bullets. Each bullet states one observable outcome in one or two sentences.
+- Omit headings, fenced code, inline code, implementation details, and internal package or framework names.
+- If users must act, state only the action they need to take.
+
+An entry is complete when every bullet describes an observable user outcome and no implementation detail remains.

--- a/apps/extension/release.md
+++ b/apps/extension/release.md
@@ -4,12 +4,10 @@ The Chrome extension ships through `.github/workflows/extension-release.yml` to 
 
 ## Canonical release
 
-1. Update every tracked `package.json` to the same next patch version.
-2. Run `bun install` to synchronize `bun.lock`, then prove `bun install --frozen-lockfile` exits successfully.
-3. Merge the scoped version and lockfile change to `main`.
-4. `Version Tag` verifies the patch and lockstep invariants, creates `v<version>`, and dispatches every product release for that tag.
-5. `Extension Release` verifies the extension version, builds the production Chrome zip, submits it to the Chrome Web Store, and attaches `teak-extension-<version>-chrome.zip` to the matching GitHub Release.
-6. Verify the workflow and GitHub artifact, then check the Chrome Web Store submission state. Store review may continue after the workflow succeeds.
+1. Complete the shared preparation in `../../docs/agents/releases.md` and merge the scoped version change to `main`.
+2. `Version Tag` verifies the patch and lockstep invariants, creates `v<version>`, and dispatches every product release for that tag.
+3. `Extension Release` verifies the extension version, builds the production Chrome zip, submits it to the Chrome Web Store, and attaches `teak-extension-<version>-chrome.zip` to the matching GitHub Release.
+4. Verify the workflow and GitHub artifact, then check the Chrome Web Store submission state. Store review may continue after the workflow succeeds.
 
 The release is complete when the exact zip is attached to the GitHub Release and the store has accepted the submission for review.
 

--- a/apps/extension/release.md
+++ b/apps/extension/release.md
@@ -1,82 +1,32 @@
-# Extension Release Process
+# Browser extension release
 
-The browser extension ships automatically to the Chrome Web Store and to GitHub Releases through `.github/workflows/extension-release.yml`. Releases are driven by the same tag flow as the desktop app: bump every `package.json`, push the tag, the workflow does the rest.
+The Chrome extension ships through `.github/workflows/extension-release.yml` to the Chrome Web Store and the matching GitHub Release.
 
-## How to cut a release
+## Canonical release
 
-1. Bump the `version` field in **every** `package.json` across the monorepo (root + all workspaces under `apps/*` and `packages/*`). The extension reads its manifest version from `apps/extension/package.json` — `wxt.config.ts` no longer hardcodes it.
-2. Sync `bun.lock` in the **same commit** as the version bumps. CI installs with `bun install --frozen-lockfile`, which fails fast (`lockfile had changes, but lockfile is frozen`) whenever the lockfile is even slightly out of sync — from the version bump itself, or from a dependency an earlier PR added/removed without resyncing the lock. Run both commands and stage `bun.lock` alongside every `package.json`:
-   ```bash
-   bun install                    # updates bun.lock (workspace version pins, prunes removed deps)
-   bun install --frozen-lockfile  # must exit 0 with "no changes" — this is the exact CI check
-   ```
-3. Commit and push to `main`.
-4. Create and push a version tag:
-   ```bash
-   git tag v<version>
-   git push origin v<version>
-   ```
-5. The `Extension Release` workflow triggers on the `v*` tag and automatically:
-   - Verifies the tag version matches `apps/extension/package.json`.
-   - Builds the production Chrome zip via `bun run zip` (WXT) with production env vars.
-   - Uploads the zip to the Chrome Web Store via the Chrome Web Store Publish API.
-   - Publishes the item (submits it for review under the default audience).
-   - Uploads the zip to the GitHub Release for tag `v<version>` as `teak-extension-<version>-chrome.zip`.
-6. The Chrome Web Store queues the new version for review. Once Google approves it (usually within a few hours to a few days), users receive the update automatically.
+1. Update every tracked `package.json` to the same next patch version.
+2. Run `bun install` to synchronize `bun.lock`, then prove `bun install --frozen-lockfile` exits successfully.
+3. Merge the scoped version and lockfile change to `main`.
+4. `Version Tag` verifies the patch and lockstep invariants, creates `v<version>`, and dispatches every product release for that tag.
+5. `Extension Release` verifies the extension version, builds the production Chrome zip, submits it to the Chrome Web Store, and attaches `teak-extension-<version>-chrome.zip` to the matching GitHub Release.
+6. Verify the workflow and GitHub artifact, then check the Chrome Web Store submission state. Store review may continue after the workflow succeeds.
 
-The same `v<version>` tag also triggers `desktop-release.yml` and `safari-extension-release.yml`, so one tag push releases desktop, extension, and Safari together.
+The release is complete when the exact zip is attached to the GitHub Release and the store has accepted the submission for review.
 
-## If a release fails partway
+## Retry and recovery
 
-The most common failure is the install step dying with `lockfile had changes, but lockfile is frozen`. That is always a `bun.lock` sync issue — fix it per step 2 above, then re-point the tag as below. (Note: the Safari workflow builds with Xcode and does not run `bun install`, so a lockfile problem only breaks the extension and desktop jobs.)
+- Rerun the failed GitHub Actions job when the failure is transient.
+- If source or workflow changes are required after a tag exists, ship the fix as the next patch version. Keep published version tags immutable.
+- The workflow skips publication when the exact versioned zip already exists on the matching GitHub Release.
+- A frozen-lockfile failure means the version commit did not include the synchronized `bun.lock`; correct it in the next patch.
+- The first Chrome Web Store upload is manual. Automated publication works only after the item exists in the store.
 
-The extension and desktop workflows fire on the `v*` tag and have no manual re-run path, so recovery means fixing `main` and moving the tag. The Safari workflow also fires on the tag but additionally supports `workflow_dispatch` with a `version` input — so a failed Safari build can be re-triggered manually from the Actions tab without moving the tag.
+## Required repository secrets
 
-Each workflow guards on its primary asset to decide whether to skip the run entirely:
+- `CHROME_EXTENSION_ID`
+- `CHROME_PUBLISHER_ID`
+- `CHROME_CLIENT_ID`
+- `CHROME_CLIENT_SECRET`
+- `CHROME_REFRESH_TOKEN`
 
-- **Extension**: skips if `teak-extension-<version>-chrome.zip` is already attached. A skipped run never re-submits to the Chrome Web Store.
-- **Desktop**: skips if `Teak-<version>-arm64.dmg` is already attached. If the workflow does run (because the DMG is missing), it uploads all assets with `--clobber`, so partial leftovers from a prior failed run are safely overwritten.
-- **Safari**: skips if `teak-safari-<version>-mac-app-store.pkg` is already attached.
-
-Moving the tag therefore re-runs only the jobs whose primary asset is missing.
-
-1. Fix the problem on `main` (usually a lockfile resync) and push it.
-2. Move the tag to the fixed commit and force-push it:
-   ```bash
-   git tag -f v<version> <fixed-commit-sha>
-   git push origin v<version> --force
-   ```
-3. Watch the reruns with `gh run list --limit 6`: jobs whose assets already exist skip, and the previously failed jobs rebuild from the fixed commit.
-
-## Required GitHub secrets
-
-Set these once under **Settings → Secrets and variables → Actions**:
-
-| Secret                    | What it is                                                                                                                                    |
-| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `CHROME_EXTENSION_ID`     | The extension's ID from the Chrome Web Store Developer Dashboard (32-character lowercase string).                                             |
-| `CHROME_PUBLISHER_ID`     | The publisher's numeric ID. Open the Developer Dashboard, click into your item, and copy the long ID segment from the URL `…/devconsole/<PUBLISHER_ID>/…`. Needed for the v2 cancelSubmission API. |
-| `CHROME_CLIENT_ID`        | OAuth 2.0 client ID from a Google Cloud project with the Chrome Web Store API enabled (Desktop app client type).                             |
-| `CHROME_CLIENT_SECRET`    | OAuth 2.0 client secret for the same client.                                                                                                  |
-| `CHROME_REFRESH_TOKEN`    | OAuth 2.0 refresh token for the Chrome Web Store publisher account that owns the extension. Generate with `bunx chrome-webstore-upload-keys`. |
-
-### One-time: how to generate the Chrome Web Store credentials
-
-Follow the steps in [fregante/chrome-webstore-upload-keys](https://github.com/fregante/chrome-webstore-upload-keys). Condensed:
-
-1. Go to https://console.developers.google.com/apis/credentials and create a project (e.g. `teak-extension-release`).
-2. At https://console.cloud.google.com/auth/overview, set up OAuth (Internal audience is fine).
-3. Create an OAuth client of type **Desktop app**. Save the client ID and client secret → these become `CHROME_CLIENT_ID` and `CHROME_CLIENT_SECRET`.
-4. Enable the Chrome Web Store API at https://console.cloud.google.com/apis/library/chromewebstore.googleapis.com.
-5. Generate the refresh token locally, signed into the same Google account that owns the extension in the Chrome Web Store:
-   ```bash
-   bunx chrome-webstore-upload-keys
-   ```
-   Enter the client ID and client secret, approve in the browser, and copy the `REFRESH_TOKEN` value → this becomes `CHROME_REFRESH_TOKEN`.
-6. Grab the extension ID from the Chrome Web Store Developer Dashboard → this becomes `CHROME_EXTENSION_ID`.
-
-These credentials are long-lived (refresh tokens do not expire unless revoked) and are reused for every future release.
-
-## First-time prerequisite
-
-The Chrome Web Store API can only publish extensions that already exist in the store. The very first upload must be done manually from the dashboard. After that, every release is automated via the tag push.
+Generate publisher credentials with the current procedure documented by the Chrome Web Store upload tooling. Keep refresh tokens in GitHub Actions secrets and never persist or print them in repository files or logs.

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -1,1 +1,5 @@
-- use `font({ design: "rounded" })` modifier on all Text elements
+# Mobile conventions
+
+Apply `font({ design: "rounded" })` to every SwiftUI `Text` element.
+
+For an iOS release, read `release.md` completely and follow its canonical sequence.

--- a/apps/mobile/release.md
+++ b/apps/mobile/release.md
@@ -9,8 +9,8 @@ iOS build history.
 
 ## Canonical release
 
-1. Patch-bump every tracked `package.json` to the same next version.
-2. Merge that scoped bump to `main`.
+1. Complete the shared preparation in `../../docs/agents/releases.md`.
+2. Merge that scoped version change to `main`.
 3. `Version Tag` verifies that the change is exactly one patch, creates
    `v<version>`, and dispatches every product release at that tag. A rerun
    reuses successful or active child runs and dispatches only missing work.

--- a/apps/safari-extension/release.md
+++ b/apps/safari-extension/release.md
@@ -7,8 +7,8 @@ patch bump merged to `main` is the only normal manual release action. Root
 
 ## Canonical release
 
-1. Patch-bump every tracked `package.json` to the same next version and merge
-   the scoped bump to `main`.
+1. Complete the shared preparation in `../../docs/agents/releases.md` and merge
+   the scoped version change to `main`.
 2. `Version Tag` verifies the next-patch and lockstep invariants, creates
    `v<version>`, and dispatches every product release at that tag. A rerun
    reuses successful or active child runs and dispatches only missing work.

--- a/docs/agents/headless-development.md
+++ b/docs/agents/headless-development.md
@@ -6,7 +6,7 @@ Use this guide only in Cursor Cloud or another headless VM. For local developmen
 
 Read the required Bun version from the root `packageManager` field. Install that exact version if Bun is unavailable, then run `bun install --frozen-lockfile` from the repository root.
 
-`turbo watch` expects an interactive UI. In a headless session, set `TURBO_UI=tui` or run the required services separately.
+`turbo watch` defaults to an interactive UI. In a headless session, set `TURBO_UI=false` for streaming output or run the required services separately.
 
 ## Minimal web stack
 

--- a/docs/agents/headless-development.md
+++ b/docs/agents/headless-development.md
@@ -1,0 +1,43 @@
+# Headless development
+
+Use this guide only in Cursor Cloud or another headless VM. For local development, use the normal root scripts.
+
+## Runtime
+
+Read the required Bun version from the root `packageManager` field. Install that exact version if Bun is unavailable, then run `bun install --frozen-lockfile` from the repository root.
+
+`turbo watch` expects an interactive UI. In a headless session, set `TURBO_UI=tui` or run the required services separately.
+
+## Minimal web stack
+
+Start Convex from `packages/convex` in a persistent session:
+
+```bash
+export CONVEX_AGENT_MODE=anonymous
+bun run dev
+```
+
+Start the web app from `apps/web` in another persistent session:
+
+```bash
+bunx portless app.teak next dev
+```
+
+Use the localhost URL printed by Portless. Do not assume a fixed port.
+
+Create `apps/web/.env.local` from the active Convex deployment values. A local anonymous deployment normally uses:
+
+```dotenv
+NEXT_PUBLIC_CONVEX_URL=http://127.0.0.1:3210
+NEXT_PUBLIC_CONVEX_SITE_URL=http://127.0.0.1:3211
+```
+
+## First-run authentication
+
+Set the anonymous Convex deployment's Google client values, `SITE_URL`, and `JWKS`. Test values are acceptable for OAuth credentials in local development. Generate `JWKS` as the array expected by the installed `@convex-dev/better-auth` version; consult its current documentation instead of copying a stale shape.
+
+Better Auth validates the browser origin. If authentication reports `Invalid origin`, set `SITE_URL` to the exact browser origin, wait for Convex to redeploy, and retry.
+
+Test users can be marked verified through the existing internal test-setup endpoint. Inspect its current validator and route before calling it; do not cache a request contract here.
+
+The environment is ready when Convex and the web app remain running, the login page loads at the printed localhost URL, and a test session can authenticate without an origin error.

--- a/docs/agents/releases.md
+++ b/docs/agents/releases.md
@@ -1,0 +1,13 @@
+# Shared release preparation
+
+Every Teak product release starts from one next-patch version change. Complete this preparation before following a product runbook:
+
+1. Update the `version` field in every tracked `package.json` to the same next patch version.
+2. Run `bun install` from the repository root to synchronize `bun.lock`.
+3. From `apps/raycast`, run `npm install --package-lock-only --ignore-scripts` to synchronize both version fields in `package-lock.json`.
+4. From the repository root, run `bun install --frozen-lockfile` and `node scripts/release-version.mjs lockstep <version>`. Both commands must exit successfully without changing files.
+5. Commit every package manifest, `bun.lock`, and `apps/raycast/package-lock.json` together as one scoped version change.
+
+The preparation is complete when the working tree contains the intended version-only diff and the lockstep validator confirms every package manifest and npm lockfile uses the target version.
+
+Keep published version tags immutable. The `Version Tag` workflow creates the tag after the version change reaches `main`; do not create or move it manually during the normal release path.

--- a/packages/convex/AGENTS.md
+++ b/packages/convex/AGENTS.md
@@ -1,7 +1,3 @@
 <!-- convex-ai-start -->
-This project uses [Convex](https://convex.dev) as its backend.
-
-When working on Convex code, **always read `/_generated/ai/guidelines.md` first** for important guidelines on how to correctly use Convex APIs and patterns. The file contains rules that override what you may have learned about Convex from training data.
-
-Convex agent skills for common tasks can be installed by running `npx convex ai-files install`.
+Before editing this workspace, read `_generated/ai/guidelines.md` completely. Its generated Convex API and architecture rules override general guidance.
 <!-- convex-ai-end -->

--- a/packages/convex/CLAUDE.md
+++ b/packages/convex/CLAUDE.md
@@ -1,7 +1,1 @@
-<!-- convex-ai-start -->
-This project uses [Convex](https://convex.dev) as its backend.
-
-When working on Convex code, **always read `/_generated/ai/guidelines.md` first** for important guidelines on how to correctly use Convex APIs and patterns. The file contains rules that override what you may have learned about Convex from training data.
-
-Convex agent skills for common tasks can be installed by running `npx convex ai-files install`.
-<!-- convex-ai-end -->
+@AGENTS.md


### PR DESCRIPTION
## Summary
- reduce the always-loaded root agent guide and point branch-specific work to canonical references
- add scoped guidance for CLI releases, docs changelogs, mobile UI, Convex, and headless development
- align desktop and browser-extension runbooks with the automatic immutable-tag release flow

## Validation
- pre-commit: `turbo run typecheck lint build --affected` (18/18 tasks passed)
- `bun run --cwd apps/docs build` (0 audit errors)
- `bun run --cwd apps/docs validate` (no broken links)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added concise guidance for project architecture, verification, release procedures, and headless development.
  * Added CLI release documentation, including package publishing and version verification steps.
  * Updated desktop, extension, mobile, and backend workflow references with streamlined release and development instructions.
  * Added changelog writing conventions focused on clear, user-observable outcomes.
  * Clarified mobile interface font conventions for SwiftUI text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->