### PR TITLE
docs: sync monorepo layout and Bun prerequisite with current repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,14 @@ teak/
 │   ├── safari-extension/ # Native macOS Safari extension app
 │   ├── raycast/    # Raycast extension
 │   ├── cli/        # npm command line client
-│   └── docs/       # Documentation site (Blume)
+│   ├── docs/       # Documentation site (Blume)
+│   └── files-worker/ # Cloudflare Worker for file delivery and processing
 ├── .agents/
 │   └── skills/     # Agent Skills published through skills.sh-compatible repos
 ├── packages/
 │   ├── convex/     # Convex backend, public API, MCP, and SDK
+│   ├── files-protocol/ # Shared Worker operation contracts
+│   ├── tests/      # Cross-surface Playwright journeys
 │   └── ui/         # Shared UI package
 ├── turbo.json      # Turborepo pipeline config
 └── package.json

--- a/apps/docs/content/docs/(developers)/development.mdx
+++ b/apps/docs/content/docs/(developers)/development.mdx
@@ -3,7 +3,7 @@ title: Development Guide
 description: Setup and development workflow for Teak
 ---
 
-**Prerequisites:** Bun 1.0+, Node.js 20+, Git
+**Prerequisites:** Bun 1.4.0+, Node.js 20+, Git
 
 ## Quick Start (local)
 
@@ -57,12 +57,17 @@ description: Setup and development workflow for Teak
     - raycast/ Raycast extension
     - cli/ npm command line client
     - docs/ Documentation site (Blume)
+    - files-worker/ Cloudflare Worker for file delivery and processing
+  - .agents/
+    - skills/ Agent Skills for skills.sh
   - packages/
     - convex/ Convex backend
       - ai/ AI metadata helpers
       - card/ Card mutations/queries
       - workflows/ AI pipeline orchestration
     - ui/ Shared UI components and hooks
+    - files-protocol/ Shared Worker operation contracts
+    - tests/ Cross-surface Playwright journeys
   - turbo.json Turborepo pipeline config
   - package.json Root package + workspaces
 

--- a/apps/docs/content/docs/(developers)/development.mdx
+++ b/apps/docs/content/docs/(developers)/development.mdx
@@ -58,10 +58,10 @@ description: Setup and development workflow for Teak
     - cli/ npm command line client
     - docs/ Documentation site (Blume)
     - files-worker/ Cloudflare Worker for file delivery and processing
-  - .agents/
-    - skills/ Agent Skills for skills.sh
   - packages/
     - convex/ Convex backend
+      - .agents/
+        - skills/ Agent Skills for skills.sh
       - ai/ AI metadata helpers
       - card/ Card mutations/queries
       - workflows/ AI pipeline orchestration

--- a/apps/docs/content/docs/(developers)/development.mdx
+++ b/apps/docs/content/docs/(developers)/development.mdx
@@ -58,10 +58,10 @@ description: Setup and development workflow for Teak
     - cli/ npm command line client
     - docs/ Documentation site (Blume)
     - files-worker/ Cloudflare Worker for file delivery and processing
+  - .agents/
+    - skills/ Agent Skills for skills.sh
   - packages/
     - convex/ Convex backend
-      - .agents/
-        - skills/ Agent Skills for skills.sh
       - ai/ AI metadata helpers
       - card/ Card mutations/queries
       - workflows/ AI pipeline orchestration


### PR DESCRIPTION
Summary
- Update `Prerequisites` in the development guide from Bun 1.0+ to 1.4.0+ to match the pinned `packageManager` (bun@1.4.0) and release workflows that now pin 1.4.0.
- Add the missing `files-worker` Cloudflare Worker to the FileTree in both the README monorepo diagram and the development guide layout.
- Add `.agents/skills`, `packages/files-protocol`, and `packages/tests` to the FileTree so docs reflect the actual workspace layout introduced since the Worker and shared protocol were added.

The existing FileTree in `apps/docs/content/docs/(developers)/development.mdx` and the README `Monorepo` diagram listed only `apps/{web,mobile,desktop,extension,safari-extension,raycast,cli,docs}` and `packages/{convex,ui}`. Contributors following the guide would miss the canonical file-processing Worker and the shared contracts/tests packages.

Test Plan
- Verified `bun run build` (affected) passes — docs and typecheck/lint succeeded.
- Visually confirmed README and development.mdx render the updated trees correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the documented project structure to reflect current application and package locations.
  - Added references to the files worker, files protocol, agent skills, and cross-surface tests.
  - Updated the Bun prerequisite to version 1.4.0 or later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->