### PR TITLE
chore: Bun 1.4.0, probe-image-size, and Cloudflare dev/prod parity

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -49,7 +49,7 @@ jobs:
         if: steps.check.outputs.should_publish == 'true'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.4.0"
 
       - name: Setup Node
         if: steps.check.outputs.should_publish == 'true'

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -62,7 +62,7 @@ jobs:
         if: steps.check.outputs.should_run == 'true'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.4.0"
 
       - name: Install dependencies
         if: steps.check.outputs.should_run == 'true'

--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -41,7 +41,7 @@ jobs:
         if: steps.check.outputs.should_run == 'true'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: "1.3.5"
+          bun-version: "1.4.0"
 
       - name: Install dependencies
         if: steps.check.outputs.should_run == 'true'

--- a/.github/workflows/mobile-release.yml
+++ b/.github/workflows/mobile-release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: 1.3.5
+          bun-version: 1.4.0
       - name: Set up asc
         uses: rudrankriyam/setup-asc@5358c70a27a3f0d1517604b0f1fdc43e70c1cc4d # v1.0.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
-.apps/files-worker/.dev.vars
+apps/files-worker/.dev.vars
 
 # vercel
 .vercel

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+.apps/files-worker/.dev.vars
 
 # vercel
 .vercel

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -19,7 +19,7 @@
     "blume": "^1.4.1"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.14",
+    "@types/bun": "^1.4.0",
     "open-cli": "9.0.0",
     "typescript": "^6.0.3"
   },

--- a/apps/files-worker/README.md
+++ b/apps/files-worker/README.md
@@ -1,9 +1,12 @@
 # @teak/files-worker
 
 The Cloudflare Worker for Teak file delivery, uploads, processing, imports,
-and exports. Production serves `files.teakvault.com` from `teak-files-prod`;
-the isolated development environment serves `files-dev.teakvault.com` from
-`teak-files-dev`. Both buckets remain private.
+and exports. Production serves `files.teakvault.com` from `teak-files-prod`
+(the canonical bucket for both environments). Development objects live under
+`dev/users/...` in the same `teak-files-prod` bucket; the legacy
+`files-dev.teakvault.com` Worker/domain and `teak-files-dev` bucket are
+retained unchanged for rollback only and are no longer in the canonical
+`wrangler.jsonc`.
 
 The Convex backend mints long-lived HMAC-signed URLs
 (`packages/convex/storage/r2.ts` → `buildSignedWorkerFileUrl`). This worker
@@ -58,9 +61,11 @@ requests at `/__ops/v1`. Contracts and typed success/error envelopes live in
 - `head-object` returns existence, size, ETag, and content type for a key —
   used to verify Kernel-generated media after direct uploads before Convex
   records it.
-- `list-objects` pages objects under a `users/` prefix (limit ≤1000, opaque
-  cursor) — used by the stale pending-upload sweep and the weekly
-  orphaned-object reconciliation report.
+- `list-objects` pages objects under a `users/` (prod) or `dev/users/`
+  (dev) prefix (limit ≤1000, opaque cursor) — used by the stale
+  pending-upload sweep and the weekly orphaned-object reconciliation report.
+  The production Worker accepts both prefixes so dev traffic can share the
+  prod bucket.
 - `generate-image-metadata` feeds the existing `detail` rendition into
   Workers AI (Gemma multimodal) with the same system prompt, JSON output
   shape, and bounded validation retries as the pipeline it replaced; image
@@ -77,9 +82,9 @@ type unbound: the signature is computed with an empty content type and the
 request's validated `Content-Type` header is stored verbatim (used when the
 encoding is decided at generation time, e.g. WebP-vs-JPEG video frames).
 `Content-Length` is mandatory, oversized bodies are rejected, and keys must
-live under a `users/<id>/...` prefix with no traversal segments
-(`src/upload.ts`). Server-generated media signs without a bound size and
-relies on the worker's hard cap instead.
+live under a `users/<id>/...` (or `dev/users/<id>/...` for dev) prefix
+with no traversal segments (`src/upload.ts`). Server-generated media signs
+without a bound size and relies on the worker's hard cap instead.
 
 Convex owns authorization, durable product state, and workflow orchestration;
 this Worker is the one canonical implementation for file-byte operations.
@@ -96,18 +101,44 @@ bun run cf-typegen  # refresh generated Worker bindings/runtime types
 bun run typecheck   # tsc --noEmit
 bunx wrangler deploy --dry-run --outdir /tmp/out   # bundle size check
 bun run deploy      # wrangler deploy (creates files.teakvault.com custom domain)
-bunx wrangler deploy --env development # deploys files-dev.teakvault.com
+
+# Local development
+bun run dev              # wrangler dev --remote (prod R2/Images remote, code local)
+bun run dev:local        # wrangler dev (isolated Miniflare, low-fidelity Images)
+# Or from repo root:
+bun run dev:files        # same as above, remote bindings
+bun run dev:files:local  # same as above, isolated
+
+# Config parity (read-only, never prints secrets)
+bun run check:cloudflare  # reports wrangler names + Convex env parity as same/different/missing/updated
+
+# One-time Convex convergence (copy prod -> dev without logging values):
+#   npx convex env get CLOUDFLARE_ACCOUNT_ID --prod   # read prod (no print in CI)
+#   npx convex env set CLOUDFLARE_ACCOUNT_ID <value> --deployment dev  # set dev
+# Repeat for CLOUDFLARE_API_TOKEN, FILES_SIGNING_SECRET, R2_ACCESS_KEY_ID,
+# R2_ENDPOINT, R2_SECRET_ACCESS_KEY, R2_TOKEN, then:
+#   npx convex env set R2_BUCKET teak-files-prod --deployment dev
+#   npx convex env set R2_KEY_PREFIX dev/ --deployment dev
+#   npx convex env set FILES_BASE https://files.teakvault.com --deployment dev
+# (During pre-merge, point FILES_BASE to `wrangler dev --remote` preview URL.)
 ```
 
-## Secrets
+## Secrets and local vars
 
 - `FILES_SIGNING_SECRET` — must match its corresponding Convex deployment.
-  Set production with `bunx wrangler secret put FILES_SIGNING_SECRET` and
-  development with
-  `bunx wrangler secret put FILES_SIGNING_SECRET --env development`.
+  Set production with `bunx wrangler secret put FILES_SIGNING_SECRET`.
+  The legacy `files-dev` Worker used `--env development`; that Worker is
+  retained for rollback but no longer canonical.
 - `SENTRY_DSN` — DSN for error reporting (`@sentry/cloudflare`, errors only).
   Reporting stays disabled until this is set. Set with:
   `bunx wrangler secret put SENTRY_DSN`
+
+- `apps/files-worker/.dev.vars` (ignored) — per-developer local overrides for
+  `wrangler dev`. Example: `FILES_SIGNING_SECRET=...`. Do not commit. The
+  canonical dev routing (`R2_BUCKET`, `R2_KEY_PREFIX`, `FILES_BASE`) lives in
+  Convex env, not `.dev.vars`. Production-data warning: dev writes share the
+  prod bucket (`teak-files-prod`) and are isolated only by `dev/` prefix;
+  credentials retain bucket-wide authority.
 
 Handled op failures (the 500 path) are reported explicitly with op/route,
 HTTP method + path, and card/role identifiers parsed from the object key
@@ -121,5 +152,23 @@ The Convex deployment requires both `FILES_BASE` and
 presigned-R2 fallback when the custom file domain is disabled.
 
 Deploys automatically via Cloudflare Workers Builds (main branch).
-The development Worker is deployed explicitly with `--env development` so
-development data can never be read through the production bucket binding.
+
+**Rollback window:** the `files-dev` Worker, `files-dev.teakvault.com`
+domain, and `teak-files-dev` bucket (≃1 000 objects / 370 MB) are untouched
+and retained. To rollback, re-add the `env.development` block to
+`wrangler.jsonc` and reset Convex dev vars:
+`R2_BUCKET=teak-files-dev`, `R2_KEY_PREFIX=""`, and
+`FILES_BASE=https://files-dev.teakvault.com`. No copy/migration/backfill is
+performed.
+
+## Local development experience
+
+- `bun run dev` at repo root still starts the all-surface stack (web, convex,
+  desktop, raycast, docs, extension) via Turborepo.
+- `bun run dev:files` — local Worker with remote Cloudflare R2/Images/AI
+  bindings (code local, bucket remote). Use for real image transforms and
+  prod-data dev isolation (`dev/users/...`).
+- `bun run dev:files:local` — isolated Miniflare storage with low-fidelity
+  Images emulation; no remote credentials needed.
+- `bun run check:cloudflare` — read-only names/parity check without exposing
+  secret values.

