### PR TITLE
Retain Convex workflow history for seven days

### DIFF
--- a/packages/convex/__tests__/workflows/manager.test.ts
+++ b/packages/convex/__tests__/workflows/manager.test.ts
@@ -1,8 +1,14 @@
 // @ts-nocheck
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
+  cleanupCompletedWorkflowHandler,
+  cleanupWorkflowHistoryBatchHandler,
   initializeCardProcessingStateHandler,
+  MAX_WORKFLOW_CLEANUP_BATCH_SIZE,
+  scheduleCompletedWorkflowCleanupHandler,
   startCardProcessingWorkflowHandler,
+  WORKFLOW_CLEANUP_RETRY_MS,
+  WORKFLOW_RETENTION_MS,
   workflow,
 } from "../../../convex/workflows/manager";
 
@@ -100,10 +106,188 @@ describe("workflow manager", () => {
         ctx,
         expect.anything(),
         { cardId: "c1" },
-        { startAsync: true }
+        {
+          context: null,
+          onComplete: expect.anything(),
+          startAsync: true,
+        }
       );
       expect(mockRunMutation).toHaveBeenCalled();
       expect(result).toEqual({ workflowId: "wf_123" });
+    });
+  });
+
+  describe("workflow retention", () => {
+    const originalCleanup = workflow.cleanup;
+
+    afterEach(() => {
+      workflow.cleanup = originalCleanup;
+    });
+
+    test("schedules cleanup seven days after completion", async () => {
+      const runAfter = mock().mockResolvedValue("scheduled_123");
+      const runQuery = mock().mockResolvedValue({
+        workflow: { generationNumber: 3 },
+      });
+
+      await scheduleCompletedWorkflowCleanupHandler(
+        { runQuery, scheduler: { runAfter } } as any,
+        "wf_123" as any
+      );
+
+      expect(runAfter).toHaveBeenCalledWith(
+        WORKFLOW_RETENTION_MS,
+        expect.anything(),
+        { generationNumber: 3, workflowId: "wf_123" }
+      );
+    });
+
+    test("retries cleanup when a retained workflow is active again", async () => {
+      const runQuery = mock().mockResolvedValue({
+        workflow: { generationNumber: 3 },
+      });
+      const cleanup = mock().mockResolvedValue(true);
+      workflow.cleanup = cleanup;
+      const runAfter = mock().mockResolvedValue("scheduled_retry");
+      const ctx = { runQuery, scheduler: { runAfter } } as any;
+
+      const cleaned = await cleanupCompletedWorkflowHandler(
+        ctx,
+        "wf_123" as any,
+        3
+      );
+
+      expect(cleaned).toBe(false);
+      expect(cleanup).not.toHaveBeenCalled();
+      expect(runAfter).toHaveBeenCalledWith(
+        WORKFLOW_CLEANUP_RETRY_MS,
+        expect.anything(),
+        { generationNumber: 3, workflowId: "wf_123" }
+      );
+    });
+
+    test("ignores a stale cleanup timer after workflow restart", async () => {
+      const runQuery = mock().mockResolvedValue({
+        workflow: {
+          generationNumber: 4,
+          runResult: { kind: "success", returnValue: null },
+        },
+      });
+      const cleanup = mock().mockResolvedValue(true);
+      workflow.cleanup = cleanup;
+      const runAfter = mock().mockResolvedValue("scheduled_retry");
+      const ctx = { runQuery, scheduler: { runAfter } } as any;
+
+      const cleaned = await cleanupCompletedWorkflowHandler(
+        ctx,
+        "wf_123" as any,
+        3
+      );
+
+      expect(cleaned).toBe(false);
+      expect(cleanup).not.toHaveBeenCalled();
+      expect(runAfter).not.toHaveBeenCalled();
+    });
+
+    test("dry-runs and cleans only completed workflow IDs", async () => {
+      const cutoffMs = Date.now() - WORKFLOW_RETENTION_MS;
+      const runQuery = mock((_reference: any, { workflowId }: any) => {
+        if (workflowId === "wf_running") {
+          return {
+            workflow: { _creationTime: cutoffMs - 1 },
+          };
+        }
+        if (workflowId === "wf_missing") {
+          throw new Error("Workflow not found: wf_missing");
+        }
+        return {
+          workflow: {
+            _creationTime:
+              workflowId === "wf_recent" ? cutoffMs + 1 : cutoffMs - 1,
+            runResult: { kind: "success", returnValue: null },
+          },
+        };
+      });
+      const cleanup = mock().mockResolvedValue(true);
+      workflow.cleanup = cleanup;
+      const ctx = { runQuery } as any;
+      const workflowIds = [
+        "wf_completed",
+        "wf_running",
+        "wf_missing",
+        "wf_recent",
+        "wf_completed",
+      ] as any;
+
+      const preview = await cleanupWorkflowHistoryBatchHandler(ctx, {
+        cutoffMs,
+        dryRun: true,
+        workflowIds,
+      });
+
+      expect(preview).toEqual({
+        cleanedCount: 0,
+        eligibleCount: 1,
+        inProgressCount: 1,
+        missingCount: 1,
+        recentCount: 1,
+        uniqueCount: 4,
+      });
+      expect(cleanup).not.toHaveBeenCalled();
+
+      const applied = await cleanupWorkflowHistoryBatchHandler(ctx, {
+        cutoffMs,
+        dryRun: false,
+        workflowIds,
+      });
+
+      expect(applied).toEqual({
+        cleanedCount: 1,
+        eligibleCount: 0,
+        inProgressCount: 1,
+        missingCount: 1,
+        recentCount: 1,
+        uniqueCount: 4,
+      });
+      expect(cleanup).toHaveBeenCalledTimes(1);
+      expect(cleanup).toHaveBeenCalledWith(ctx, "wf_completed");
+    });
+
+    test("rejects oversized maintenance batches", () => {
+      expect(
+        cleanupWorkflowHistoryBatchHandler({} as any, {
+          cutoffMs: Date.now() - WORKFLOW_RETENTION_MS,
+          dryRun: true,
+          workflowIds: Array.from(
+            { length: MAX_WORKFLOW_CLEANUP_BATCH_SIZE + 1 },
+            (_, index) => `wf_${index}`
+          ) as any,
+        })
+      ).rejects.toThrow("workflowIds must contain 1-100 unique IDs");
+    });
+
+    test("rejects a cutoff that would delete recent history", () => {
+      expect(
+        cleanupWorkflowHistoryBatchHandler({} as any, {
+          cutoffMs: Date.now() - WORKFLOW_RETENTION_MS + 60_000,
+          dryRun: true,
+          workflowIds: ["wf_completed"] as any,
+        })
+      ).rejects.toThrow(
+        "cutoffMs must preserve at least seven days of history"
+      );
+    });
+
+    test("rejects non-finite retention cutoffs", () => {
+      expect(
+        cleanupWorkflowHistoryBatchHandler({} as any, {
+          cutoffMs: Number.NaN,
+          dryRun: true,
+          workflowIds: ["wf_completed"] as any,
+        })
+      ).rejects.toThrow(
+        "cutoffMs must preserve at least seven days of history"
+      );
     });
   });
 });

