### PR TITLE
Preserve exact workflow retention during transition

### DIFF
--- a/packages/convex/__tests__/workflows/manager.test.ts
+++ b/packages/convex/__tests__/workflows/manager.test.ts
@@ -241,6 +241,7 @@ describe("workflow manager", () => {
         eligibleCount: 1,
         inProgressCount: 1,
         missingCount: 1,
+        noTimestampCount: 0,
         oversizedCount: 0,
         recentCount: 1,
         uniqueCount: 4,
@@ -258,6 +259,7 @@ describe("workflow manager", () => {
         eligibleCount: 0,
         inProgressCount: 1,
         missingCount: 1,
+        noTimestampCount: 0,
         oversizedCount: 0,
         recentCount: 1,
         uniqueCount: 4,
@@ -341,8 +343,10 @@ describe("workflow manager", () => {
 
       expect(result).toEqual({
         eligibleCount: 0,
+        failedCount: 0,
         inProgressCount: 0,
         missingCount: 0,
+        noTimestampCount: 0,
         oversizedCount: 0,
         scheduledCount: 1,
         uniqueCount: 1,
@@ -373,6 +377,57 @@ describe("workflow manager", () => {
       expect(result.oversizedCount).toBe(1);
       expect(result.scheduledCount).toBe(0);
       expect(runAfter).not.toHaveBeenCalled();
+    });
+
+    test("fails closed when historical completion timestamps are missing", async () => {
+      const runQuery = mock().mockResolvedValue({
+        journalEntries: [{ step: {} }],
+        ok: true,
+        workflow: {
+          _creationTime: Date.now() - WORKFLOW_RETENTION_MS,
+          generationNumber: 3,
+          runResult: { kind: "success", returnValue: null },
+        },
+      });
+      const runAfter = mock().mockResolvedValue("scheduled_transition");
+
+      const result = await scheduleWorkflowHistoryCleanupBatchHandler(
+        { runQuery, scheduler: { runAfter } } as any,
+        { dryRun: false, workflowIds: ["wf_no_timestamp"] as any }
+      );
+
+      expect(result.noTimestampCount).toBe(1);
+      expect(result.scheduledCount).toBe(0);
+      expect(runAfter).not.toHaveBeenCalled();
+    });
+
+    test("reports partial scheduling failures without losing successful counts", async () => {
+      const runQuery = mock().mockResolvedValue({
+        journalEntries: [{ step: { completedAt: Date.now() } }],
+        ok: true,
+        workflow: {
+          _creationTime: Date.now(),
+          generationNumber: 3,
+          runResult: { kind: "success", returnValue: null },
+        },
+      });
+      const runAfter = mock((_delay: number, _reference: any, args: any) => {
+        if (args.workflowId === "wf_failed") {
+          throw new Error("scheduler unavailable");
+        }
+        return "scheduled_transition";
+      });
+
+      const result = await scheduleWorkflowHistoryCleanupBatchHandler(
+        { runQuery, scheduler: { runAfter } } as any,
+        {
+          dryRun: false,
+          workflowIds: ["wf_scheduled", "wf_failed"] as any,
+        }
+      );
+
+      expect(result.failedCount).toBe(1);
+      expect(result.scheduledCount).toBe(1);
     });
 
     test("dry-runs historical cleanup scheduling without creating timers", async () => {

--- a/packages/convex/__tests__/workflows/manager.test.ts
+++ b/packages/convex/__tests__/workflows/manager.test.ts
@@ -6,6 +6,7 @@ import {
   initializeCardProcessingStateHandler,
   MAX_WORKFLOW_CLEANUP_BATCH_SIZE,
   scheduleCompletedWorkflowCleanupHandler,
+  scheduleWorkflowHistoryCleanupBatchHandler,
   startCardProcessingWorkflowHandler,
   WORKFLOW_CLEANUP_RETRY_MS,
   WORKFLOW_RETENTION_MS,
@@ -317,6 +318,83 @@ describe("workflow manager", () => {
       expect(result.oversizedCount).toBe(1);
       expect(result.cleanedCount).toBe(0);
       expect(cleanup).not.toHaveBeenCalled();
+    });
+
+    test("schedules historical cleanup from the original completion time", async () => {
+      const now = Date.now();
+      const completedAt = now - WORKFLOW_RETENTION_MS + 60_000;
+      const runQuery = mock().mockResolvedValue({
+        journalEntries: [{ step: { completedAt } }],
+        ok: true,
+        workflow: {
+          _creationTime: completedAt - 1000,
+          generationNumber: 3,
+          runResult: { kind: "success", returnValue: null },
+        },
+      });
+      const runAfter = mock().mockResolvedValue("scheduled_transition");
+
+      const result = await scheduleWorkflowHistoryCleanupBatchHandler(
+        { runQuery, scheduler: { runAfter } } as any,
+        { dryRun: false, workflowIds: ["wf_123"] as any }
+      );
+
+      expect(result).toEqual({
+        eligibleCount: 0,
+        inProgressCount: 0,
+        missingCount: 0,
+        oversizedCount: 0,
+        scheduledCount: 1,
+        uniqueCount: 1,
+      });
+      const [delay, , args] = runAfter.mock.calls[0];
+      expect(delay).toBeGreaterThanOrEqual(59_000);
+      expect(delay).toBeLessThanOrEqual(60_000);
+      expect(args).toEqual({ generationNumber: 3, workflowId: "wf_123" });
+    });
+
+    test("fails closed when historical workflow journals are incomplete", async () => {
+      const runQuery = mock().mockResolvedValue({
+        journalEntries: [],
+        ok: false,
+        workflow: {
+          _creationTime: Date.now(),
+          generationNumber: 3,
+          runResult: { kind: "success", returnValue: null },
+        },
+      });
+      const runAfter = mock().mockResolvedValue("scheduled_transition");
+
+      const result = await scheduleWorkflowHistoryCleanupBatchHandler(
+        { runQuery, scheduler: { runAfter } } as any,
+        { dryRun: false, workflowIds: ["wf_oversized"] as any }
+      );
+
+      expect(result.oversizedCount).toBe(1);
+      expect(result.scheduledCount).toBe(0);
+      expect(runAfter).not.toHaveBeenCalled();
+    });
+
+    test("dry-runs historical cleanup scheduling without creating timers", async () => {
+      const runQuery = mock().mockResolvedValue({
+        journalEntries: [{ step: { completedAt: Date.now() } }],
+        ok: true,
+        workflow: {
+          _creationTime: Date.now(),
+          generationNumber: 3,
+          runResult: { kind: "success", returnValue: null },
+        },
+      });
+      const runAfter = mock().mockResolvedValue("scheduled_transition");
+
+      const result = await scheduleWorkflowHistoryCleanupBatchHandler(
+        { runQuery, scheduler: { runAfter } } as any,
+        { dryRun: true, workflowIds: ["wf_123"] as any }
+      );
+
+      expect(result.eligibleCount).toBe(1);
+      expect(result.scheduledCount).toBe(0);
+      expect(runAfter).not.toHaveBeenCalled();
     });
 
     test("rejects oversized maintenance batches", () => {

--- a/packages/convex/workflows/manager.ts
+++ b/packages/convex/workflows/manager.ts
@@ -138,6 +138,25 @@ type WorkflowCleanupStatus =
   | "oversized"
   | "recent";
 
+type WorkflowCleanupSchedulingStatus =
+  | "eligible"
+  | "inProgress"
+  | "missing"
+  | "oversized"
+  | "scheduled";
+
+const getWorkflowCompletionTime = (
+  workflowRecord: { _creationTime: number },
+  journalEntries: Array<{ step: { completedAt?: number } }>
+): number => {
+  const completionTimes = journalEntries.flatMap((entry) =>
+    entry.step.completedAt === undefined ? [] : [entry.step.completedAt]
+  );
+  return completionTimes.length === 0
+    ? workflowRecord._creationTime
+    : Math.max(...completionTimes);
+};
+
 const cleanupWorkflowHistoryEntry = async (
   ctx: ActionCtx,
   workflowId: WorkflowId,
@@ -158,13 +177,10 @@ const cleanupWorkflowHistoryEntry = async (
     if (!completeJournalLoaded) {
       return "oversized";
     }
-    const completionTimes = journalEntries.flatMap((entry) =>
-      entry.step.completedAt === undefined ? [] : [entry.step.completedAt]
+    const completedAt = getWorkflowCompletionTime(
+      workflowRecord,
+      journalEntries
     );
-    const completedAt =
-      completionTimes.length === 0
-        ? workflowRecord._creationTime
-        : Math.max(...completionTimes);
     if (completedAt >= cutoffMs) {
       return "recent";
     }
@@ -181,6 +197,98 @@ const cleanupWorkflowHistoryEntry = async (
     }
     throw error;
   }
+};
+
+const scheduleWorkflowHistoryEntry = async (
+  ctx: ActionCtx,
+  workflowId: WorkflowId,
+  dryRun: boolean
+): Promise<WorkflowCleanupSchedulingStatus> => {
+  try {
+    const {
+      journalEntries,
+      ok: completeJournalLoaded,
+      workflow: workflowRecord,
+    } = await ctx.runQuery(components.workflow.journal.load, { workflowId });
+    if (!workflowRecord.runResult) {
+      return "inProgress";
+    }
+    if (!completeJournalLoaded) {
+      return "oversized";
+    }
+    const completedAt = getWorkflowCompletionTime(
+      workflowRecord,
+      journalEntries
+    );
+    if (dryRun) {
+      return "eligible";
+    }
+    await ctx.scheduler.runAfter(
+      Math.max(0, completedAt + WORKFLOW_RETENTION_MS - Date.now()),
+      internalAny["workflows/manager"].cleanupCompletedWorkflow,
+      {
+        generationNumber: workflowRecord.generationNumber,
+        workflowId,
+      }
+    );
+    return "scheduled";
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes("Workflow not found")
+    ) {
+      return "missing";
+    }
+    throw error;
+  }
+};
+
+export const scheduleWorkflowHistoryCleanupBatchHandler = async (
+  ctx: ActionCtx,
+  args: { dryRun: boolean; workflowIds: WorkflowId[] }
+) => {
+  const workflowIds = [...new Set(args.workflowIds)];
+  if (
+    workflowIds.length === 0 ||
+    workflowIds.length > MAX_WORKFLOW_CLEANUP_BATCH_SIZE
+  ) {
+    throw new Error(
+      `workflowIds must contain 1-${MAX_WORKFLOW_CLEANUP_BATCH_SIZE} unique IDs`
+    );
+  }
+
+  const totals: Record<WorkflowCleanupSchedulingStatus, number> = {
+    eligible: 0,
+    inProgress: 0,
+    missing: 0,
+    oversized: 0,
+    scheduled: 0,
+  };
+  const concurrency = 10;
+  for (let offset = 0; offset < workflowIds.length; offset += concurrency) {
+    const results = await Promise.allSettled(
+      workflowIds
+        .slice(offset, offset + concurrency)
+        .map((workflowId) =>
+          scheduleWorkflowHistoryEntry(ctx, workflowId, args.dryRun)
+        )
+    );
+    for (const result of results) {
+      if (result.status === "rejected") {
+        throw result.reason;
+      }
+      totals[result.value] += 1;
+    }
+  }
+
+  return {
+    eligibleCount: totals.eligible,
+    inProgressCount: totals.inProgress,
+    missingCount: totals.missing,
+    oversizedCount: totals.oversized,
+    scheduledCount: totals.scheduled,
+    uniqueCount: workflowIds.length,
+  };
 };
 
 export const cleanupWorkflowHistoryBatchHandler = async (
@@ -267,6 +375,23 @@ export const cleanupWorkflowHistoryBatch = internalAction({
     uniqueCount: v.number(),
   }),
   handler: cleanupWorkflowHistoryBatchHandler,
+});
+
+/**
+ * Guarded transition endpoint for workflows completed before retention existed.
+ * It schedules cleanup at each workflow's original seven-day deadline.
+ */
+export const scheduleWorkflowHistoryCleanupBatch = internalAction({
+  args: { dryRun: v.boolean(), workflowIds: v.array(vWorkflowId) },
+  returns: v.object({
+    eligibleCount: v.number(),
+    inProgressCount: v.number(),
+    missingCount: v.number(),
+    oversizedCount: v.number(),
+    scheduledCount: v.number(),
+    uniqueCount: v.number(),
+  }),
+  handler: scheduleWorkflowHistoryCleanupBatchHandler,
 });
 
 interface CardIdentifier {

--- a/packages/convex/workflows/manager.ts
+++ b/packages/convex/workflows/manager.ts
@@ -135,26 +135,26 @@ type WorkflowCleanupStatus =
   | "eligible"
   | "inProgress"
   | "missing"
+  | "noTimestamp"
   | "oversized"
   | "recent";
 
 type WorkflowCleanupSchedulingStatus =
   | "eligible"
+  | "failed"
   | "inProgress"
   | "missing"
+  | "noTimestamp"
   | "oversized"
   | "scheduled";
 
 const getWorkflowCompletionTime = (
-  workflowRecord: { _creationTime: number },
   journalEntries: Array<{ step: { completedAt?: number } }>
-): number => {
+): number | null => {
   const completionTimes = journalEntries.flatMap((entry) =>
     entry.step.completedAt === undefined ? [] : [entry.step.completedAt]
   );
-  return completionTimes.length === 0
-    ? workflowRecord._creationTime
-    : Math.max(...completionTimes);
+  return completionTimes.length === 0 ? null : Math.max(...completionTimes);
 };
 
 const cleanupWorkflowHistoryEntry = async (
@@ -177,10 +177,10 @@ const cleanupWorkflowHistoryEntry = async (
     if (!completeJournalLoaded) {
       return "oversized";
     }
-    const completedAt = getWorkflowCompletionTime(
-      workflowRecord,
-      journalEntries
-    );
+    const completedAt = getWorkflowCompletionTime(journalEntries);
+    if (completedAt === null) {
+      return "noTimestamp";
+    }
     if (completedAt >= cutoffMs) {
       return "recent";
     }
@@ -216,10 +216,10 @@ const scheduleWorkflowHistoryEntry = async (
     if (!completeJournalLoaded) {
       return "oversized";
     }
-    const completedAt = getWorkflowCompletionTime(
-      workflowRecord,
-      journalEntries
-    );
+    const completedAt = getWorkflowCompletionTime(journalEntries);
+    if (completedAt === null) {
+      return "noTimestamp";
+    }
     if (dryRun) {
       return "eligible";
     }
@@ -259,8 +259,10 @@ export const scheduleWorkflowHistoryCleanupBatchHandler = async (
 
   const totals: Record<WorkflowCleanupSchedulingStatus, number> = {
     eligible: 0,
+    failed: 0,
     inProgress: 0,
     missing: 0,
+    noTimestamp: 0,
     oversized: 0,
     scheduled: 0,
   };
@@ -275,7 +277,8 @@ export const scheduleWorkflowHistoryCleanupBatchHandler = async (
     );
     for (const result of results) {
       if (result.status === "rejected") {
-        throw result.reason;
+        totals.failed += 1;
+        continue;
       }
       totals[result.value] += 1;
     }
@@ -283,8 +286,10 @@ export const scheduleWorkflowHistoryCleanupBatchHandler = async (
 
   return {
     eligibleCount: totals.eligible,
+    failedCount: totals.failed,
     inProgressCount: totals.inProgress,
     missingCount: totals.missing,
+    noTimestampCount: totals.noTimestamp,
     oversizedCount: totals.oversized,
     scheduledCount: totals.scheduled,
     uniqueCount: workflowIds.length,
@@ -318,6 +323,7 @@ export const cleanupWorkflowHistoryBatchHandler = async (
     eligible: 0,
     inProgress: 0,
     missing: 0,
+    noTimestamp: 0,
     oversized: 0,
     recent: 0,
   };
@@ -348,6 +354,7 @@ export const cleanupWorkflowHistoryBatchHandler = async (
     eligibleCount: totals.eligible,
     inProgressCount: totals.inProgress,
     missingCount: totals.missing,
+    noTimestampCount: totals.noTimestamp,
     oversizedCount: totals.oversized,
     recentCount: totals.recent,
     uniqueCount: workflowIds.length,
@@ -370,6 +377,7 @@ export const cleanupWorkflowHistoryBatch = internalAction({
     eligibleCount: v.number(),
     inProgressCount: v.number(),
     missingCount: v.number(),
+    noTimestampCount: v.number(),
     oversizedCount: v.number(),
     recentCount: v.number(),
     uniqueCount: v.number(),
@@ -385,8 +393,10 @@ export const scheduleWorkflowHistoryCleanupBatch = internalAction({
   args: { dryRun: v.boolean(), workflowIds: v.array(vWorkflowId) },
   returns: v.object({
     eligibleCount: v.number(),
+    failedCount: v.number(),
     inProgressCount: v.number(),
     missingCount: v.number(),
+    noTimestampCount: v.number(),
     oversizedCount: v.number(),
     scheduledCount: v.number(),
     uniqueCount: v.number(),


### PR DESCRIPTION
## Summary
- add a bounded, dry-run-capable transition scheduler for workflows completed before retention rollout
- derive cleanup deadlines from each workflow journal's terminal completion time
- preserve generation guards and fail closed for incomplete journals

## Verification
- `bun test packages/convex/__tests__/workflows/manager.test.ts` (17 pass)
- `bun run typecheck` in `packages/convex`
- `bunx ultracite check packages/convex/workflows/manager.ts packages/convex/__tests__/workflows/manager.test.ts`
- pre-commit affected checks (24/24 tasks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow history cleanup can now be scheduled for each workflow’s original seven-day retention deadline.
  * Added batch processing with status counts for eligible, in-progress, missing, oversized, scheduled, and duplicate workflows.
  * Added a dry-run option to report cleanup eligibility without scheduling timers.

* **Bug Fixes**
  * Cleanup timing now uses the workflow’s actual completion time, with safe fallback handling for incomplete or unavailable journal data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->