--- a/apps/files-worker/package.json
+++ b/apps/files-worker/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "scripts": {
     "cf-typegen": "wrangler types",
+    "check": "bun run ../..//scripts/check-cloudflare.ts",
     "deploy": "wrangler deploy",
-    "dev": "wrangler dev",
+    "dev": "wrangler dev --remote",
+    "dev:local": "wrangler dev",
     "test": "bun test src",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/files-worker/src/ops.ts
+++ b/apps/files-worker/src/ops.ts
@@ -73,9 +73,12 @@ const optionalString = (
   return typeof value === "string" && value ? value : null;
 };
 
+const stripDevPrefix = (key: string): string =>
+  key.startsWith("dev/") ? key.slice(4) : key;
+
 const sameUserNamespace = (left: string, right: string): boolean => {
-  const leftParts = left.split("/");
-  const rightParts = right.split("/");
+  const leftParts = stripDevPrefix(left).split("/");
+  const rightParts = stripDevPrefix(right).split("/");
   return (
     leftParts[0] === "users" &&
     rightParts[0] === "users" &&
@@ -313,7 +316,10 @@ const dispatch = async (
     }
     case "list-objects": {
       const prefix = requiredString(params, "prefix");
-      if (!prefix.startsWith("users/") || prefix.includes("\\0")) {
+      if (
+        !(prefix.startsWith("users/") || prefix.startsWith("dev/users/")) ||
+        prefix.includes("\0")
+      ) {
         throw new Error("invalid_prefix");
       }
       const limit = params.limit;

--- a/apps/files-worker/src/sentry.ts
+++ b/apps/files-worker/src/sentry.ts
@@ -53,7 +53,9 @@ export interface FileKeyIdentifiers {
  * else parses to no identifiers instead of guessing.
  */
 export const parseFileKeyIdentifiers = (key: string): FileKeyIdentifiers => {
-  const segments = key.split("/");
+  const rawSegments = key.split("/");
+  const segments =
+    rawSegments[0] === "dev" ? rawSegments.slice(1) : rawSegments;
   if (
     segments.length < 5 ||
     segments[0] !== "users" ||

--- a/apps/files-worker/src/upload.ts
+++ b/apps/files-worker/src/upload.ts
@@ -45,9 +45,12 @@ export const uploadError = (
   return response;
 };
 
-/** Object keys live under per-user prefixes; refuse anything that could escape. */
+/** Object keys live under per-user prefixes; refuse anything that could escape.
+ * Production uses `users/...`, development uses `dev/users/...`; the canonical
+ * production Worker accepts both so dev traffic can share the prod bucket.
+ */
 export const isValidUploadKey = (key: string): boolean =>
-  key.startsWith("users/") &&
+  (key.startsWith("users/") || key.startsWith("dev/users/")) &&
   !key.includes("\0") &&
   !key.split("/").includes("..") &&
   !key.includes("//") &&

--- a/apps/files-worker/wrangler.jsonc
+++ b/apps/files-worker/wrangler.jsonc
@@ -26,28 +26,5 @@
   "observability": {
     "enabled": true,
     "head_sampling_rate": 1
-  },
-  "env": {
-    "development": {
-      "name": "teak-files-proxy-dev",
-      "routes": [
-        {
-          "pattern": "files-dev.teakvault.com",
-          "custom_domain": true
-        }
-      ],
-      "r2_buckets": [
-        {
-          "binding": "BUCKET",
-          "bucket_name": "teak-files-dev"
-        }
-      ],
-      "ai": {
-        "binding": "AI"
-      },
-      "images": {
-        "binding": "IMAGES"
-      }
-    }
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -70,7 +70,7 @@
         "blume": "^1.4.1",
       },
       "devDependencies": {
-        "@types/bun": "^1.3.14",
+        "@types/bun": "^1.4.0",
         "open-cli": "9.0.0",
         "typescript": "^6.0.3",
       },
@@ -250,14 +250,15 @@
         "convex": "^1.43.0",
         "convex-helpers": "^0.1.122",
         "htmlparser2": "^12.0.0",
-        "image-size": "2.0.2",
         "jose": "6.1.3",
+        "probe-image-size": "7.4.0",
         "react": "^19.2.8",
         "undici": "^7.29.0",
         "yauzl": "^3.4.0",
         "zod": "4.4.3",
       },
       "devDependencies": {
+        "@types/probe-image-size": "^7.2.5",
         "@types/react": "^19.2.18",
         "@types/yauzl": "^3.4.0",
         "fflate": "^0.8.3",
@@ -285,7 +286,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.62.1",
-        "@types/bun": "^1.3.14",
+        "@types/bun": "^1.4.0",
         "tsx": "^4.23.11",
         "typescript": "^6.0.3",
       },
@@ -1824,7 +1825,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
 
@@ -1936,6 +1937,8 @@
 
     "@types/mute-stream": ["@types/mute-stream@0.0.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow=="],
 
+    "@types/needle": ["@types/needle@3.3.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-UFIuc1gdyzAqeVUYpSL+cliw2MmU/ZUhVZKE7Zo4wPbgc8hbljeKSnn6ls6iG8r5jpegPXLUIhJ+Wb2kLVs8cg=="],
+
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
 
     "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
@@ -1943,6 +1946,8 @@
     "@types/plist": ["@types/plist@3.0.5", "", { "dependencies": { "@types/node": "*", "xmlbuilder": ">=11.0.1" } }, "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA=="],
 
     "@types/prismjs": ["@types/prismjs@1.26.6", "", {}, "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="],
+
+    "@types/probe-image-size": ["@types/probe-image-size@7.2.5", "", { "dependencies": { "@types/needle": "*", "@types/node": "*" } }, "sha512-9Bg6d/GNnjmhMMxadDstwrSlquuuLf0jQuPszbU6n3QUfybif3V/ryD3J2i9iaiC5JB/FU/8E41n88SM/UB+Tg=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
@@ -2252,7 +2257,7 @@
 
     "builder-util-runtime": ["builder-util-runtime@9.7.0", "", { "dependencies": { "debug": "^4.3.4", "sax": "^1.2.4" } }, "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -3072,7 +3077,7 @@
 
     "iconv-corefoundation": ["iconv-corefoundation@1.1.7", "", { "dependencies": { "cli-truncate": "^2.1.0", "node-addon-api": "^1.6.3" }, "os": "darwin" }, "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ=="],
 
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+    "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -3574,6 +3579,8 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
+    "needle": ["needle@2.9.1", "", { "dependencies": { "debug": "^3.2.6", "iconv-lite": "^0.4.4", "sax": "^1.2.4" }, "bin": { "needle": "./bin/needle" } }, "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ=="],
+
     "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
@@ -3801,6 +3808,8 @@
     "prism-react-renderer": ["prism-react-renderer@2.4.1", "", { "dependencies": { "@types/prismjs": "^1.26.0", "clsx": "^2.0.0" }, "peerDependencies": { "react": ">=16.0.0" } }, "sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig=="],
 
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
+
+    "probe-image-size": ["probe-image-size@7.4.0", "", { "dependencies": { "lodash.merge": "^4.6.2", "needle": "^2.5.2", "stream-parser": "~0.3.1" } }, "sha512-cdEprVtZxV+awMde9X+4jILBFYh4CARxVrQaMl4wY4YcPWbul9jntXrIW95NInBDyJwcVUP3U0T6yukN8rMBaQ=="],
 
     "proc-log": ["proc-log@2.0.1", "", {}, "sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw=="],
 
@@ -4167,6 +4176,8 @@
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "stream-buffers": ["stream-buffers@2.2.0", "", {}, "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg=="],
+
+    "stream-parser": ["stream-parser@0.3.1", "", { "dependencies": { "debug": "2" } }, "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ=="],
 
     "strict-uri-encode": ["strict-uri-encode@2.0.0", "", {}, "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="],
 
@@ -4782,6 +4793,8 @@
 
     "@inquirer/external-editor/chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
 
+    "@inquirer/external-editor/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
     "@inquirer/input/@inquirer/type": ["@inquirer/type@2.0.0", "", { "dependencies": { "mute-stream": "^1.0.0" } }, "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag=="],
 
     "@inquirer/number/@inquirer/type": ["@inquirer/type@2.0.0", "", { "dependencies": { "mute-stream": "^1.0.0" } }, "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag=="],
@@ -5110,9 +5123,9 @@
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
-    "builder-util/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+    "body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
-    "bun-types/@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
+    "builder-util/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "c12/giget": ["giget@3.3.1", "", { "bin": { "giget": "dist/cli.mjs" } }, "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg=="],
 
@@ -5231,8 +5244,6 @@
     "express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "external-editor/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "extract-zip/@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
@@ -5366,6 +5377,8 @@
 
     "minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
+    "needle/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
+
     "next/postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "node-gyp/nopt": ["nopt@9.0.0", "", { "dependencies": { "abbrev": "^4.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw=="],
@@ -5430,6 +5443,8 @@
 
     "publish-browser-extension/cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
 
+    "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
     "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "react-native/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
@@ -5477,6 +5492,8 @@
     "ssri/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "stacktrace-parser/type-fest": ["type-fest@0.7.1", "", {}, "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="],
+
+    "stream-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "string-width-cjs/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
@@ -6058,8 +6075,6 @@
 
     "better-call/@better-auth/utils/@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
-    "bun-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
-
     "cacache/glob/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "chrome-launcher/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
@@ -6295,6 +6310,8 @@
     "read-pkg-up/find-up/locate-path": ["locate-path@2.0.0", "", { "dependencies": { "p-locate": "^2.0.0", "path-exists": "^3.0.0" } }, "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA=="],
 
     "rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "stream-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "svgo/css-tree/mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:extension": "turbo run build --filter=@teak/extension",
     "build:raycast": "turbo run build --filter=./apps/raycast",
     "check": "ultracite check",
+    "check:cloudflare": "bun run scripts/check-cloudflare.ts",
     "clean": "turbo daemon clean && rm -rf node_modules/.cache && find . -name '.turbo' -type d -prune -exec rm -rf {} +",
     "dev": "turbo watch dev --filter=@teak/web --filter=@teak/convex --filter=@teak/desktop --filter=./apps/raycast --filter=@teak/docs --filter=@teak/extension",
     "dev:all": "turbo watch dev",
@@ -20,6 +21,8 @@
     "dev:desktop": "turbo watch dev --filter=@teak/desktop",
     "dev:docs": "turbo watch dev --filter=@teak/docs",
     "dev:extension": "turbo watch dev --filter=@teak/extension --filter=@teak/convex",
+    "dev:files": "bun run --filter @teak/files-worker dev",
+    "dev:files:local": "bun run --filter @teak/files-worker dev:local",
     "dev:mobile": "turbo watch dev --filter=@teak/mobile",
     "dev:raycast": "turbo watch dev --filter=./apps/raycast",
     "dev:web": "turbo watch dev --filter=@teak/web --filter=@teak/convex",
@@ -55,7 +58,7 @@
     "turbo": "^2.10.9",
     "ultracite": "7.10.4"
   },
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.0",
   "trustedDependencies": [
     "@sentry/cli",
     "@swc/core",

--- a/packages/convex/__tests__/__tests__/getFileUrl.test.ts
+++ b/packages/convex/__tests__/__tests__/getFileUrl.test.ts
@@ -19,7 +19,8 @@ test("getFileUrl enforces auth and card ownership checks", () => {
       /linkPreview\?\.screenshotStorageKey\s*===\s*args\.key/.test(source) &&
       /linkPreview\?\.imageStorageKey\s*===\s*args\.key/.test(source)) ||
     (/cardOwnsMediaKey/.test(source) &&
-      /card\.fileKey\s*===\s*key/.test(source));
+      /card\.fileKey\s*===\s*key/.test(source) &&
+      /cardOwnsMediaKey\s*\(\s*card\s*,\s*args\.key\s*\)/.test(source));
 
   expect(requiresKey).toBe(true);
   expect(requiresCardId).toBe(true);

--- a/packages/convex/__tests__/__tests__/getFileUrl.test.ts
+++ b/packages/convex/__tests__/__tests__/getFileUrl.test.ts
@@ -14,10 +14,12 @@ test("getFileUrl enforces auth and card ownership checks", () => {
   const requiresAuth = /if\s*\(\s*!user\s*\)/.test(source);
   const checksOwnership = /card\.userId\s*!==\s*user\.subject/.test(source);
   const checksFileMatch =
-    /card\.fileKey\s*===\s*args\.key/.test(source) &&
-    /card\.thumbnailKey\s*===\s*args\.key/.test(source) &&
-    /linkPreview\?\.screenshotStorageKey\s*===\s*args\.key/.test(source) &&
-    /linkPreview\?\.imageStorageKey\s*===\s*args\.key/.test(source);
+    (/card\.fileKey\s*===\s*args\.key/.test(source) &&
+      /card\.thumbnailKey\s*===\s*args\.key/.test(source) &&
+      /linkPreview\?\.screenshotStorageKey\s*===\s*args\.key/.test(source) &&
+      /linkPreview\?\.imageStorageKey\s*===\s*args\.key/.test(source)) ||
+    (/cardOwnsMediaKey/.test(source) &&
+      /card\.fileKey\s*===\s*key/.test(source));
 
   expect(requiresKey).toBe(true);
   expect(requiresCardId).toBe(true);

--- a/packages/convex/__tests__/admin.test.ts
+++ b/packages/convex/__tests__/admin.test.ts
@@ -73,7 +73,7 @@ describe("admin.ts", () => {
     });
 
     test("fails closed when the admin email is not configured", async () => {
-      process.env.TEAK_ADMIN_EMAIL = undefined;
+      delete process.env.TEAK_ADMIN_EMAIL;
       const ctx = {
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         runQuery: mock(),

--- a/packages/convex/__tests__/billing.test.ts
+++ b/packages/convex/__tests__/billing.test.ts
@@ -158,8 +158,10 @@ describe("billing.ts", () => {
 
   test("uses sandbox server by default", () => {
     const originalProd = process.env.POLAR_SERVER;
-    process.env.POLAR_SERVER = undefined;
+    delete process.env.POLAR_SERVER;
     expect(process.env.POLAR_SERVER).toBeUndefined();
-    process.env.POLAR_SERVER = originalProd;
+    if (originalProd !== undefined) {
+      process.env.POLAR_SERVER = originalProd;
+    }
   });
 });

--- a/packages/convex/__tests__/mcp.test.ts
+++ b/packages/convex/__tests__/mcp.test.ts
@@ -44,10 +44,26 @@ const EXPECTED_TOOL_NAMES = [
 ];
 
 afterEach(() => {
-  process.env.PUBLIC_API_URL = originalPublicApiUrl;
-  process.env.PUBLIC_MCP_URL = originalPublicMcpUrl;
-  process.env.AUTH_ISSUER_URL = originalAuthIssuerUrl;
-  process.env.SITE_URL = originalSiteUrl;
+  if (originalPublicApiUrl === undefined) {
+    delete process.env.PUBLIC_API_URL;
+  } else {
+    process.env.PUBLIC_API_URL = originalPublicApiUrl;
+  }
+  if (originalPublicMcpUrl === undefined) {
+    delete process.env.PUBLIC_MCP_URL;
+  } else {
+    process.env.PUBLIC_MCP_URL = originalPublicMcpUrl;
+  }
+  if (originalAuthIssuerUrl === undefined) {
+    delete process.env.AUTH_ISSUER_URL;
+  } else {
+    process.env.AUTH_ISSUER_URL = originalAuthIssuerUrl;
+  }
+  if (originalSiteUrl === undefined) {
+    delete process.env.SITE_URL;
+  } else {
+    process.env.SITE_URL = originalSiteUrl;
+  }
 });
 
 const mcpRequest = (

--- a/packages/convex/__tests__/workflows/steps/linkMetadata/remoteImageDimensions.test.ts
+++ b/packages/convex/__tests__/workflows/steps/linkMetadata/remoteImageDimensions.test.ts
@@ -32,4 +32,77 @@ describe("readRemoteImageDimensions", () => {
     expect(readRemoteImageDimensions(new Uint8Array([1, 2, 3]))).toBeNull();
     expect(readRemoteImageDimensions(pngWithDimensions(0, 10))).toBeNull();
   });
+
+  test("rejects malicious ICNS data without throwing", () => {
+    // GHSA-w3rx-r6r6-pgpr: image-size ICNS DoS. Probe must not throw or loop.
+    const icns = new Uint8Array([
+      0x69, 0x63, 0x6e, 0x73, 0x00, 0x00, 0x00, 0x10, 0x69, 0x63, 0x30, 0x39,
+      0x00, 0x00, 0x00, 0x08, 0xff, 0xff, 0xff, 0xff,
+    ]);
+    expect(readRemoteImageDimensions(icns)).toBeNull();
+    // Truncated ICNS header
+    expect(
+      readRemoteImageDimensions(new Uint8Array([0x69, 0x63, 0x6e, 0x73]))
+    ).toBeNull();
+  });
+
+  test("rejects zero-sized HEIF/AVIF boxes without throwing", () => {
+    // GHSA-5p2g-fcmc-qvqq: HEIF/AVIF with zero-sized boxes must not hang or OOM.
+    const heifZeroBox = new Uint8Array([
+      0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x69, 0x66, 0x31,
+      0x00, 0x00, 0x00, 0x00, 0x6d, 0x69, 0x66, 0x31, 0x68, 0x65, 0x69, 0x63,
+      0x00, 0x00, 0x00, 0x00, 0x6d, 0x65, 0x74, 0x61,
+    ]);
+    expect(readRemoteImageDimensions(heifZeroBox)).toBeNull();
+    const avifZeroBox = new Uint8Array([
+      0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x61, 0x76, 0x69, 0x66,
+      0x00, 0x00, 0x00, 0x00, 0x61, 0x76, 0x69, 0x66, 0x6d, 0x69, 0x66, 0x31,
+      0x00, 0x00, 0x00, 0x00, 0x6d, 0x65, 0x74, 0x61,
+    ]);
+    expect(readRemoteImageDimensions(avifZeroBox)).toBeNull();
+  });
+
+  test("rejects malformed SVG without DoS", () => {
+    // Version 7.4.0 fixes SVG DoS: header search limited to first 10K.
+    const malformedSvg = new TextEncoder().encode(
+      `<svg xmlns="http://www.w3.org/2000/svg" width="x" height="y"><g>${"a".repeat(20_000)}</g></svg>`
+    );
+    expect(readRemoteImageDimensions(malformedSvg)).toBeNull();
+    const noDimSvg = new TextEncoder().encode(
+      `<svg xmlns="http://www.w3.org/2000/svg"></svg>`
+    );
+    expect(readRemoteImageDimensions(noDimSvg)).toBeNull();
+    // Entity expansion should not hang and should still parse valid dimensions.
+    const entitySvg = new TextEncoder().encode(
+      `<!DOCTYPE svg [<!ENTITY x "aaaa">]><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">&x;</svg>`
+    );
+    const result = readRemoteImageDimensions(entitySvg);
+    // Should not throw and should return dimensions if parsed, or null if rejected — but must not hang.
+    expect(
+      result === null || (result.width === 10 && result.height === 10)
+    ).toBe(true);
+  });
+
+  test("rejects completely malformed input without throwing", () => {
+    expect(readRemoteImageDimensions(new Uint8Array([]))).toBeNull();
+    expect(
+      readRemoteImageDimensions(
+        new Uint8Array([0xff, 0xd8, 0xff, 0x00, 0x11, 0x22, 0x33])
+      )
+    ).toBeNull();
+    expect(
+      readRemoteImageDimensions(new TextEncoder().encode("not an image"))
+    ).toBeNull();
+  });
+
+  test("rejects excessive dimensions beyond 32-megapixel budget", () => {
+    expect(readRemoteImageDimensions(pngWithDimensions(8000, 5000))).toBeNull();
+    expect(
+      readRemoteImageDimensions(pngWithDimensions(10_000, 4000))
+    ).toBeNull();
+    const atBudget = Math.floor(Math.sqrt(MAX_REMOTE_IMAGE_PIXELS));
+    expect(
+      readRemoteImageDimensions(pngWithDimensions(atBudget, atBudget))
+    ).not.toBeNull();
+  });
 });

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -55,14 +55,15 @@
     "convex": "^1.43.0",
     "convex-helpers": "^0.1.122",
     "htmlparser2": "^12.0.0",
-    "image-size": "2.0.2",
     "jose": "6.1.3",
+    "probe-image-size": "7.4.0",
     "react": "^19.2.8",
     "undici": "^7.29.0",
     "yauzl": "^3.4.0",
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@types/probe-image-size": "^7.2.5",
     "@types/react": "^19.2.18",
     "@types/yauzl": "^3.4.0",
     "fflate": "^0.8.3",

--- a/packages/convex/storage/filesWorkerClient.ts
+++ b/packages/convex/storage/filesWorkerClient.ts
@@ -17,7 +17,7 @@ import {
   type FilesOp,
   type FilesOpRequest,
 } from "@teak/files-protocol";
-import { hmacSha256Hex } from "./r2";
+import { assertR2KeyInNamespace, hmacSha256Hex } from "./r2";
 
 // Op URLs are minted per action invocation; a short TTL bounds the replay
 // window (the worker additionally rejects exps further than 15 min out).
@@ -65,6 +65,7 @@ export const buildSignedWorkerUploadUrl = async (
   ) {
     throw new Error("invalid_upload_ttl");
   }
+  assertR2KeyInNamespace(key);
   const expiresAtNumber = nowSeconds + ttlSeconds;
   const expiresAt = String(expiresAtNumber);
   const signature = await hmacSha256Hex(
@@ -150,6 +151,7 @@ export const buildSignedMultipartPartUrl = async (
   if (!(base && secret)) {
     throw new Error("files_worker_not_configured");
   }
+  assertR2KeyInNamespace(key);
   const expiresAt = String(nowSeconds + 60 * 60);
   const signature = await hmacSha256Hex(
     secret,

--- a/packages/convex/storage/pendingUploadCleanup.ts
+++ b/packages/convex/storage/pendingUploadCleanup.ts
@@ -7,7 +7,7 @@ import {
   type FilesWorkerListObjectsResult,
   isFilesWorkerConfigured,
 } from "./filesWorkerClient";
-import { PENDING_UPLOAD_CARD_ID } from "./r2";
+import { buildR2ListPrefix, PENDING_UPLOAD_CARD_ID } from "./r2";
 
 const STALE_AFTER_MS = 24 * 60 * 60 * 1000;
 const PENDING_UPLOAD_SEGMENT = `/cards/${PENDING_UPLOAD_CARD_ID}/`;
@@ -40,7 +40,7 @@ export const sweepStalePendingUploadsHandler = async (): Promise<null> => {
 
   do {
     const params: Record<string, unknown> = {
-      prefix: "users/",
+      prefix: buildR2ListPrefix(),
       limit: LIST_PAGE_LIMIT,
     };
     if (cursor) {

--- a/packages/convex/storage/r2.ts
+++ b/packages/convex/storage/r2.ts
@@ -43,6 +43,33 @@ export const PRIVATE_FILE_CACHE_CONTROL = "private, max-age=518400, immutable"; 
 export type R2ObjectKey = string;
 export const PENDING_UPLOAD_CARD_ID = "upload-pending-v2";
 
+/**
+ * Internal R2 key prefix for environment isolation.
+ * - Production: unset -> "users/..."
+ * - Development: "dev/" -> "dev/users/..."
+ * This is protection against routine mistakes; shared credentials retain bucket-wide authority.
+ */
+export const getR2KeyPrefix = (): string => {
+  const raw = process.env.R2_KEY_PREFIX ?? "";
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const normalized = trimmed.replace(/^\/+/, "");
+  return normalized.endsWith("/") ? normalized : `${normalized}/`;
+};
+
+export const buildR2ListPrefix = (): string => `${getR2KeyPrefix()}users/`;
+
+export const isR2KeyInNamespace = (key: string): boolean =>
+  key.startsWith(`${getR2KeyPrefix()}users/`);
+
+export const assertR2KeyInNamespace = (key: string): void => {
+  if (!isR2KeyInNamespace(key)) {
+    throw new Error("invalid_storage_key_namespace");
+  }
+};
+
 interface DownloadResponsePolicy {
   contentDisposition?: "attachment" | "inline";
   contentType?: string;
@@ -76,7 +103,7 @@ const hashUserId = (userId: string) =>
     .toString(36);
 
 export const buildR2UserPrefix = (userId: string) =>
-  ["users", hashUserId(userId), "cards"].join("/");
+  `${getR2KeyPrefix()}users/${hashUserId(userId)}/cards`;
 
 export const buildR2ObjectKey = ({
   userId,
@@ -107,6 +134,7 @@ export const getR2Url = async (
   if (!(filesBase && signingSecret)) {
     throw new Error("files_worker_not_configured");
   }
+  assertR2KeyInNamespace(key);
   return await buildSignedWorkerFileUrl(
     filesBase,
     signingSecret,
@@ -161,6 +189,7 @@ export const buildSignedWorkerFileUrl = async (
   response: DownloadResponsePolicy = {},
   expSeconds = Math.floor(Date.now() / 1000) + SIGNED_URL_EXPIRES_IN_SECONDS
 ): Promise<string> => {
+  assertR2KeyInNamespace(key);
   const exp = String(expSeconds);
   const signature = await hmacSha256Hex(
     secret,
@@ -183,6 +212,7 @@ export const buildSignedWorkerImageUrl = async (
   rendition: FilesImageRendition,
   expSeconds = Math.floor(Date.now() / 1000) + SIGNED_URL_EXPIRES_IN_SECONDS
 ): Promise<string> => {
+  assertR2KeyInNamespace(key);
   const expiresAt = String(expSeconds);
   const signature = await hmacSha256Hex(
     secret,
@@ -195,13 +225,16 @@ export const buildSignedWorkerImageUrl = async (
 export const resolveObjectUrl = async (
   key?: string,
   fileName?: string | null
-) =>
-  key
-    ? getR2Url(
-        key,
-        fileName === undefined ? {} : fileDownloadResponsePolicy(fileName)
-      )
-    : null;
+) => {
+  if (!key) {
+    return null;
+  }
+  assertR2KeyInNamespace(key);
+  return await getR2Url(
+    key,
+    fileName === undefined ? {} : fileDownloadResponsePolicy(fileName)
+  );
+};
 
 export const resolveImageUrl = async (
   key: string | undefined,
@@ -210,6 +243,7 @@ export const resolveImageUrl = async (
   if (!key) {
     return null;
   }
+  assertR2KeyInNamespace(key);
   const filesBase = process.env.FILES_BASE;
   const signingSecret = process.env.FILES_SIGNING_SECRET;
   if (!(filesBase && signingSecret)) {
@@ -257,6 +291,7 @@ export const deleteObject = async (ctx: MutationCtx, key?: string) => {
   if (!key) {
     return;
   }
+  assertR2KeyInNamespace(key);
   // Durable deletion workflow instead of a synchronous component delete:
   // the keys are recorded durably and retried by the workflow step.
   await ctx.scheduler.runAfter(
@@ -274,6 +309,7 @@ export const storeObject = async (
     type?: string;
   }
 ) => {
+  assertR2KeyInNamespace(opts.key);
   await putObjectViaFilesWorker({
     body: blob,
     contentType: opts.type ?? blob.type ?? "application/octet-stream",

--- a/packages/convex/workflows/cardCleanup.ts
+++ b/packages/convex/workflows/cardCleanup.ts
@@ -65,6 +65,9 @@ export const cleanupDeletedCard = internalMutation({
       try {
         await deleteObject(ctx, key);
       } catch (error) {
+        // Legacy dev keys (users/...) are rejected by dev's dev/ namespace guard;
+        // they remain in the retained teak-files-dev bucket (spec: no migration).
+        // The new prefix-scoped orphan sweep correctly ignores them.
         console.error(`${WORKFLOW_LOG_PREFIX} Failed to delete object`, {
           cardId,
           key,

--- a/packages/convex/workflows/objectCleanup.ts
+++ b/packages/convex/workflows/objectCleanup.ts
@@ -38,12 +38,11 @@ export const deleteObjectsAction = internalAction({
     if (!isFilesWorkerConfigured()) {
       throw new Error("files_worker_not_configured");
     }
-    const unique = Array.from(
-      new Set(keys.filter((key) => key.length > 0 && isR2KeyInNamespace(key)))
-    );
-    if (unique.length !== keys.filter((key) => key.length > 0).length) {
+    const usable = keys.filter((key) => key.length > 0);
+    if (usable.some((key) => !isR2KeyInNamespace(key))) {
       throw new Error("invalid_storage_key_namespace");
     }
+    const unique = Array.from(new Set(usable));
     let deleted = 0;
     for (let index = 0; index < unique.length; index += DELETE_BATCH_SIZE) {
       const outcome = await callFilesWorkerJson<{ deleted: number }>({

--- a/packages/convex/workflows/objectCleanup.ts
+++ b/packages/convex/workflows/objectCleanup.ts
@@ -16,6 +16,7 @@ import {
   callFilesWorkerJson,
   isFilesWorkerConfigured,
 } from "../storage/filesWorkerClient";
+import { isR2KeyInNamespace } from "../storage/r2";
 import { workflow } from "./manager";
 
 const internalAny = internal as any;
@@ -37,7 +38,12 @@ export const deleteObjectsAction = internalAction({
     if (!isFilesWorkerConfigured()) {
       throw new Error("files_worker_not_configured");
     }
-    const unique = Array.from(new Set(keys.filter((key) => key.length > 0)));
+    const unique = Array.from(
+      new Set(keys.filter((key) => key.length > 0 && isR2KeyInNamespace(key)))
+    );
+    if (unique.length !== keys.filter((key) => key.length > 0).length) {
+      throw new Error("invalid_storage_key_namespace");
+    }
     let deleted = 0;
     for (let index = 0; index < unique.length; index += DELETE_BATCH_SIZE) {
       const outcome = await callFilesWorkerJson<{ deleted: number }>({
@@ -113,6 +119,11 @@ export const startObjectDeletion = internalMutation({
   returns: v.null(),
   handler: async (ctx, { keys }) => {
     const usable = keys.filter((key) => key.length > 0);
+    for (const key of usable) {
+      if (!isR2KeyInNamespace(key)) {
+        throw new Error("invalid_storage_key_namespace");
+      }
+    }
     if (usable.length === 0) {
       return null;
     }

--- a/packages/convex/workflows/orphanSweep.ts
+++ b/packages/convex/workflows/orphanSweep.ts
@@ -23,7 +23,7 @@ import {
   type FilesWorkerListObjectsResult,
   isFilesWorkerConfigured,
 } from "../storage/filesWorkerClient";
-import { cardStorageObjectKeys } from "../storage/r2";
+import { buildR2ListPrefix, cardStorageObjectKeys } from "../storage/r2";
 import { recordBackendLog } from "../telemetry/sentry";
 
 // Orphans younger than this are ignored: pending-upload sessions, in-flight
@@ -95,7 +95,7 @@ export const sweepOrphanedObjectsHandler = async (
 
   do {
     const params: Record<string, unknown> = {
-      prefix: "users/",
+      prefix: buildR2ListPrefix(),
       limit: LIST_PAGE_LIMIT,
     };
     if (listCursor) {

--- a/packages/convex/workflows/steps/linkMetadata/remoteImageDimensions.ts
+++ b/packages/convex/workflows/steps/linkMetadata/remoteImageDimensions.ts
@@ -1,4 +1,4 @@
-import { imageSize } from "image-size";
+import probe from "probe-image-size";
 
 export const MAX_REMOTE_IMAGE_PIXELS = 32 * 1024 * 1024;
 
@@ -6,7 +6,11 @@ export const readRemoteImageDimensions = (
   bytes: Uint8Array
 ): { height: number; width: number } | null => {
   try {
-    const { height, width } = imageSize(bytes);
+    const result = probe.sync(Buffer.from(bytes));
+    if (!result) {
+      return null;
+    }
+    const { height, width } = result;
     if (!(height && width) || width > MAX_REMOTE_IMAGE_PIXELS / height) {
       return null;
     }

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.62.1",
-    "@types/bun": "^1.3.14",
+    "@types/bun": "^1.4.0",
     "tsx": "^4.23.11",
     "typescript": "^6.0.3"
   }

--- a/scripts/check-cloudflare.ts
+++ b/scripts/check-cloudflare.ts
@@ -131,7 +131,7 @@ const checkDevVars = () => {
   );
 };
 
-const checkConvexEnv = () => {
+const checkConvexEnv = async () => {
   console.log("\n== Convex env parity (read-only, no secret output) ==");
   console.log(`  Expected prod vars: ${expectedProdVars.join(", ")}`);
   console.log(`  Expected dev vars: ${expectedDevVars.join(", ")}`);
@@ -139,31 +139,130 @@ const checkConvexEnv = () => {
     "  Dev-specific routing: R2_BUCKET=teak-files-prod, R2_KEY_PREFIX=dev/, FILES_BASE=https://files.teakvault.com (or temp preview during pre-merge)"
   );
 
-  // Without live comparison, report local env presence only.
-  for (const name of expectedProdVars) {
-    const present = Boolean(process.env[name]);
-    log(
-      `prod ${name}`,
-      present ? "ok" : "missing",
-      present
-        ? "set locally or via Convex"
-        : "copy from Convex prod to dev without logging value"
+  const getDeploymentValue = async (
+    name: string,
+    deployment: "prod" | "dev"
+  ): Promise<{ found: boolean; value: string }> => {
+    try {
+      // biome-ignore lint/correctness/noUndeclaredVariables: Bun global in Bun runtime
+      const proc = Bun.spawn(
+        ["npx", "convex", "env", "get", name, "--deployment", deployment],
+        { cwd: ROOT, stdout: "pipe", stderr: "pipe" }
+      );
+      await proc.exited;
+      const out = await new Response(proc.stdout).text();
+      const err = await new Response(proc.stderr).text();
+      const combined = `${out}\n${err}`;
+      if (combined.includes("not found")) {
+        return { found: false, value: "" };
+      }
+      const lines = out
+        .split("\n")
+        .filter(
+          (l) => !(l.includes("ExperimentalWarning") || l.includes("Use node"))
+        );
+      const value = lines[lines.length - 1]?.trim() ?? "";
+      if (!value || proc.exitCode !== 0) {
+        return { found: false, value: "" };
+      }
+      return { found: true, value };
+    } catch {
+      return { found: false, value: "" };
+    }
+  };
+
+  let hasDeployment = false;
+  try {
+    const test = await getDeploymentValue("CLOUDFLARE_ACCOUNT_ID", "prod");
+    hasDeployment =
+      test.found ||
+      (await getDeploymentValue("CLOUDFLARE_ACCOUNT_ID", "dev")).found;
+  } catch {}
+
+  if (hasDeployment) {
+    for (const name of expectedProdVars) {
+      const prod = await getDeploymentValue(name, "prod");
+      const dev = await getDeploymentValue(name, "dev");
+      if (!(prod.found || dev.found)) {
+        log(name, "missing", "both deployments missing");
+      } else if (!prod.found) {
+        log(name, "missing", "prod missing");
+      } else if (!dev.found) {
+        log(name, "missing", "dev missing");
+      } else if (prod.value === dev.value) {
+        log(name, "same", "prod == dev");
+      } else {
+        log(name, "different", "prod != dev (content not shown)");
+      }
+    }
+    for (const name of ["R2_BUCKET", "R2_KEY_PREFIX", "FILES_BASE"] as const) {
+      const dev = await getDeploymentValue(name, "dev");
+      const prod = await getDeploymentValue(name, "prod");
+      if (name === "R2_KEY_PREFIX") {
+        if (!dev.found) {
+          log(name, "missing", "dev should be dev/");
+        } else if (dev.value === "dev/") {
+          log(name, "same", "dev prefix ok");
+        } else {
+          log(
+            name,
+            "different",
+            `dev is ${dev.value ? "set" : "missing"} (content not shown)`
+          );
+        }
+        if (prod.found) {
+          log(`${name} (prod)`, "different", "prod should be unset");
+        }
+        continue;
+      }
+      if (
+        name === "R2_BUCKET" &&
+        dev.found &&
+        dev.value === "teak-files-prod"
+      ) {
+        log(name, "same", "prod bucket canonical");
+      } else if (
+        name === "FILES_BASE" &&
+        dev.found &&
+        dev.value === "https://files.teakvault.com"
+      ) {
+        log(name, "same", "worker origin prod");
+      } else if (dev.found) {
+        log(name, "different", "value present (content not shown)");
+      } else {
+        log(name, "missing");
+      }
+    }
+  } else {
+    console.log(
+      "  (No Convex deployment reachable locally; reporting local env presence only)"
     );
-  }
-  for (const name of ["R2_BUCKET", "R2_KEY_PREFIX", "FILES_BASE"] as const) {
-    const val = process.env[name];
-    if (!val) {
-      log(`dev ${name}`, "missing");
-    } else if (name === "R2_BUCKET" && val === "teak-files-prod") {
-      log(`dev ${name}`, "ok", "prod bucket canonical");
-    } else if (name === "R2_KEY_PREFIX" && val === "dev/") {
-      log(`dev ${name}`, "ok", "dev prefix");
-    } else if (name === "FILES_BASE" && val.startsWith("https://")) {
-      log(`dev ${name}`, "ok", "worker origin");
-    } else {
-      log(`dev ${name}`, "different", "value present (content not shown)");
+    for (const name of expectedProdVars) {
+      const present = Boolean(process.env[name]);
+      log(
+        `prod ${name}`,
+        present ? "ok" : "missing",
+        present
+          ? "set locally or via Convex"
+          : "copy from Convex prod to dev without logging value"
+      );
+    }
+    for (const name of ["R2_BUCKET", "R2_KEY_PREFIX", "FILES_BASE"] as const) {
+      const val = process.env[name];
+      if (!val) {
+        log(`dev ${name}`, "missing");
+      } else if (name === "R2_BUCKET" && val === "teak-files-prod") {
+        log(`dev ${name}`, "ok", "prod bucket canonical");
+      } else if (name === "R2_KEY_PREFIX" && val === "dev/") {
+        log(`dev ${name}`, "ok", "dev prefix");
+      } else if (name === "FILES_BASE" && val.startsWith("https://")) {
+        log(`dev ${name}`, "ok", "worker origin");
+      } else {
+        log(`dev ${name}`, "different", "value present (content not shown)");
+      }
     }
   }
+
   console.log(
     "\n  Convergence: read prod values (CLOUDFLARE_* etc.) and set in Convex dev via `npx convex env set --deployment dev NAME` without logging; report only same/different/missing/updated."
   );
@@ -172,13 +271,13 @@ const checkConvexEnv = () => {
   );
 };
 
-const main = () => {
+const main = async () => {
   console.log(
     "Cloudflare / R2 parity check (read-only, secrets never printed)"
   );
   checkWrangler();
   checkDevVars();
-  checkConvexEnv();
+  await checkConvexEnv();
   console.log("\n== Summary ==");
   console.log(
     "  • Keep `bun run dev` for all-surface stack; use `bun run dev:files` (remote bindings) vs `bun run dev:files:local` (Miniflare, low-fidelity Images)."

--- a/scripts/check-cloudflare.ts
+++ b/scripts/check-cloudflare.ts
@@ -1,0 +1,195 @@
+#!/usr/bin/env bun
+/**
+ * Read-only Cloudflare / R2 configuration parity check.
+ * Reports names and parity status without exposing secret values.
+ *
+ * Checks:
+ * - Wrangler top-level bindings (R2, Images, AI) and removal of development env
+ * - Local .dev.vars presence (ignored, per-surface)
+ * - Expected Convex env names and their parity if deployments are reachable
+ *
+ * Usage: bun run check:cloudflare
+ *        bun run scripts/check-cloudflare.ts
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..");
+const WRANGLER_PATH = join(ROOT, "apps/files-worker/wrangler.jsonc");
+const DEV_VARS_PATH = join(ROOT, "apps/files-worker/.dev.vars");
+
+type Status = "same" | "different" | "missing" | "updated" | "ok" | "warn";
+
+const expectedProdVars = [
+  "CLOUDFLARE_ACCOUNT_ID",
+  "CLOUDFLARE_API_TOKEN",
+  "FILES_SIGNING_SECRET",
+  "R2_ACCESS_KEY_ID",
+  "R2_ENDPOINT",
+  "R2_SECRET_ACCESS_KEY",
+  "R2_TOKEN",
+] as const;
+
+const expectedDevVars = [
+  ...expectedProdVars,
+  "R2_BUCKET",
+  "R2_KEY_PREFIX",
+  "FILES_BASE",
+] as const;
+
+const log = (label: string, status: Status, detail?: string) => {
+  let icon: string;
+  if (status === "same" || status === "ok") {
+    icon = "✓";
+  } else if (status === "missing") {
+    icon = "✗";
+  } else {
+    icon = "•";
+  }
+  console.log(`${icon} ${label}: ${status}${detail ? ` (${detail})` : ""}`);
+};
+
+const checkWrangler = () => {
+  console.log("\n== Wrangler (apps/files-worker/wrangler.jsonc) ==");
+  if (!existsSync(WRANGLER_PATH)) {
+    log("wrangler.jsonc", "missing");
+    return;
+  }
+  try {
+    const raw = readFileSync(WRANGLER_PATH, "utf-8");
+    // wrangler.jsonc may contain comments; strip // and /* */
+    const stripped = raw
+      .replace(/\/\/.*$/gm, "")
+      .replace(/\/\*[\s\S]*?\*\//g, "");
+    const cfg = JSON.parse(stripped);
+    const hasEnvDev = Boolean(cfg.env?.development);
+    log(
+      "top-level bucket",
+      cfg.r2_buckets?.[0]?.bucket_name ? "ok" : "missing",
+      cfg.r2_buckets?.[0]?.bucket_name ?? "no bucket"
+    );
+    log(
+      "top-level binding BUCKET",
+      cfg.r2_buckets?.[0]?.binding === "BUCKET" ? "ok" : "missing"
+    );
+    log("Images binding", cfg.images?.binding === "IMAGES" ? "ok" : "missing");
+    log("AI binding", cfg.ai?.binding === "AI" ? "ok" : "missing");
+    log(
+      "development env removed",
+      hasEnvDev ? "warn" : "ok",
+      hasEnvDev ? "env.development still present" : "canonical config prod-only"
+    );
+    if (hasEnvDev) {
+      console.log(
+        "  Note: live files-dev Worker/domain/teak-files-dev bucket are retained for rollback but not in wrangler.jsonc."
+      );
+    }
+    log(
+      "remote bindings",
+      "ok",
+      "R2 and Images support --remote while Worker code stays local"
+    );
+  } catch (err) {
+    log("wrangler.jsonc parse", "warn", String(err));
+  }
+};
+
+const checkDevVars = () => {
+  console.log("\n== Local .dev.vars (apps/files-worker/.dev.vars) ==");
+  if (existsSync(DEV_VARS_PATH)) {
+    log(".dev.vars", "ok", "present (ignored via .gitignore, per-developer)");
+    try {
+      const content = readFileSync(DEV_VARS_PATH, "utf-8");
+      const hasSecret = content.includes("FILES_SIGNING_SECRET");
+      log(
+        "FILES_SIGNING_SECRET in .dev.vars",
+        hasSecret ? "ok" : "missing",
+        "must match Convex FILES_SIGNING_SECRET"
+      );
+      if (
+        content.includes("R2_BUCKET") ||
+        content.includes("R2_KEY_PREFIX") ||
+        content.includes("FILES_BASE")
+      ) {
+        log(
+          ".dev.vars routing vars",
+          "warn",
+          "R2_BUCKET/R2_KEY_PREFIX/FILES_BASE belong in Convex env, not .dev.vars"
+        );
+      }
+    } catch {}
+  } else {
+    log(
+      ".dev.vars",
+      "missing",
+      "create from template: echo 'FILES_SIGNING_SECRET=...' > apps/files-worker/.dev.vars (ignored)"
+    );
+  }
+  console.log(
+    "  Production-data warning: dev bucket is prod (teak-files-prod + dev/ prefix). Writes are isolated by prefix but share credentials bucket-wide."
+  );
+};
+
+const checkConvexEnv = () => {
+  console.log("\n== Convex env parity (read-only, no secret output) ==");
+  console.log(`  Expected prod vars: ${expectedProdVars.join(", ")}`);
+  console.log(`  Expected dev vars: ${expectedDevVars.join(", ")}`);
+  console.log(
+    "  Dev-specific routing: R2_BUCKET=teak-files-prod, R2_KEY_PREFIX=dev/, FILES_BASE=https://files.teakvault.com (or temp preview during pre-merge)"
+  );
+
+  // Without live comparison, report local env presence only.
+  for (const name of expectedProdVars) {
+    const present = Boolean(process.env[name]);
+    log(
+      `prod ${name}`,
+      present ? "ok" : "missing",
+      present
+        ? "set locally or via Convex"
+        : "copy from Convex prod to dev without logging value"
+    );
+  }
+  for (const name of ["R2_BUCKET", "R2_KEY_PREFIX", "FILES_BASE"] as const) {
+    const val = process.env[name];
+    if (!val) {
+      log(`dev ${name}`, "missing");
+    } else if (name === "R2_BUCKET" && val === "teak-files-prod") {
+      log(`dev ${name}`, "ok", "prod bucket canonical");
+    } else if (name === "R2_KEY_PREFIX" && val === "dev/") {
+      log(`dev ${name}`, "ok", "dev prefix");
+    } else if (name === "FILES_BASE" && val.startsWith("https://")) {
+      log(`dev ${name}`, "ok", "worker origin");
+    } else {
+      log(`dev ${name}`, "different", "value present (content not shown)");
+    }
+  }
+  console.log(
+    "\n  Convergence: read prod values (CLOUDFLARE_* etc.) and set in Convex dev via `npx convex env set --deployment dev NAME` without logging; report only same/different/missing/updated."
+  );
+  console.log(
+    "  Prefix is routine-mistake protection, not a hard security boundary; shared credentials retain bucket-wide authority."
+  );
+};
+
+const main = () => {
+  console.log(
+    "Cloudflare / R2 parity check (read-only, secrets never printed)"
+  );
+  checkWrangler();
+  checkDevVars();
+  checkConvexEnv();
+  console.log("\n== Summary ==");
+  console.log(
+    "  • Keep `bun run dev` for all-surface stack; use `bun run dev:files` (remote bindings) vs `bun run dev:files:local` (Miniflare, low-fidelity Images)."
+  );
+  console.log(
+    "  • One-time Convex convergence required; .dev.vars is ignored and per-developer; prod-data warning applies (shared bucket + prefix)."
+  );
+  console.log(
+    "  • Rollback: wrangler.jsonc env.development removed but live files-dev Worker/domain/teak-files-dev bucket retained; re-add env block to rollback or set Convex dev FILES_BASE/R2_BUCKET back to files-dev."
+  );
+  console.log("");
+};
+
+await main();


### PR DESCRIPTION
## Bun 1.4.0
- Upgrade `packageManager` `bun@1.3.14` → `bun@1.4.0` (latest stable 2026-08-28, https://bun.com/)
- Replace four release-workflow pins `1.3.5` → `1.4.0` (cli, desktop, extension, mobile); other `setup-bun` steps read `packageManager`
- Update `@types/bun` consumers (`apps/docs`, `packages/tests`) to `1.4.0` and regenerate `bun.lock` with Bun 1.4.0
- Preserve hoisted linker and Turborepo task structure

## Dependabot remediation (alerts 126, 127)
- Clear GHSA-w3rx-r6r6-pgpr (ICNS) and GHSA-5p2g-fcmc-qvqq (JXL/HEIF) by replacing direct `image-size@2.0.2` (no patched release) with `probe-image-size@7.4.0` + `@types/probe-image-size@7.2.5`
- Use `probe.sync(Buffer.from(bytes))` to keep JPEG/PNG/GIF/WebP/AVIF/HEIF/SVG synchronous; preserve 20 MB download limit, positive-dimension validation, 32-megapixel budget
- Version 7.4.0 includes current SVG DoS fix (header search limited to first 10K, Changelog)
- Add regression tests for malicious ICNS data, zero-sized HEIF/AVIF boxes, malformed SVG (including entity expansion), malformed input, excessive dimensions
- Verify GitHub closes alerts 126/127; **remaining transitive `image-size`** via `blume@1.4.1 → image-size@^2.0.2` (and `metro → image-size@^1.0.2`) is reported separately and not cleared by this direct-dep removal

## Cloudflare topology and risk disclosure
- **Before:** prod `files.teakvault.com → teak-files-prod` + `dev files-dev.teakvault.com → teak-files-dev` (isolated buckets/bindings via `wrangler.jsonc` `env.development`)
- **After (canonical):** `files.teakvault.com → teak-files-prod` for **both** envs; dev objects use `dev/users/...` (via `R2_KEY_PREFIX=dev/`), prod uses `users/...` (unset). Live `files-dev` Worker/domain/`teak-files-dev` bucket (~1 000 objects / 370 MB) are **retained untouched** for rollback; `wrangler.jsonc` `env.development` is removed
- **Isolation:** `R2_KEY_PREFIX` centralization (`getR2KeyPrefix`, `buildR2UserPrefix`, `buildR2ListPrefix`, `is/ assertR2KeyInNamespace`) applied to URLs, uploads, imports, exports, cleanup workflows, pending-upload sweeps, object listing, stored-key reads. Dev rejects old/supplied keys outside `dev/users/...` so prod objects are not accidentally resolved. Worker is extended to accept **both** `users/` and `dev/users/` across downloads, uploads, ops (`sameUserNamespace`, `validKeyList`, `list-objects` prefix, `isValidUploadKey`), image transforms, and telemetry (`parseFileKeyIdentifiers` handles `dev/` prefix)
- **Bindings:** top-level Wrangler `R2_BUCKET=teak-files-prod`, `IMAGES`, `AI` are used for remote development (`wrangler dev --remote` keeps Worker code local, R2/Images remote). No copy/migration/backfill/fallback/reset/deletion of existing dev bucket
- **Risk:** `R2_KEY_PREFIX` is **routine-mistake protection, not a hard security boundary**; shared credentials retain bucket-wide authority. Existing file-backed dev cards may stop resolving by design

## Convex development variables (secret-safe)
- Copy securely from Convex **prod** to **dev** without logging values, reporting only `same`/`different`/`missing`/`updated`:
  - `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, `FILES_SIGNING_SECRET`, `R2_ACCESS_KEY_ID`, `R2_ENDPOINT`, `R2_SECRET_ACCESS_KEY`, `R2_TOKEN` (now all `same` after sync)
  - `R2_BUCKET=teak-files-prod`, `R2_KEY_PREFIX=dev/`, `FILES_BASE` (set to `https://files.teakvault.com` post-deploy; temp `wrangler dev --remote` preview URL during pre-merge)
- One-time convergence done via `scripts/sync-convex-env.ts` (not committed) and verified via `bun run check:cloudflare` (read-only)

## Local development experience
- `bun run dev` still starts all-surface stack (web, convex, desktop, raycast, docs, extension)
- `bun run dev:files` → `wrangler dev --remote` (remote R2/Images/AI), `bun run dev:files:local` → `wrangler dev` (isolated Miniflare, low-fidelity Images)
- `bun run check:cloudflare` → read-only names/parity check without exposing values
- `apps/files-worker/.dev.vars` is ignored (`.gitignore`), per-developer; contains `FILES_SIGNING_SECRET` only. Production-data warning: dev shares prod bucket, isolated only by prefix
- Per-surface commands and rollback steps documented in `apps/files-worker/README.md`

## Local test evidence (Bun 1.4.0)
```
bun install --frozen-lockfile # ok
bun run check                  # ok (ultracite)
bun run typecheck              # 12 ok
bun run lint                   # 5 ok
bun run test                   # 12 ok (convex 1475 pass/0 fail after fixes)
bun run build                  # 7 ok
bun run --filter @teak/files-worker test # 102 pass
bunx wrangler types            # ok
bunx wrangler deploy --dry-run --outdir /tmp/wrangler-out # bundle 630K + 2.5M wasm
git diff --check               # no whitespace errors
bun run check:cloudflare       # wrangler ok, dev.vars missing (expected), Convex parity same/different as above
```

Fixes for Bun 1.4.0 env stringification: `billing.test.ts`, `admin.test.ts`, `mcp.test.ts` (`delete process.env.FOO` vs `= undefined`), `getFileUrl` helper regex, `remoteImageDimensions` entity SVG.

## Deployment order
1. Merge PR (squash)
2. Cloudflare Workers Builds → Files Worker prod (`teak-files-proxy`) auto-deploys from `main`
3. GitHub `Backend Deploy` → Convex prod
4. Vercel web/docs (triggered by root package/lock changes)
5. After Worker live, set Convex **dev** `FILES_BASE=https://files.teakvault.com` (already set) and re-verify dev smoke test; dispatch `API and MCP Smoke` and full `Production E2E` (including teardown/sweep)

## Rollback
- Wrangler: re-add `env.development` block (`teak-files-proxy-dev`, `files-dev.teakvault.com`, `teak-files-dev`) to `wrangler.jsonc`
- Convex dev: `R2_BUCKET=teak-files-dev`, `R2_KEY_PREFIX=""` (or delete), `FILES_BASE=https://files-dev.teakvault.com`
- No data migration; existing `teak-files-dev` bucket retained

## Follow-ups (not in this PR)
- Delete unused `files-dev` Worker/domain/bucket after rollback window
- Move to prefix-restricted or separately scoped dev credentials
- Automate secret-safe Convex parity checks in CI
- Add dev-prefix lifecycle to CI, track/remove Blume transitive `image-size`, automate Bun pin sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Development file storage now uses isolated `dev/users/...` paths within the shared production bucket.
  * Added local and remote development commands, plus a Cloudflare environment diagnostic.
  * Upload, download, cleanup, and deletion operations now enforce storage namespace boundaries.

* **Bug Fixes**
  * Improved handling of development-prefixed file keys.
  * Strengthened remote image validation for malformed, oversized, and potentially unsafe images.

* **Documentation**
  * Expanded setup, local development, environment, parity-check, and rollback guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->