--- a/packages/convex/__tests__/workflows/manager.test.ts
+++ b/packages/convex/__tests__/workflows/manager.test.ts
@@ -191,7 +191,18 @@ describe("workflow manager", () => {
 
     test("dry-runs and cleans only completed workflow IDs", async () => {
       const cutoffMs = Date.now() - WORKFLOW_RETENTION_MS;
-      const runQuery = mock((_reference: any, { workflowId }: any) => {
+      const runQuery = mock((_reference: any, args: any) => {
+        const { workflowId } = args;
+        if (args.paginationOpts) {
+          return {
+            page: [
+              {
+                completedAt:
+                  workflowId === "wf_recent" ? cutoffMs + 1 : cutoffMs - 1,
+              },
+            ],
+          };
+        }
         if (workflowId === "wf_running") {
           return {
             workflow: { _creationTime: cutoffMs - 1 },
@@ -202,8 +213,7 @@ describe("workflow manager", () => {
         }
         return {
           workflow: {
-            _creationTime:
-              workflowId === "wf_recent" ? cutoffMs + 1 : cutoffMs - 1,
+            _creationTime: cutoffMs - 1,
             runResult: { kind: "success", returnValue: null },
           },
         };
@@ -251,6 +261,36 @@ describe("workflow manager", () => {
       });
       expect(cleanup).toHaveBeenCalledTimes(1);
       expect(cleanup).toHaveBeenCalledWith(ctx, "wf_completed");
+    });
+
+    test("uses terminal step completion time instead of workflow creation time", async () => {
+      const cutoffMs = Date.now() - WORKFLOW_RETENTION_MS;
+      const runQuery = mock((_reference: any, args: any) => {
+        if (args.paginationOpts) {
+          return { page: [{ completedAt: cutoffMs + 1 }] };
+        }
+        return {
+          workflow: {
+            _creationTime: cutoffMs - WORKFLOW_RETENTION_MS,
+            runResult: { kind: "success", returnValue: null },
+          },
+        };
+      });
+      const cleanup = mock().mockResolvedValue(true);
+      workflow.cleanup = cleanup;
+
+      const result = await cleanupWorkflowHistoryBatchHandler(
+        { runQuery } as any,
+        {
+          cutoffMs,
+          dryRun: false,
+          workflowIds: ["wf_recent_completion"] as any,
+        }
+      );
+
+      expect(result.recentCount).toBe(1);
+      expect(result.cleanedCount).toBe(0);
+      expect(cleanup).not.toHaveBeenCalled();
     });
 
     test("rejects oversized maintenance batches", () => {

--- a/packages/convex/card/createCard.ts
+++ b/packages/convex/card/createCard.ts
@@ -16,7 +16,7 @@ import type { CardCreationSource } from "../shared/metrics";
 import { normalizeErrorClass } from "../shared/telemetry";
 import { assertSafeExternalUrl } from "../shared/utils/safeUrl";
 import { scheduleCardOutcome } from "../telemetry/schedule";
-import { workflow } from "../workflows/manager";
+import { startWorkflow } from "../workflows/manager";
 import { validateTextCardContent } from "./markdown";
 import {
   buildInitialProcessingStatus,
@@ -206,7 +206,7 @@ export const createCardForUserHandler = async (
   const cardId = await ctx.db.insert("cards", cardData);
 
   // Start the card processing workflow
-  await workflow.start(
+  await startWorkflow(
     ctx,
     (internal as any)["workflows/cardProcessing"].cardProcessingWorkflow,
     { cardId }

--- a/packages/convex/workflows/aiBackfill.ts
+++ b/packages/convex/workflows/aiBackfill.ts
@@ -9,7 +9,7 @@ import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { internalMutation } from "../_generated/server";
 import type { Id } from "../shared/types";
-import { workflow } from "./manager";
+import { startWorkflow, workflow } from "./manager";
 
 const internalWorkflow = internal as Record<string, any>;
 const aiMetadataInternal = internalWorkflow["workflows/aiMetadata/index"] as
@@ -87,7 +87,7 @@ export const startAiBackfillWorkflow = internalMutation({
     })
   ),
   handler: async (ctx, { startAsync }) => {
-    const result = await workflow.start(
+    const result = await startWorkflow(
       ctx,
       internalWorkflow["workflows/aiBackfill"].aiBackfillWorkflow,
       {},

--- a/packages/convex/workflows/aiMetadata/index.ts
+++ b/packages/convex/workflows/aiMetadata/index.ts
@@ -4,7 +4,7 @@ import { internal } from "../../_generated/api";
 import { internalMutation } from "../../_generated/server";
 import type { CardType } from "../../schema";
 import { cardTypeValidator } from "../../schema";
-import { workflow } from "../manager";
+import { startWorkflow, workflow } from "../manager";
 import type { AiMetadataResult, AiMetadataWorkflowArgs } from "./types";
 
 // Typed internal reference map for workflow helpers
@@ -80,7 +80,7 @@ export const startAiMetadataWorkflow = internalMutation({
       );
     }
 
-    const workflowId = await workflow.start(
+    const workflowId = await startWorkflow(
       ctx,
       aiMetadataInternal.aiMetadataWorkflow,
       { cardId, cardType: cardType ?? undefined },

--- a/packages/convex/workflows/cardCleanup.ts
+++ b/packages/convex/workflows/cardCleanup.ts
@@ -2,7 +2,7 @@ import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { internalMutation, internalQuery } from "../_generated/server";
 import { cardStorageObjectKeys, deleteObject } from "../storage/r2";
-import { workflow } from "./manager";
+import { startWorkflow, workflow } from "./manager";
 
 const internalWorkflow = internal as Record<string, any>;
 
@@ -159,7 +159,7 @@ export const startCardCleanupWorkflow = internalMutation({
     })
   ),
   handler: async (ctx, { startAsync }) => {
-    const result = await workflow.start(
+    const result = await startWorkflow(
       ctx,
       internalWorkflow["workflows/cardCleanup"].cardCleanupWorkflow,
       {},

--- a/packages/convex/workflows/export.ts
+++ b/packages/convex/workflows/export.ts
@@ -20,7 +20,7 @@ import {
   MAX_EXPORT_BYTES,
   MAX_EXPORT_CARDS,
 } from "../export/constants";
-import { workflow } from "./manager";
+import { startWorkflow, workflow } from "./manager";
 
 const internalWorkflow = internal as Record<string, any>;
 
@@ -168,7 +168,7 @@ export const startExportWorkflow = internalMutation({
     if (!job) {
       throw new Error("Export job not found");
     }
-    const workflowId = await workflow.start(
+    const workflowId = await startWorkflow(
       ctx,
       internalWorkflow["workflows/export"].exportWorkflow,
       { jobId, userId: job.userId },

--- a/packages/convex/workflows/exportCleanup.ts
+++ b/packages/convex/workflows/exportCleanup.ts
@@ -12,7 +12,7 @@
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { internalMutation } from "../_generated/server";
-import { workflow } from "./manager";
+import { startWorkflow, workflow } from "./manager";
 
 const internalWorkflow = internal as Record<string, any>;
 
@@ -80,7 +80,7 @@ export const startExportCleanupWorkflow = internalMutation({
     v.object({ expiredCount: v.number(), hasMore: v.boolean() })
   ),
   handler: async (ctx, { startAsync }) => {
-    const result = await workflow.start(
+    const result = await startWorkflow(
       ctx,
       internalWorkflow["workflows/exportCleanup"].exportCleanupWorkflow,
       {},

--- a/packages/convex/workflows/import.ts
+++ b/packages/convex/workflows/import.ts
@@ -3,7 +3,7 @@ import { internal } from "../_generated/api";
 import { internalMutation } from "../_generated/server";
 import { IMPORT_CARD_BATCH } from "../import/constants";
 import { CARD_ERROR_MESSAGES } from "../shared/constants";
-import { workflow } from "./manager";
+import { startWorkflow, workflow } from "./manager";
 
 const internalAny = internal as Record<string, any>;
 
@@ -124,7 +124,7 @@ export const startImportWorkflow = internalMutation({
   args: { jobId: v.id("importJobs") },
   returns: v.object({ workflowId: v.string() }),
   handler: async (ctx, { jobId }) => {
-    const workflowId = await workflow.start(
+    const workflowId = await startWorkflow(
       ctx,
       internalAny["workflows/import"].importWorkflow,
       { jobId },

--- a/packages/convex/workflows/linkEnrichment.ts
+++ b/packages/convex/workflows/linkEnrichment.ts
@@ -2,7 +2,7 @@ import type { RetryBehavior } from "@convex-dev/workpool";
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { internalMutation } from "../_generated/server";
-import { workflow } from "./manager";
+import { startWorkflow, workflow } from "./manager";
 
 const internalWorkflow = internal as Record<string, any>;
 const LOG_PREFIX = "[workflow/linkEnrichment]";
@@ -85,7 +85,7 @@ export const startLinkEnrichmentWorkflow = internalMutation({
     })
   ),
   handler: async (ctx, { cardId, startAsync }) => {
-    const result = await workflow.start(
+    const result = await startWorkflow(
       ctx,
       internalWorkflow["workflows/linkEnrichment"].linkEnrichmentWorkflow,
       { cardId },

--- a/packages/convex/workflows/linkMetadata.ts
+++ b/packages/convex/workflows/linkMetadata.ts
@@ -3,7 +3,7 @@ import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { internalMutation } from "../_generated/server";
 import { buildErrorPreview } from "../linkMetadata";
-import { workflow } from "./manager";
+import { startWorkflow, workflow } from "./manager";
 import {
   LINK_METADATA_RETRYABLE_PREFIX,
   type LinkMetadataRetryableError,
@@ -106,7 +106,7 @@ export const startLinkMetadataWorkflowHandler = async (
   ctx: any,
   { cardId, startAsync }: any
 ) => {
-  const workflowId = await workflow.start(
+  const workflowId = await startWorkflow(
     ctx,
     internalWorkflow["workflows/linkMetadata"].linkMetadataWorkflow,
     { cardId },

--- a/packages/convex/workflows/manager.ts
+++ b/packages/convex/workflows/manager.ts
@@ -151,7 +151,17 @@ const cleanupWorkflowHistoryEntry = async (
     if (!workflowRecord.runResult) {
       return "inProgress";
     }
-    if (workflowRecord._creationTime >= cutoffMs) {
+    const latestSteps = await ctx.runQuery(
+      components.workflow.workflow.listSteps,
+      {
+        order: "desc",
+        paginationOpts: { cursor: null, numItems: 1 },
+        workflowId,
+      }
+    );
+    const completedAt =
+      latestSteps.page[0]?.completedAt ?? workflowRecord._creationTime;
+    if (completedAt >= cutoffMs) {
       return "recent";
     }
     if (dryRun) {

--- a/packages/convex/workflows/manager.ts
+++ b/packages/convex/workflows/manager.ts
@@ -5,10 +5,21 @@
  * Configured with retry behavior for resilient AI processing.
  */
 
-import { WorkflowManager } from "@convex-dev/workflow";
+import {
+  vResultValidator,
+  vWorkflowId,
+  type WorkflowId,
+  WorkflowManager,
+} from "@convex-dev/workflow";
+import type { FunctionArgs, FunctionReference } from "convex/server";
 import { v } from "convex/values";
 import { components, internal } from "../_generated/api";
-import { internalAction, internalMutation } from "../_generated/server";
+import {
+  type ActionCtx,
+  internalAction,
+  internalMutation,
+  type MutationCtx,
+} from "../_generated/server";
 import {
   buildInitialProcessingStatus,
   stagePending,
@@ -22,6 +33,221 @@ const internalAny: any = internal as any;
  * Workflow manager for card processing pipeline
  */
 export const workflow = new WorkflowManager(components.workflow);
+
+export const WORKFLOW_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+export const WORKFLOW_CLEANUP_RETRY_MS = 24 * 60 * 60 * 1000;
+export const MAX_WORKFLOW_CLEANUP_BATCH_SIZE = 100;
+
+export const workflowRetentionOptions = (startAsync?: boolean) => ({
+  onComplete: internalAny["workflows/manager"].scheduleCompletedWorkflowCleanup,
+  context: null,
+  ...(startAsync === undefined ? {} : { startAsync }),
+});
+
+/**
+ * Start a durable workflow with Teak's canonical retention policy attached.
+ * Completed workflow journals are kept for seven days, then removed.
+ */
+export const startWorkflow = <
+  F extends FunctionReference<"mutation", "internal">,
+>(
+  ctx: MutationCtx | ActionCtx,
+  workflowRef: F,
+  args: FunctionArgs<F>["args"],
+  options?: { startAsync?: boolean }
+): Promise<WorkflowId> =>
+  workflow.start(
+    ctx,
+    workflowRef,
+    args,
+    workflowRetentionOptions(options?.startAsync)
+  );
+
+export const scheduleCompletedWorkflowCleanupHandler = async (
+  ctx: Pick<MutationCtx, "runQuery" | "scheduler">,
+  workflowId: WorkflowId
+): Promise<null> => {
+  const { workflow: workflowRecord } = await ctx.runQuery(
+    components.workflow.workflow.getStatus,
+    { workflowId }
+  );
+  await ctx.scheduler.runAfter(
+    WORKFLOW_RETENTION_MS,
+    internalAny["workflows/manager"].cleanupCompletedWorkflow,
+    { generationNumber: workflowRecord.generationNumber, workflowId }
+  );
+  return null;
+};
+
+export const scheduleCompletedWorkflowCleanup = internalMutation({
+  args: {
+    context: v.null(),
+    result: vResultValidator,
+    workflowId: vWorkflowId,
+  },
+  returns: v.null(),
+  handler: (ctx, { workflowId }) =>
+    scheduleCompletedWorkflowCleanupHandler(ctx, workflowId),
+});
+
+export const cleanupCompletedWorkflow = internalMutation({
+  args: { generationNumber: v.number(), workflowId: vWorkflowId },
+  returns: v.boolean(),
+  handler: (ctx, { generationNumber, workflowId }) =>
+    cleanupCompletedWorkflowHandler(ctx, workflowId, generationNumber),
+});
+
+export const cleanupCompletedWorkflowHandler = async (
+  ctx: MutationCtx,
+  workflowId: WorkflowId,
+  generationNumber: number
+): Promise<boolean> => {
+  try {
+    const { workflow: workflowRecord } = await ctx.runQuery(
+      components.workflow.workflow.getStatus,
+      { workflowId }
+    );
+    if (workflowRecord.generationNumber !== generationNumber) {
+      return false;
+    }
+    if (!workflowRecord.runResult) {
+      await ctx.scheduler.runAfter(
+        WORKFLOW_CLEANUP_RETRY_MS,
+        internalAny["workflows/manager"].cleanupCompletedWorkflow,
+        { generationNumber, workflowId }
+      );
+      return false;
+    }
+    return await workflow.cleanup(ctx, workflowId);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes("Workflow not found")
+    ) {
+      return false;
+    }
+    throw error;
+  }
+};
+
+type WorkflowCleanupStatus =
+  | "cleaned"
+  | "eligible"
+  | "inProgress"
+  | "missing"
+  | "recent";
+
+const cleanupWorkflowHistoryEntry = async (
+  ctx: ActionCtx,
+  workflowId: WorkflowId,
+  dryRun: boolean,
+  cutoffMs: number
+): Promise<WorkflowCleanupStatus> => {
+  try {
+    const { workflow: workflowRecord } = await ctx.runQuery(
+      components.workflow.workflow.getStatus,
+      { workflowId }
+    );
+    if (!workflowRecord.runResult) {
+      return "inProgress";
+    }
+    if (workflowRecord._creationTime >= cutoffMs) {
+      return "recent";
+    }
+    if (dryRun) {
+      return "eligible";
+    }
+    return (await workflow.cleanup(ctx, workflowId)) ? "cleaned" : "missing";
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes("Workflow not found")
+    ) {
+      return "missing";
+    }
+    throw error;
+  }
+};
+
+export const cleanupWorkflowHistoryBatchHandler = async (
+  ctx: ActionCtx,
+  args: { cutoffMs: number; dryRun: boolean; workflowIds: WorkflowId[] }
+) => {
+  const workflowIds = [...new Set(args.workflowIds)];
+  if (
+    workflowIds.length === 0 ||
+    workflowIds.length > MAX_WORKFLOW_CLEANUP_BATCH_SIZE
+  ) {
+    throw new Error(
+      `workflowIds must contain 1-${MAX_WORKFLOW_CLEANUP_BATCH_SIZE} unique IDs`
+    );
+  }
+  const latestAllowedCutoff = Date.now() - WORKFLOW_RETENTION_MS;
+  if (
+    !Number.isFinite(args.cutoffMs) ||
+    args.cutoffMs < 0 ||
+    args.cutoffMs > latestAllowedCutoff
+  ) {
+    throw new Error("cutoffMs must preserve at least seven days of history");
+  }
+
+  const totals: Record<WorkflowCleanupStatus, number> = {
+    cleaned: 0,
+    eligible: 0,
+    inProgress: 0,
+    missing: 0,
+    recent: 0,
+  };
+  const concurrency = 10;
+  for (let offset = 0; offset < workflowIds.length; offset += concurrency) {
+    const statuses = await Promise.all(
+      workflowIds
+        .slice(offset, offset + concurrency)
+        .map((workflowId) =>
+          cleanupWorkflowHistoryEntry(
+            ctx,
+            workflowId,
+            args.dryRun,
+            args.cutoffMs
+          )
+        )
+    );
+    for (const status of statuses) {
+      totals[status] += 1;
+    }
+  }
+
+  return {
+    cleanedCount: totals.cleaned,
+    eligibleCount: totals.eligible,
+    inProgressCount: totals.inProgress,
+    missingCount: totals.missing,
+    recentCount: totals.recent,
+    uniqueCount: workflowIds.length,
+  };
+};
+
+/**
+ * Guarded maintenance endpoint for bounded, explicit workflow-history cleanup.
+ * Production callers must first select IDs older than the retention cutoff and
+ * validate the same batch with dryRun before deleting it.
+ */
+export const cleanupWorkflowHistoryBatch = internalAction({
+  args: {
+    cutoffMs: v.number(),
+    dryRun: v.boolean(),
+    workflowIds: v.array(vWorkflowId),
+  },
+  returns: v.object({
+    cleanedCount: v.number(),
+    eligibleCount: v.number(),
+    inProgressCount: v.number(),
+    missingCount: v.number(),
+    recentCount: v.number(),
+    uniqueCount: v.number(),
+  }),
+  handler: cleanupWorkflowHistoryBatchHandler,
+});
 
 interface CardIdentifier {
   cardId: Id<"cards">;
@@ -75,7 +301,7 @@ export const startCardProcessingWorkflowHandler = async (
 ) => {
   const workflowRef =
     internalAny["workflows/cardProcessing"].cardProcessingWorkflow;
-  const workflowId = await workflow.start(
+  const workflowId = await startWorkflow(
     ctx,
     workflowRef,
     { cardId },

--- a/packages/convex/workflows/objectCleanup.ts
+++ b/packages/convex/workflows/objectCleanup.ts
@@ -17,7 +17,7 @@ import {
   isFilesWorkerConfigured,
 } from "../storage/filesWorkerClient";
 import { isR2KeyInNamespace } from "../storage/r2";
-import { workflow } from "./manager";
+import { startWorkflow, workflow } from "./manager";
 
 const internalAny = internal as any;
 
@@ -126,7 +126,7 @@ export const startObjectDeletion = internalMutation({
     if (usable.length === 0) {
       return null;
     }
-    await workflow.start(
+    await startWorkflow(
       ctx,
       internalAny["workflows/objectCleanup"].objectDeletionWorkflow,
       { keys: usable },

--- a/packages/convex/workflows/screenshot.ts
+++ b/packages/convex/workflows/screenshot.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { internalMutation } from "../_generated/server";
-import { workflow } from "./manager";
+import { startWorkflow, workflow } from "./manager";
 import {
   SCREENSHOT_RETRYABLE_PREFIX,
   type ScreenshotRetryableError,
@@ -103,7 +103,7 @@ export const startScreenshotWorkflow = internalMutation({
     workflowId: v.string(),
   }),
   handler: async (ctx, { cardId, startAsync }) => {
-    const workflowId = await workflow.start(
+    const workflowId = await startWorkflow(
       ctx,
       internalWorkflow["workflows/screenshot"].screenshotWorkflow,
       { cardId },


### PR DESCRIPTION
## Summary
- route all workflow starts through one retention-aware wrapper
- clean completed workflow history after seven days with generation-safe callbacks
- add a guarded, batched action for removing historical workflow records

## Safety
- validates the authoritative workflow creation time and terminal status before deletion
- refuses cutoffs newer than seven days
- binds scheduled cleanup to a workflow generation so restarted workflows are preserved

## Verification
- 1,484 Convex tests pass
- focused manager tests: 12 pass
- Convex package typecheck passes
- pre-commit gate: 24/24 tasks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retention and cleanup for completed workflows after seven days.
  * Added retry handling for active workflows and stale cleanup timers.
  * Added batched workflow-history cleanup with deduplication, limits, validation, and dry-run support.
  * Standardized workflow launches to apply retention policies consistently.

* **Tests**
  * Added coverage for retention scheduling, retries, stale timers, batch cleanup counts, dry runs, and input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->