### PR TITLE
Support legacy workflow journals during cleanup

### DIFF
--- a/packages/convex/__tests__/workflows/manager.test.ts
+++ b/packages/convex/__tests__/workflows/manager.test.ts
@@ -191,20 +191,11 @@ describe("workflow manager", () => {
 
     test("dry-runs and cleans only completed workflow IDs", async () => {
       const cutoffMs = Date.now() - WORKFLOW_RETENTION_MS;
-      const runQuery = mock((_reference: any, args: any) => {
-        const { workflowId } = args;
-        if (args.paginationOpts) {
-          return {
-            page: [
-              {
-                completedAt:
-                  workflowId === "wf_recent" ? cutoffMs + 1 : cutoffMs - 1,
-              },
-            ],
-          };
-        }
+      const runQuery = mock((_reference: any, { workflowId }: any) => {
         if (workflowId === "wf_running") {
           return {
+            journalEntries: [],
+            ok: true,
             workflow: { _creationTime: cutoffMs - 1 },
           };
         }
@@ -212,6 +203,15 @@ describe("workflow manager", () => {
           throw new Error("Workflow not found: wf_missing");
         }
         return {
+          journalEntries: [
+            {
+              step: {
+                completedAt:
+                  workflowId === "wf_recent" ? cutoffMs + 1 : cutoffMs - 1,
+              },
+            },
+          ],
+          ok: true,
           workflow: {
             _creationTime: cutoffMs - 1,
             runResult: { kind: "success", returnValue: null },
@@ -240,6 +240,7 @@ describe("workflow manager", () => {
         eligibleCount: 1,
         inProgressCount: 1,
         missingCount: 1,
+        oversizedCount: 0,
         recentCount: 1,
         uniqueCount: 4,
       });
@@ -256,6 +257,7 @@ describe("workflow manager", () => {
         eligibleCount: 0,
         inProgressCount: 1,
         missingCount: 1,
+        oversizedCount: 0,
         recentCount: 1,
         uniqueCount: 4,
       });
@@ -265,16 +267,13 @@ describe("workflow manager", () => {
 
     test("uses terminal step completion time instead of workflow creation time", async () => {
       const cutoffMs = Date.now() - WORKFLOW_RETENTION_MS;
-      const runQuery = mock((_reference: any, args: any) => {
-        if (args.paginationOpts) {
-          return { page: [{ completedAt: cutoffMs + 1 }] };
-        }
-        return {
-          workflow: {
-            _creationTime: cutoffMs - WORKFLOW_RETENTION_MS,
-            runResult: { kind: "success", returnValue: null },
-          },
-        };
+      const runQuery = mock().mockResolvedValue({
+        journalEntries: [{ step: { completedAt: cutoffMs + 1 } }],
+        ok: true,
+        workflow: {
+          _creationTime: cutoffMs - WORKFLOW_RETENTION_MS,
+          runResult: { kind: "success", returnValue: null },
+        },
       });
       const cleanup = mock().mockResolvedValue(true);
       workflow.cleanup = cleanup;
@@ -289,6 +288,33 @@ describe("workflow manager", () => {
       );
 
       expect(result.recentCount).toBe(1);
+      expect(result.cleanedCount).toBe(0);
+      expect(cleanup).not.toHaveBeenCalled();
+    });
+
+    test("preserves workflows whose complete journal cannot be inspected", async () => {
+      const cutoffMs = Date.now() - WORKFLOW_RETENTION_MS;
+      const runQuery = mock().mockResolvedValue({
+        journalEntries: [],
+        ok: false,
+        workflow: {
+          _creationTime: cutoffMs - 1,
+          runResult: { kind: "success", returnValue: null },
+        },
+      });
+      const cleanup = mock().mockResolvedValue(true);
+      workflow.cleanup = cleanup;
+
+      const result = await cleanupWorkflowHistoryBatchHandler(
+        { runQuery } as any,
+        {
+          cutoffMs,
+          dryRun: false,
+          workflowIds: ["wf_oversized"] as any,
+        }
+      );
+
+      expect(result.oversizedCount).toBe(1);
       expect(result.cleanedCount).toBe(0);
       expect(cleanup).not.toHaveBeenCalled();
     });

--- a/packages/convex/workflows/manager.ts
+++ b/packages/convex/workflows/manager.ts
@@ -135,6 +135,7 @@ type WorkflowCleanupStatus =
   | "eligible"
   | "inProgress"
   | "missing"
+  | "oversized"
   | "recent";
 
 const cleanupWorkflowHistoryEntry = async (
@@ -144,23 +145,26 @@ const cleanupWorkflowHistoryEntry = async (
   cutoffMs: number
 ): Promise<WorkflowCleanupStatus> => {
   try {
-    const { workflow: workflowRecord } = await ctx.runQuery(
-      components.workflow.workflow.getStatus,
-      { workflowId }
-    );
+    const {
+      journalEntries,
+      ok: completeJournalLoaded,
+      workflow: workflowRecord,
+    } = await ctx.runQuery(components.workflow.journal.load, {
+      workflowId,
+    });
     if (!workflowRecord.runResult) {
       return "inProgress";
     }
-    const latestSteps = await ctx.runQuery(
-      components.workflow.workflow.listSteps,
-      {
-        order: "desc",
-        paginationOpts: { cursor: null, numItems: 1 },
-        workflowId,
-      }
+    if (!completeJournalLoaded) {
+      return "oversized";
+    }
+    const completionTimes = journalEntries.flatMap((entry) =>
+      entry.step.completedAt === undefined ? [] : [entry.step.completedAt]
     );
     const completedAt =
-      latestSteps.page[0]?.completedAt ?? workflowRecord._creationTime;
+      completionTimes.length === 0
+        ? workflowRecord._creationTime
+        : Math.max(...completionTimes);
     if (completedAt >= cutoffMs) {
       return "recent";
     }
@@ -206,11 +210,12 @@ export const cleanupWorkflowHistoryBatchHandler = async (
     eligible: 0,
     inProgress: 0,
     missing: 0,
+    oversized: 0,
     recent: 0,
   };
   const concurrency = 10;
   for (let offset = 0; offset < workflowIds.length; offset += concurrency) {
-    const statuses = await Promise.all(
+    const results = await Promise.allSettled(
       workflowIds
         .slice(offset, offset + concurrency)
         .map((workflowId) =>
@@ -222,8 +227,11 @@ export const cleanupWorkflowHistoryBatchHandler = async (
           )
         )
     );
-    for (const status of statuses) {
-      totals[status] += 1;
+    for (const result of results) {
+      if (result.status === "rejected") {
+        throw result.reason;
+      }
+      totals[result.value] += 1;
     }
   }
 
@@ -232,6 +240,7 @@ export const cleanupWorkflowHistoryBatchHandler = async (
     eligibleCount: totals.eligible,
     inProgressCount: totals.inProgress,
     missingCount: totals.missing,
+    oversizedCount: totals.oversized,
     recentCount: totals.recent,
     uniqueCount: workflowIds.length,
   };
@@ -253,6 +262,7 @@ export const cleanupWorkflowHistoryBatch = internalAction({
     eligibleCount: v.number(),
     inProgressCount: v.number(),
     missingCount: v.number(),
+    oversizedCount: v.number(),
     recentCount: v.number(),
     uniqueCount: v.number(),
   }),


### PR DESCRIPTION
## Summary
- inspect raw workflow journals so legacy function steps without `kind` can be verified
- skip oversized journals unless the full completion history is available
- await all concurrent inspections before surfacing a batch error

## Verification
- focused workflow-manager tests: 14 pass
- full Convex suite: 2,079 pass
- Convex typecheck passes
- pre-commit gate: 24/24 tasks pass
- production dry run failed closed before any deletion