### PR TITLE
fix(convex): shard card usage writes

### DIFF
--- a/packages/convex/__tests__/__tests__/auth.test.ts
+++ b/packages/convex/__tests__/__tests__/auth.test.ts
@@ -265,10 +265,13 @@ describe("auth", () => {
                 };
                 callback(builder);
                 return {
-                  unique: async () => ({
-                    activeCardCount: 12,
-                    isCountExact: true,
-                  }),
+                  unique: async () =>
+                    table === "userCardUsage"
+                      ? {
+                          activeCardCount: 12,
+                          isCountExact: true,
+                        }
+                      : null,
                 };
               },
             };
@@ -727,7 +730,8 @@ describe("auth", () => {
         db: {
           query: (table: string) => ({
             withIndex: (_name: string, cb: any) => {
-              cb({ eq: () => undefined });
+              const builder = { eq: () => builder };
+              cb(builder);
               return {
                 take: async () =>
                   table === "cardUsageMigrationEntries"

--- a/packages/convex/__tests__/card/createCard.test.ts
+++ b/packages/convex/__tests__/card/createCard.test.ts
@@ -10,6 +10,7 @@ process.env.APPLE_PRIVATE_KEY = TEST_APPLE_PRIVATE_KEY;
 process.env.APPLE_TEAM_ID = "test-apple-team-id";
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { CARD_USAGE_SHARD_VERSION } from "../../card/cardUsage";
 import { TEST_APPLE_PRIVATE_KEY } from "../helpers/appleAuth.test-utils";
 
 describe("card/createCard.ts", () => {
@@ -23,6 +24,23 @@ describe("card/createCard.ts", () => {
     }
     const query = ctx.db.query.bind(ctx.db);
     ctx.db.query = mock((table: string) => {
+      if (table === "userCardUsageShards") {
+        return {
+          withIndex: (_name: string, callback: (builder: any) => void) => {
+            const builder = { eq: () => builder };
+            callback(builder);
+            return {
+              unique: mock().mockResolvedValue({
+                _id: "usage_shard_1",
+                activeCardCount: 0,
+                shard: 0,
+                updatedAt: 1,
+                userId: "u1",
+              }),
+            };
+          },
+        };
+      }
       if (table !== "userCardUsage") {
         return query(table);
       }
@@ -31,7 +49,10 @@ describe("card/createCard.ts", () => {
           unique: mock().mockResolvedValue({
             _id: "usage_1",
             activeCardCount: 0,
+            isCountExact: true,
             isSaturated: false,
+            shardVersion: CARD_USAGE_SHARD_VERSION,
+            shardedAt: 1,
           }),
         }),
       };

--- a/packages/convex/__tests__/card/defaultCards.test.ts
+++ b/packages/convex/__tests__/card/defaultCards.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { CARD_USAGE_TOTAL_SHARDS } from "../../card/cardUsage";
 
 describe("card/defaultCards.ts", () => {
   let createDefaultCardsForUser: any;
@@ -7,22 +8,72 @@ describe("card/defaultCards.ts", () => {
 
   const addUsageRecord = (ctx: any) => {
     ctx.scheduler ??= { runAfter: mock().mockResolvedValue(null) };
+    const usageRecord = {
+      _id: "usage_1",
+      activeCardCount: 0,
+      isCountExact: true,
+      isSaturated: false,
+      updatedAt: 1,
+      userId: "u1",
+    };
+    const usageShards = new Map<number, Record<string, any>>();
     const query = ctx.db.query.bind(ctx.db);
     ctx.db.query = mock((table: string) => {
+      if (table === "userCardUsageShards") {
+        return {
+          withIndex: (_name: string, callback: (builder: any) => void) => {
+            let shard: number | undefined;
+            const builder = {
+              eq: (field: string, value: unknown) => {
+                if (field === "shard") {
+                  shard = value as number;
+                }
+                return builder;
+              },
+            };
+            callback(builder);
+            return {
+              collect: mock().mockImplementation(async () => [
+                ...usageShards.values(),
+              ]),
+              take: mock().mockImplementation(async () => [
+                ...usageShards.values(),
+              ]),
+              unique: mock().mockImplementation(async () =>
+                shard === undefined ? null : (usageShards.get(shard) ?? null)
+              ),
+            };
+          },
+        };
+      }
       if (table !== "userCardUsage") {
         return query(table);
       }
       return {
         withIndex: () => ({
-          unique: mock().mockResolvedValue({
-            _id: "usage_1",
-            activeCardCount: 0,
-            isSaturated: false,
-          }),
+          unique: mock().mockImplementation(async () => usageRecord),
         }),
       };
     });
-    ctx.db.patch ??= mock().mockResolvedValue(null);
+    const insert = ctx.db.insert.bind(ctx.db);
+    ctx.db.insert = mock(async (table: string, value: Record<string, any>) => {
+      if (table === "userCardUsageShards") {
+        usageShards.set(value.shard, {
+          ...value,
+          _id: `usage_shard_${value.shard}`,
+        });
+      }
+      return await insert(table, value);
+    });
+    const patch = ctx.db.patch?.bind(ctx.db);
+    ctx.db.patch = mock(
+      (table: string, id: string, value: Record<string, unknown>) => {
+        if (table === "userCardUsage" && id === usageRecord._id) {
+          Object.assign(usageRecord, value);
+        }
+        return patch?.(table, id, value);
+      }
+    );
   };
 
   beforeEach(async () => {
@@ -96,7 +147,11 @@ describe("card/defaultCards.ts", () => {
     const result = await handler(ctx, { userId: "u1" });
 
     expect(result).toEqual({ created: false, reason: "cards_exist" });
-    expect(ctx.db.insert).not.toHaveBeenCalled();
+    expect(
+      ctx.db.insert.mock.calls.filter(
+        ([table]: [string]) => table === "userCardUsageShards"
+      )
+    ).toHaveLength(CARD_USAGE_TOTAL_SHARDS);
   });
 
   test("creates default cards for new user", async () => {
@@ -116,7 +171,19 @@ describe("card/defaultCards.ts", () => {
       (createDefaultCardsForUser as any).handler ?? createDefaultCardsForUser;
     const result = await handler(ctx, { userId: "u1" });
 
-    expect(ctx.db.insert).toHaveBeenCalledTimes(3);
+    const insertTables = ctx.db.insert.mock.calls.map(
+      ([table]: [string]) => table
+    );
+    expect(
+      insertTables.filter((table: string) => table === "cards")
+    ).toHaveLength(3);
+    expect(
+      insertTables.filter((table: string) => table === "userCardUsageShards")
+    ).toHaveLength(CARD_USAGE_TOTAL_SHARDS);
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      "userCardUsageShards",
+      expect.objectContaining({ userId: "u1", shard: 0 })
+    );
     expect(ctx.scheduler.runAfter).toHaveBeenCalledTimes(3);
     expect(result).toEqual({ created: true, count: 3 });
   });
@@ -130,8 +197,10 @@ describe("card/defaultCards.ts", () => {
             first: mock().mockResolvedValue(null),
           }),
         }),
-        insert: mock().mockImplementation((_table: string, data: any) => {
-          insertedCards.push(data);
+        insert: mock().mockImplementation((table: string, data: any) => {
+          if (table === "cards") {
+            insertedCards.push(data);
+          }
           return `id_${insertedCards.length}`;
         }),
       },
@@ -185,8 +254,10 @@ describe("card/defaultCards.ts", () => {
             first: mock().mockResolvedValue(null),
           }),
         }),
-        insert: mock().mockImplementation((_table: string, data: any) => {
-          insertedCards.push(data);
+        insert: mock().mockImplementation((table: string, data: any) => {
+          if (table === "cards") {
+            insertedCards.push(data);
+          }
           return `id_${insertedCards.length}`;
         }),
       },
@@ -218,8 +289,10 @@ describe("card/defaultCards.ts", () => {
             first: mock().mockResolvedValue(null),
           }),
         }),
-        insert: mock().mockImplementation((_table: string, data: any) => {
-          insertedCards.push(data);
+        insert: mock().mockImplementation((table: string, data: any) => {
+          if (table === "cards") {
+            insertedCards.push(data);
+          }
           return `id_${insertedCards.length}`;
         }),
       },

--- a/packages/convex/__tests__/card/updateCard.test.ts
+++ b/packages/convex/__tests__/card/updateCard.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { CARD_USAGE_SHARD_VERSION } from "../../card/cardUsage";
 
 const mockReprocessLimit = mock().mockResolvedValue({ ok: true });
 
@@ -11,22 +12,43 @@ describe("card/updateCard.ts", () => {
     if (!ctx.db) {
       return;
     }
-    if (!ctx.db.query) {
-      ctx.db.query = mock((table: string) => ({
-        withIndex: () => ({
-          unique: mock().mockResolvedValue(
-            table === "userCardUsage"
-              ? {
-                  _id: "usage_1",
-                  activeCardCount: 1,
-                  isCountExact: true,
-                  isSaturated: false,
-                }
-              : null
-          ),
-        }),
-      }));
-    }
+    const query = ctx.db.query?.bind(ctx.db);
+    ctx.db.query = mock((table: string) => {
+      if (table === "userCardUsage") {
+        return {
+          withIndex: () => ({
+            unique: mock().mockResolvedValue({
+              _id: "usage_1",
+              activeCardCount: 1,
+              isCountExact: true,
+              isSaturated: false,
+              shardVersion: CARD_USAGE_SHARD_VERSION,
+              shardedAt: 1,
+            }),
+          }),
+        };
+      }
+      if (table === "userCardUsageShards") {
+        return {
+          withIndex: () => ({
+            unique: mock().mockResolvedValue({
+              _id: "usage_shard_1",
+              activeCardCount: 0,
+              shard: 0,
+              updatedAt: 1,
+              userId: "u1",
+            }),
+          }),
+        };
+      }
+      return query
+        ? query(table)
+        : {
+            withIndex: () => ({
+              unique: mock().mockResolvedValue(null),
+            }),
+          };
+    });
   };
 
   beforeEach(async () => {

--- a/packages/convex/__tests__/publicApi.test.ts
+++ b/packages/convex/__tests__/publicApi.test.ts
@@ -355,16 +355,32 @@ describe("publicApi", () => {
             insert,
             patch: mock().mockResolvedValue(null),
             query: (table: string) => ({
-              withIndex: () =>
-                table === "userCardUsage"
-                  ? {
-                      unique: mock().mockResolvedValue({
-                        _id: "usage_1",
-                        activeCardCount: 0,
-                        isSaturated: false,
-                      }),
-                    }
-                  : { take: mock().mockResolvedValue([]) },
+              withIndex: () => {
+                if (table === "userCardUsage") {
+                  return {
+                    unique: mock().mockResolvedValue({
+                      _id: "usage_1",
+                      activeCardCount: 0,
+                      isCountExact: true,
+                      isSaturated: false,
+                      shardVersion: 1,
+                      shardedAt: 1,
+                    }),
+                  };
+                }
+                if (table === "userCardUsageShards") {
+                  return {
+                    unique: mock().mockResolvedValue({
+                      _id: "usage_shard_1",
+                      activeCardCount: 0,
+                      shard: 0,
+                      updatedAt: 1,
+                      userId: "user_1",
+                    }),
+                  };
+                }
+                return { take: mock().mockResolvedValue([]) };
+              },
             }),
           },
           scheduler: { runAfter: mock().mockResolvedValue(null) },

--- a/packages/convex/auth.ts
+++ b/packages/convex/auth.ts
@@ -26,7 +26,7 @@ import authConfig from "./auth.config";
 import { polar } from "./billing";
 import {
   CARD_USAGE_SCAN_LIMIT,
-  getCardUsage,
+  getCardUsageSnapshot,
   removeCardUsage,
 } from "./card/cardUsage";
 
@@ -435,7 +435,7 @@ export const getCurrentUserHandler = async (ctx: any) => {
     hasPremium = false;
   }
 
-  const usage = await getCardUsage(ctx, userId);
+  const usage = await getCardUsageSnapshot(ctx, userId);
   const cardsQuery = ctx.db
     .query("cards")
     .withIndex("by_user_deleted", (q: any) =>
@@ -499,7 +499,7 @@ export const getCardCreationStatusHandler = async (ctx: any) => {
     };
   }
 
-  const usage = await getCardUsage(ctx, userId);
+  const usage = await getCardUsageSnapshot(ctx, userId);
   const activeCardCount =
     usage?.isCountExact === true
       ? usage.activeCardCount

--- a/packages/convex/card/cardUsage.ts
+++ b/packages/convex/card/cardUsage.ts
@@ -173,10 +173,19 @@ const incrementShardedUsage = async (
   hasPremium: boolean
 ) => {
   if (!hasPremium) {
+    let overflowActiveCardCount = 0;
     for (let offset = 0; offset < CARD_USAGE_OVERFLOW_SHARDS; offset += 1) {
       const shard = CARD_USAGE_BASE_SHARDS + offset;
       const overflow = await getRequiredCardUsageShard(ctx, userId, shard);
-      if (overflow.activeCardCount > 0) {
+      overflowActiveCardCount += overflow.activeCardCount;
+    }
+    if (overflowActiveCardCount > 0) {
+      let activeCardCount = overflowActiveCardCount;
+      for (let shard = 0; shard < CARD_USAGE_BASE_SHARDS; shard += 1) {
+        const usage = await getRequiredCardUsageShard(ctx, userId, shard);
+        activeCardCount += usage.activeCardCount;
+      }
+      if (activeCardCount >= FREE_TIER_LIMIT) {
         throw new ConvexError({
           code: CARD_ERROR_CODES.CARD_LIMIT_REACHED,
           message: CARD_ERROR_MESSAGES.CARD_LIMIT_REACHED,

--- a/packages/convex/card/cardUsage.ts
+++ b/packages/convex/card/cardUsage.ts
@@ -1,8 +1,18 @@
+import { ConvexError } from "convex/values";
 import type { Doc, Id } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
-import { FREE_TIER_LIMIT } from "../shared/constants";
+import {
+  CARD_ERROR_CODES,
+  CARD_ERROR_MESSAGES,
+  FREE_TIER_LIMIT,
+} from "../shared/constants";
 
 export const CARD_USAGE_SCAN_LIMIT = FREE_TIER_LIMIT + 1;
+export const CARD_USAGE_BASE_SHARDS = 16;
+export const CARD_USAGE_OVERFLOW_SHARDS = 8;
+export const CARD_USAGE_TOTAL_SHARDS =
+  CARD_USAGE_BASE_SHARDS + CARD_USAGE_OVERFLOW_SHARDS;
+export const CARD_USAGE_SHARD_VERSION = 1;
 
 type DatabaseReaderCtx = Pick<MutationCtx | QueryCtx, "db">;
 
@@ -24,6 +34,216 @@ export const getCardUsage = async (ctx: DatabaseReaderCtx, userId: string) =>
     .query("userCardUsage")
     .withIndex("by_userId", (query) => query.eq("userId", userId))
     .unique();
+
+const getCardUsageShard = async (
+  ctx: DatabaseReaderCtx,
+  userId: string,
+  shard: number
+) => {
+  const indexedQuery = ctx.db
+    .query("userCardUsageShards")
+    .withIndex("by_userId_and_shard", (query) =>
+      query.eq("userId", userId).eq("shard", shard)
+    );
+  if (typeof indexedQuery.unique !== "function") {
+    return null;
+  }
+  return await indexedQuery.unique();
+};
+
+const getRequiredCardUsageShard = async (
+  ctx: DatabaseReaderCtx,
+  userId: string,
+  shard: number
+) => {
+  const usageShard = await getCardUsageShard(ctx, userId, shard);
+  if (!usageShard) {
+    throw new Error(`Card usage shard ${shard} is missing for user`);
+  }
+  return usageShard;
+};
+
+export const initializeCardUsageShards = async (
+  ctx: MutationCtx,
+  usage: Doc<"userCardUsage">
+) => {
+  const existingShards = await ctx.db
+    .query("userCardUsageShards")
+    .withIndex("by_userId_and_shard", (query) =>
+      query.eq("userId", usage.userId)
+    )
+    .take(CARD_USAGE_TOTAL_SHARDS + 1);
+  if (usage.shardVersion === CARD_USAGE_SHARD_VERSION) {
+    const shardNumbers = new Set(existingShards.map((shard) => shard.shard));
+    if (
+      existingShards.length !== CARD_USAGE_TOTAL_SHARDS ||
+      shardNumbers.size !== CARD_USAGE_TOTAL_SHARDS ||
+      [...shardNumbers].some(
+        (shard) => shard < 0 || shard >= CARD_USAGE_TOTAL_SHARDS
+      )
+    ) {
+      throw new Error("Card usage shard set is incomplete");
+    }
+    return false;
+  }
+  if (usage.shardVersion !== undefined || usage.shardedAt !== undefined) {
+    throw new Error("Card usage shard version is unsupported");
+  }
+  if (!usage.isCountExact) {
+    throw new Error("Card usage must be exact before sharding");
+  }
+  for (const existingShard of existingShards) {
+    await ctx.db.delete("userCardUsageShards", existingShard._id);
+  }
+
+  const { activeCardCount, userId } = usage;
+  const cappedCount = Math.min(activeCardCount, FREE_TIER_LIMIT);
+  const overflowCount = Math.max(0, activeCardCount - FREE_TIER_LIMIT);
+  const now = Date.now();
+  for (let shard = 0; shard < CARD_USAGE_TOTAL_SHARDS; shard += 1) {
+    const isOverflow = shard >= CARD_USAGE_BASE_SHARDS;
+    const relativeShard = isOverflow ? shard - CARD_USAGE_BASE_SHARDS : shard;
+    const count = isOverflow ? overflowCount : cappedCount;
+    const shardCountForTier = isOverflow
+      ? CARD_USAGE_OVERFLOW_SHARDS
+      : CARD_USAGE_BASE_SHARDS;
+    const shardCount =
+      Math.floor(count / shardCountForTier) +
+      (relativeShard < count % shardCountForTier ? 1 : 0);
+    await ctx.db.insert("userCardUsageShards", {
+      userId,
+      shard,
+      activeCardCount: shardCount,
+      updatedAt: now,
+    });
+  }
+  await ctx.db.patch("userCardUsage", usage._id, {
+    migrationBackfilledAt: undefined,
+    shardVersion: CARD_USAGE_SHARD_VERSION,
+    shardedAt: now,
+    updatedAt: now,
+  });
+  return true;
+};
+
+export const getCardUsageSnapshot = async (
+  ctx: DatabaseReaderCtx,
+  userId: string
+) => {
+  const usage = await getCardUsage(ctx, userId);
+  if (usage?.shardVersion !== CARD_USAGE_SHARD_VERSION) {
+    return usage;
+  }
+  const shards = await Promise.all(
+    Array.from({ length: CARD_USAGE_TOTAL_SHARDS }, (_, shard) =>
+      getRequiredCardUsageShard(ctx, userId, shard)
+    )
+  );
+  const activeCardCount = shards.reduce(
+    (sum, shard) => sum + shard.activeCardCount,
+    0
+  );
+  return {
+    activeCardCount,
+    isCountExact: true,
+    isSaturated: activeCardCount >= FREE_TIER_LIMIT,
+    shardVersion: usage.shardVersion,
+    shardedAt: usage.shardedAt,
+    updatedAt: Math.max(...shards.map((shard) => shard.updatedAt)),
+    userId,
+  };
+};
+
+const shardForCard = (cardId: Id<"cards">) => {
+  let hash = 0;
+  for (const character of cardId) {
+    hash = (hash * 31 + character.charCodeAt(0)) % 2_147_483_647;
+  }
+  return hash;
+};
+
+const baseShardCapacity = (shard: number) =>
+  Math.floor(FREE_TIER_LIMIT / CARD_USAGE_BASE_SHARDS) +
+  (shard < FREE_TIER_LIMIT % CARD_USAGE_BASE_SHARDS ? 1 : 0);
+
+const incrementShardedUsage = async (
+  ctx: MutationCtx,
+  userId: string,
+  cardId: Id<"cards">,
+  hasPremium: boolean
+) => {
+  if (!hasPremium) {
+    for (let offset = 0; offset < CARD_USAGE_OVERFLOW_SHARDS; offset += 1) {
+      const shard = CARD_USAGE_BASE_SHARDS + offset;
+      const overflow = await getRequiredCardUsageShard(ctx, userId, shard);
+      if (overflow.activeCardCount > 0) {
+        throw new ConvexError({
+          code: CARD_ERROR_CODES.CARD_LIMIT_REACHED,
+          message: CARD_ERROR_MESSAGES.CARD_LIMIT_REACHED,
+        });
+      }
+    }
+  }
+
+  const start = shardForCard(cardId) % CARD_USAGE_BASE_SHARDS;
+  for (let offset = 0; offset < CARD_USAGE_BASE_SHARDS; offset += 1) {
+    const shard = (start + offset) % CARD_USAGE_BASE_SHARDS;
+    const usage = await getRequiredCardUsageShard(ctx, userId, shard);
+    if (usage.activeCardCount < baseShardCapacity(shard)) {
+      await ctx.db.patch("userCardUsageShards", usage._id, {
+        activeCardCount: usage.activeCardCount + 1,
+        updatedAt: Date.now(),
+      });
+      return;
+    }
+  }
+
+  if (!hasPremium) {
+    throw new ConvexError({
+      code: CARD_ERROR_CODES.CARD_LIMIT_REACHED,
+      message: CARD_ERROR_MESSAGES.CARD_LIMIT_REACHED,
+    });
+  }
+  const overflowShard =
+    CARD_USAGE_BASE_SHARDS +
+    (shardForCard(cardId) % CARD_USAGE_OVERFLOW_SHARDS);
+  const overflow = await getRequiredCardUsageShard(ctx, userId, overflowShard);
+  await ctx.db.patch("userCardUsageShards", overflow._id, {
+    activeCardCount: overflow.activeCardCount + 1,
+    updatedAt: Date.now(),
+  });
+};
+
+const decrementShardedUsage = async (
+  ctx: MutationCtx,
+  userId: string,
+  cardId: Id<"cards">
+) => {
+  const start = shardForCard(cardId);
+  for (let offset = 0; offset < CARD_USAGE_OVERFLOW_SHARDS; offset += 1) {
+    const shard =
+      CARD_USAGE_BASE_SHARDS + ((start + offset) % CARD_USAGE_OVERFLOW_SHARDS);
+    const usage = await getRequiredCardUsageShard(ctx, userId, shard);
+    if (usage.activeCardCount > 0) {
+      await ctx.db.patch("userCardUsageShards", usage._id, {
+        activeCardCount: usage.activeCardCount - 1,
+        updatedAt: Date.now(),
+      });
+      return;
+    }
+  }
+  for (let offset = 0; offset < CARD_USAGE_BASE_SHARDS; offset += 1) {
+    const shard = (start + offset) % CARD_USAGE_BASE_SHARDS;
+    const usage = await getRequiredCardUsageShard(ctx, userId, shard);
+    if (usage.activeCardCount > 0) {
+      await ctx.db.patch("userCardUsageShards", usage._id, {
+        activeCardCount: usage.activeCardCount - 1,
+        updatedAt: Date.now(),
+      });
+      return;
+    }
+  }
+};
 
 export const getOrInitializeCardUsage = async (
   ctx: MutationCtx,
@@ -57,41 +277,56 @@ export const getOrInitializeCardUsage = async (
   return initialized;
 };
 
+export const ensureCardUsageShards = async (
+  ctx: MutationCtx,
+  userId: string,
+  hasPremium: boolean
+) => {
+  const usage = await getOrInitializeCardUsage(ctx, userId);
+  if (usage.shardVersion === CARD_USAGE_SHARD_VERSION) {
+    return;
+  }
+  if (
+    !hasPremium &&
+    (usage.isSaturated ||
+      !usage.isCountExact ||
+      usage.activeCardCount >= FREE_TIER_LIMIT)
+  ) {
+    throw new ConvexError({
+      code: CARD_ERROR_CODES.CARD_LIMIT_REACHED,
+      message: CARD_ERROR_MESSAGES.CARD_LIMIT_REACHED,
+    });
+  }
+  await initializeCardUsageShards(ctx, usage);
+};
+
+export const ensureCardUsageShardsForRemoval = async (
+  ctx: MutationCtx,
+  userId: string
+) => {
+  const usage = await getOrInitializeCardUsage(ctx, userId);
+  if (usage.shardVersion !== CARD_USAGE_SHARD_VERSION && usage.isCountExact) {
+    await initializeCardUsageShards(ctx, usage);
+  }
+};
+
 export const recordActiveCardCreated = async (
   ctx: MutationCtx,
   userId: string,
-  cardId: Id<"cards">
+  cardId: Id<"cards">,
+  options: { hasPremium?: boolean } = {}
 ) => {
-  const usage = await getOrInitializeCardUsage(ctx, userId);
-  const nextCount = usage.activeCardCount + 1;
-  const migrationEntry = await getCardUsageMigrationEntry(ctx, cardId);
-  let migrationActiveCardCount = usage.migrationActiveCardCount;
-  if (migrationActiveCardCount !== undefined) {
-    if (migrationEntry) {
-      if (!migrationEntry.countedActive) {
-        await ctx.db.patch("cardUsageMigrationEntries", migrationEntry._id, {
-          countedActive: true,
-        });
-        migrationActiveCardCount += 1;
-      }
-    } else {
-      await ctx.db.insert("cardUsageMigrationEntries", {
-        cardId,
-        userId,
-        countedActive: true,
-        createdAt: Date.now(),
-      });
-      migrationActiveCardCount += 1;
-    }
+  const usage = await getCardUsage(ctx, userId);
+  if (usage?.shardVersion === CARD_USAGE_SHARD_VERSION) {
+    await incrementShardedUsage(
+      ctx,
+      userId,
+      cardId,
+      options.hasPremium ?? false
+    );
+    return;
   }
-  await ctx.db.patch("userCardUsage", usage._id, {
-    activeCardCount: nextCount,
-    isCountExact: usage.isCountExact,
-    isSaturated: usage.isSaturated || nextCount >= FREE_TIER_LIMIT,
-    migrationActiveCardCount,
-    migrationBackfilledAt: undefined,
-    updatedAt: Date.now(),
-  });
+  throw new Error("Card usage shards must be initialized before card creation");
 };
 
 export const recordActiveCardRemoved = async (
@@ -99,18 +334,24 @@ export const recordActiveCardRemoved = async (
   userId: string,
   cardId: Id<"cards">
 ) => {
-  const usage = await getOrInitializeCardUsage(ctx, userId);
+  const usage = await getCardUsage(ctx, userId);
+  if (usage?.shardVersion === CARD_USAGE_SHARD_VERSION) {
+    await decrementShardedUsage(ctx, userId, cardId);
+    return;
+  }
+  const initializedUsage =
+    usage ?? (await getOrInitializeCardUsage(ctx, userId));
   const migrationEntry = await getCardUsageMigrationEntry(ctx, cardId);
-  let migrationActiveCardCount = usage.migrationActiveCardCount;
+  let migrationActiveCardCount = initializedUsage.migrationActiveCardCount;
   if (migrationActiveCardCount !== undefined && migrationEntry?.countedActive) {
     await ctx.db.patch("cardUsageMigrationEntries", migrationEntry._id, {
       countedActive: false,
     });
     migrationActiveCardCount = Math.max(0, migrationActiveCardCount - 1);
   }
-  if (usage.isCountExact ?? !usage.isSaturated) {
-    const nextCount = Math.max(0, usage.activeCardCount - 1);
-    await ctx.db.patch("userCardUsage", usage._id, {
+  if (initializedUsage.isCountExact ?? !initializedUsage.isSaturated) {
+    const nextCount = Math.max(0, initializedUsage.activeCardCount - 1);
+    await ctx.db.patch("userCardUsage", initializedUsage._id, {
       activeCardCount: nextCount,
       isCountExact: true,
       isSaturated: nextCount >= FREE_TIER_LIMIT,
@@ -127,7 +368,7 @@ export const recordActiveCardRemoved = async (
       query.eq("userId", userId).eq("isDeleted", undefined)
     )
     .take(CARD_USAGE_SCAN_LIMIT);
-  await ctx.db.patch("userCardUsage", usage._id, {
+  await ctx.db.patch("userCardUsage", initializedUsage._id, {
     activeCardCount: remaining.length,
     isCountExact: remaining.length < CARD_USAGE_SCAN_LIMIT,
     isSaturated: remaining.length >= FREE_TIER_LIMIT,
@@ -138,6 +379,12 @@ export const recordActiveCardRemoved = async (
 };
 
 export const removeCardUsage = async (ctx: MutationCtx, userId: string) => {
+  for (let shard = 0; shard < CARD_USAGE_TOTAL_SHARDS; shard += 1) {
+    const usageShard = await getCardUsageShard(ctx, userId, shard);
+    if (usageShard) {
+      await ctx.db.delete("userCardUsageShards", usageShard._id);
+    }
+  }
   const usage = await getCardUsage(ctx, userId);
   if (usage) {
     await ctx.db.delete("userCardUsage", usage._id);

--- a/packages/convex/card/createCard.ts
+++ b/packages/convex/card/createCard.ts
@@ -10,7 +10,6 @@ import {
   type MutationCtx,
   mutation,
 } from "../_generated/server";
-import { ensureCardCreationAllowed } from "../auth";
 import { cardTypeValidator, colorValidator } from "../schema";
 import type { CardCreationSource } from "../shared/metrics";
 import { normalizeErrorClass } from "../shared/telemetry";
@@ -24,6 +23,7 @@ import {
   stageCompleted,
   stagePending,
 } from "./processingStatus";
+import { authorizeCardCreation } from "./quota";
 import { normalizeQuoteContent } from "./quoteFormatting";
 import { scheduleCardSearchSync } from "./searchDocumentHelpers";
 import { extractUrlFromContent } from "./validationUtils";
@@ -80,7 +80,7 @@ export const createCardForUserHandler = async (
   } = {}
 ): Promise<Id<"cards">> => {
   // Check rate limit and card count limit
-  await ensureCardCreationAllowed(ctx, userId);
+  const { hasPremium } = await authorizeCardCreation(ctx, userId);
 
   const now = Date.now();
 
@@ -206,7 +206,7 @@ export const createCardForUserHandler = async (
   };
 
   const cardId = await ctx.db.insert("cards", cardData);
-  await recordActiveCardCreated(ctx, userId, cardId);
+  await recordActiveCardCreated(ctx, userId, cardId, { hasPremium });
   await scheduleCardSearchSync(ctx, cardId);
 
   // Start the card processing workflow

--- a/packages/convex/card/defaultCards.ts
+++ b/packages/convex/card/defaultCards.ts
@@ -3,7 +3,11 @@ import { internalMutation } from "../_generated/server";
 import { assertAccountNotDeleting } from "../accountDeletion";
 import type { CardType } from "../schema";
 import { buildColorFacets } from "../shared/utils/colorUtils";
-import { getOrInitializeCardUsage, recordActiveCardCreated } from "./cardUsage";
+import {
+  getOrInitializeCardUsage,
+  initializeCardUsageShards,
+  recordActiveCardCreated,
+} from "./cardUsage";
 import { type ProcessingStatus, stageCompleted } from "./processingStatus";
 import { scheduleCardSearchSync } from "./searchDocumentHelpers";
 
@@ -103,6 +107,8 @@ export const createDefaultCardsForUser = internalMutation({
   args: { userId: v.string() },
   handler: async (ctx, { userId }) => {
     await assertAccountNotDeleting(ctx, userId);
+    const usage = await getOrInitializeCardUsage(ctx, userId);
+    await initializeCardUsageShards(ctx, usage);
     // Check if user already has any non-deleted cards
     const existingCard = await ctx.db
       .query("cards")
@@ -118,7 +124,6 @@ export const createDefaultCardsForUser = internalMutation({
     // Create default cards with slight timestamp offsets for consistent ordering
     const now = Date.now();
     const processingStatus = buildCompletedProcessingStatus(now);
-    await getOrInitializeCardUsage(ctx, userId);
 
     for (let i = 0; i < DEFAULT_CARDS.length; i++) {
       const cardDef = DEFAULT_CARDS[i];

--- a/packages/convex/card/deleteCard.ts
+++ b/packages/convex/card/deleteCard.ts
@@ -1,7 +1,10 @@
 import { v } from "convex/values";
 import { mutation } from "../_generated/server";
 import { cardStorageObjectKeys, deleteObject } from "../storage/r2";
-import { getOrInitializeCardUsage, recordActiveCardRemoved } from "./cardUsage";
+import {
+  ensureCardUsageShardsForRemoval,
+  recordActiveCardRemoved,
+} from "./cardUsage";
 import { scheduleCardSearchSync } from "./searchDocumentHelpers";
 
 export const permanentDeleteCard = mutation({
@@ -26,7 +29,7 @@ export const permanentDeleteCard = mutation({
     }
 
     if (!card.isDeleted) {
-      await getOrInitializeCardUsage(ctx, card.userId);
+      await ensureCardUsageShardsForRemoval(ctx, card.userId);
     }
 
     // Permanently remove from database

--- a/packages/convex/card/quota.ts
+++ b/packages/convex/card/quota.ts
@@ -9,7 +9,7 @@ import {
 } from "../shared/constants";
 import { isApprovedActiveSubscription } from "../shared/polarPlans";
 import { rateLimiter } from "../shared/rateLimits";
-import { getOrInitializeCardUsage } from "./cardUsage";
+import { ensureCardUsageShards, getCardUsageSnapshot } from "./cardUsage";
 
 export interface CardQuotaDeps {
   getSubscription: (
@@ -31,23 +31,36 @@ const defaultCardCreationDeps: CardCreationDeps = {
   rateLimiter,
 };
 
+const consumeCardCreationLimit = async (
+  ctx: MutationCtx,
+  userId: string,
+  limiter: CardCreationDeps["rateLimiter"]
+) => {
+  const rateLimitResult = await limiter.limit(ctx, "cardCreation", {
+    key: userId,
+    throws: false,
+  });
+  if (!rateLimitResult.ok) {
+    throw new ConvexError({
+      code: CARD_ERROR_CODES.RATE_LIMITED,
+      message: CARD_ERROR_MESSAGES.RATE_LIMITED,
+      retryAt: Date.now() + rateLimitResult.retryAfter,
+    });
+  }
+};
+
 export const ensureCardQuotaAvailable = async (
   ctx: MutationCtx,
   userId: string,
   deps: CardQuotaDeps = defaultQuotaDeps
 ): Promise<void> => {
-  await assertAccountNotDeleting(ctx, userId);
-  let hasPremium = false;
-  try {
-    hasPremium = isApprovedActiveSubscription(
-      await deps.getSubscription(ctx, { userId })
-    );
-  } catch {
-    hasPremium = false;
+  const hasPremium = await getCardQuotaEntitlement(ctx, userId, deps);
+  if (hasPremium) {
+    return;
   }
 
-  const usage = await getOrInitializeCardUsage(ctx, userId);
-  if (hasPremium) {
+  const usage = await getCardUsageSnapshot(ctx, userId);
+  if (!usage) {
     return;
   }
   const isAtLimit = usage.isCountExact
@@ -68,21 +81,39 @@ export const ensureCardQuotaAvailable = async (
   }
 };
 
+export const getCardQuotaEntitlement = async (
+  ctx: MutationCtx,
+  userId: string,
+  deps: CardQuotaDeps = defaultQuotaDeps
+) => {
+  await assertAccountNotDeleting(ctx, userId);
+  let hasPremium = false;
+  try {
+    hasPremium = isApprovedActiveSubscription(
+      await deps.getSubscription(ctx, { userId })
+    );
+  } catch {
+    hasPremium = false;
+  }
+  return hasPremium;
+};
+
+export const authorizeCardCreation = async (
+  ctx: MutationCtx,
+  userId: string,
+  deps: CardCreationDeps = defaultCardCreationDeps
+) => {
+  await consumeCardCreationLimit(ctx, userId, deps.rateLimiter);
+  const hasPremium = await getCardQuotaEntitlement(ctx, userId, deps);
+  await ensureCardUsageShards(ctx, userId, hasPremium);
+  return { hasPremium };
+};
+
 export const ensureCardCreationAllowed = async (
   ctx: MutationCtx,
   userId: string,
   deps: CardCreationDeps = defaultCardCreationDeps
 ): Promise<void> => {
-  const rateLimitResult = await deps.rateLimiter.limit(ctx, "cardCreation", {
-    key: userId,
-    throws: false,
-  });
-  if (!rateLimitResult.ok) {
-    throw new ConvexError({
-      code: CARD_ERROR_CODES.RATE_LIMITED,
-      message: CARD_ERROR_MESSAGES.RATE_LIMITED,
-      retryAt: Date.now() + rateLimitResult.retryAfter,
-    });
-  }
+  await consumeCardCreationLimit(ctx, userId, deps.rateLimiter);
   await ensureCardQuotaAvailable(ctx, userId, deps);
 };

--- a/packages/convex/card/updateCard.ts
+++ b/packages/convex/card/updateCard.ts
@@ -10,7 +10,8 @@ import { CARD_ERROR_CODES, CARD_ERROR_MESSAGES } from "../shared/constants";
 import { rateLimiter } from "../shared/rateLimits";
 import { assertSafeExternalUrl } from "../shared/utils/safeUrl";
 import {
-  getOrInitializeCardUsage,
+  ensureCardUsageShards,
+  ensureCardUsageShardsForRemoval,
   recordActiveCardCreated,
   recordActiveCardRemoved,
 } from "./cardUsage";
@@ -21,7 +22,7 @@ import {
   stagePending,
   withStageStatus,
 } from "./processingStatus";
-import { ensureCardQuotaAvailable } from "./quota";
+import { getCardQuotaEntitlement } from "./quota";
 import { normalizeQuoteContent } from "./quoteFormatting";
 import { scheduleCardSearchSync } from "./searchDocumentHelpers";
 
@@ -338,17 +339,21 @@ export const updateCardFieldForUserHandler = async (
   }
 
   if (field === "delete") {
-    await getOrInitializeCardUsage(ctx, userId);
+    await ensureCardUsageShardsForRemoval(ctx, userId);
   }
+  const hasPremium =
+    field === "restore"
+      ? await getCardQuotaEntitlement(ctx, userId)
+      : undefined;
   if (field === "restore") {
-    await ensureCardQuotaAvailable(ctx, userId);
+    await ensureCardUsageShards(ctx, userId, hasPremium ?? false);
   }
 
   await ctx.db.patch("cards", cardId, updateData);
   if (field === "delete" && !card.isDeleted) {
     await recordActiveCardRemoved(ctx, userId, cardId);
   } else if (field === "restore" && card.isDeleted) {
-    await recordActiveCardCreated(ctx, userId, cardId);
+    await recordActiveCardCreated(ctx, userId, cardId, { hasPremium });
   }
   if (!options.deferSearchSync) {
     await scheduleCardSearchSync(ctx, cardId);

--- a/packages/convex/card/uploadCard.ts
+++ b/packages/convex/card/uploadCard.ts
@@ -29,6 +29,7 @@ import {
   buildInitialProcessingStatus,
   stageCompleted,
 } from "./processingStatus";
+import { authorizeCardCreation } from "./quota";
 import { scheduleCardSearchSync } from "./searchDocumentHelpers";
 
 const toConvexFileError = (error: FileFormatValidationError) =>
@@ -167,7 +168,7 @@ export const createUploadedCardForUser = async (
 ) => {
   const now = Date.now();
 
-  await ensureCardCreationAllowed(ctx, args.userId);
+  const { hasPremium } = await authorizeCardCreation(ctx, args.userId);
 
   if (!args.fileKey.startsWith(`${buildR2UserPrefix(args.userId)}/`)) {
     throw new ConvexError({
@@ -275,7 +276,7 @@ export const createUploadedCardForUser = async (
     createdAt: now,
     updatedAt: now,
   });
-  await recordActiveCardCreated(ctx, args.userId, cardId);
+  await recordActiveCardCreated(ctx, args.userId, cardId, { hasPremium });
   await scheduleCardSearchSync(ctx, cardId);
 
   // Object metadata is served by the Files Worker path; the Convex R2

--- a/packages/convex/migrations.ts
+++ b/packages/convex/migrations.ts
@@ -1,7 +1,12 @@
 import { Migrations } from "@convex-dev/migrations";
 import { components, internal } from "./_generated/api.js";
-import type { DataModel } from "./_generated/dataModel.js";
-import { getCardUsage } from "./card/cardUsage";
+import type { DataModel, Doc } from "./_generated/dataModel.js";
+import type { MutationCtx } from "./_generated/server.js";
+import {
+  CARD_USAGE_TOTAL_SHARDS,
+  getCardUsage,
+  initializeCardUsageShards,
+} from "./card/cardUsage";
 import { syncCardSearchDocumentHandler } from "./card/searchDocumentHelpers";
 import { FREE_TIER_LIMIT } from "./shared/constants";
 
@@ -84,6 +89,68 @@ export const backfillCardSearchDocuments = migrations.define({
   },
 });
 
+export const backfillUserCardUsageShardsHandler = async (
+  ctx: MutationCtx,
+  usage: Doc<"userCardUsage">
+) => {
+  if (!usage.isCountExact) {
+    throw new Error("Card usage must be exact before sharding");
+  }
+  await initializeCardUsageShards(ctx, usage);
+};
+
+export const backfillUserCardUsageShards = migrations.define({
+  table: "userCardUsage",
+  batchSize: 20,
+  migrateOne: backfillUserCardUsageShardsHandler,
+});
+
+export const rollbackUserCardUsageShardsHandler = async (
+  ctx: MutationCtx,
+  usage: Doc<"userCardUsage">
+) => {
+  let activeCardCount = 0;
+  const shards: Doc<"userCardUsageShards">[] = [];
+  for (let shard = 0; shard < CARD_USAGE_TOTAL_SHARDS; shard += 1) {
+    const usageShard = await ctx.db
+      .query("userCardUsageShards")
+      .withIndex("by_userId_and_shard", (query) =>
+        query.eq("userId", usage.userId).eq("shard", shard)
+      )
+      .unique();
+    if (usageShard) {
+      activeCardCount += usageShard.activeCardCount;
+      shards.push(usageShard);
+    }
+  }
+  if (shards.length === 0) {
+    if (usage.shardVersion !== undefined || usage.shardedAt !== undefined) {
+      throw new Error("Card usage shard set is incomplete");
+    }
+    return;
+  }
+  if (shards.length !== CARD_USAGE_TOTAL_SHARDS) {
+    throw new Error("Card usage shard set is incomplete");
+  }
+  await ctx.db.patch("userCardUsage", usage._id, {
+    activeCardCount,
+    isCountExact: true,
+    isSaturated: activeCardCount >= FREE_TIER_LIMIT,
+    shardVersion: undefined,
+    shardedAt: undefined,
+    updatedAt: Date.now(),
+  });
+  for (const usageShard of shards) {
+    await ctx.db.delete("userCardUsageShards", usageShard._id);
+  }
+};
+
+export const rollbackUserCardUsageShards = migrations.define({
+  table: "userCardUsage",
+  batchSize: 20,
+  migrateOne: rollbackUserCardUsageShardsHandler,
+});
+
 export const rollbackUserCardUsage = migrations.define({
   table: "userCardUsage",
   batchSize: 20,
@@ -127,4 +194,12 @@ export const runOccContentionRollback = migrations.runner([
   internal.migrations.rollbackCardUsageMigrationEntries,
   internal.migrations.rollbackUserCardUsage,
   internal.migrations.rollbackCardSearchDocuments,
+]);
+
+export const runCardUsageShardBackfill = migrations.runner([
+  internal.migrations.backfillUserCardUsageShards,
+]);
+
+export const runCardUsageShardRollback = migrations.runner([
+  internal.migrations.rollbackUserCardUsageShards,
 ]);

--- a/packages/convex/occContention.test.ts
+++ b/packages/convex/occContention.test.ts
@@ -16,13 +16,18 @@ import {
   getAccountCardDeletionBatchHandler,
 } from "./auth";
 import {
+  CARD_USAGE_BASE_SHARDS,
   CARD_USAGE_SCAN_LIMIT,
+  CARD_USAGE_TOTAL_SHARDS,
+  getCardUsageSnapshot,
   getOrInitializeCardUsage,
+  initializeCardUsageShards,
   recordActiveCardCreated,
   recordActiveCardRemoved,
+  removeCardUsage,
 } from "./card/cardUsage";
 import { getDualReadSearchLimit } from "./card/getCards";
-import { ensureCardQuotaAvailable } from "./card/quota";
+import { authorizeCardCreation, ensureCardQuotaAvailable } from "./card/quota";
 import {
   buildCardSearchText,
   deduplicateCardSearchResults,
@@ -33,6 +38,10 @@ import {
   analyticsShardForRequest,
   IDEMPOTENCY_ANALYTICS_SHARDS,
 } from "./idempotencyAnalytics";
+import {
+  backfillUserCardUsageShardsHandler,
+  rollbackUserCardUsageShardsHandler,
+} from "./migrations";
 import schema from "./schema";
 import { FREE_TIER_LIMIT } from "./shared/constants";
 import { RATE_LIMIT_CONFIG, rateLimiter } from "./shared/rateLimits";
@@ -53,6 +62,25 @@ const insertCard = async (
     ...overrides,
   });
 
+const insertExactUsage = async (
+  ctx: MutationCtx,
+  userId: string,
+  activeCardCount: number
+) => {
+  const usageId = await ctx.db.insert("userCardUsage", {
+    userId,
+    activeCardCount,
+    isCountExact: true,
+    isSaturated: activeCardCount >= FREE_TIER_LIMIT,
+    updatedAt: Date.now(),
+  });
+  const usage = await ctx.db.get("userCardUsage", usageId);
+  if (!usage) {
+    throw new Error("Failed to insert card usage test fixture");
+  }
+  return usage;
+};
+
 describe("OCC contention behavior", () => {
   test("initializes usage with a bounded saturated scan", async () => {
     const t = convexTest(schema, modules);
@@ -71,49 +99,31 @@ describe("OCC contention behavior", () => {
   test("tracks create, delete, restore, and saturated recount transitions", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
-      await getOrInitializeCardUsage(ctx, "user-2");
+      const initialUsage = await getOrInitializeCardUsage(ctx, "user-2");
+      await initializeCardUsageShards(ctx, initialUsage);
       const cardId = await insertCard(ctx, "user-2");
       await recordActiveCardCreated(ctx, "user-2", cardId);
-      let usage = await ctx.db
-        .query("userCardUsage")
-        .withIndex("by_userId", (query) => query.eq("userId", "user-2"))
-        .unique();
-      expect(usage?.activeCardCount).toBe(1);
+      expect((await getCardUsageSnapshot(ctx, "user-2"))?.activeCardCount).toBe(
+        1
+      );
 
       await ctx.db.patch("cards", cardId, {
         deletedAt: Date.now(),
         isDeleted: true,
       });
       await recordActiveCardRemoved(ctx, "user-2", cardId);
-      usage = await ctx.db
-        .query("userCardUsage")
-        .withIndex("by_userId", (query) => query.eq("userId", "user-2"))
-        .unique();
-      expect(usage?.activeCardCount).toBe(0);
+      expect((await getCardUsageSnapshot(ctx, "user-2"))?.activeCardCount).toBe(
+        0
+      );
 
       await ctx.db.patch("cards", cardId, {
         deletedAt: undefined,
         isDeleted: undefined,
       });
       await recordActiveCardCreated(ctx, "user-2", cardId);
-      usage = await ctx.db
-        .query("userCardUsage")
-        .withIndex("by_userId", (query) => query.eq("userId", "user-2"))
-        .unique();
-      expect(usage?.activeCardCount).toBe(1);
-
-      await ctx.db.patch("userCardUsage", usage?._id as Id<"userCardUsage">, {
-        activeCardCount: FREE_TIER_LIMIT,
-        isCountExact: false,
-        isSaturated: true,
-      });
-      await recordActiveCardRemoved(ctx, "user-2", cardId);
-      usage = await ctx.db
-        .query("userCardUsage")
-        .withIndex("by_userId", (query) => query.eq("userId", "user-2"))
-        .unique();
-      expect(usage?.activeCardCount).toBe(1);
-      expect(usage?.isSaturated).toBe(false);
+      expect((await getCardUsageSnapshot(ctx, "user-2"))?.activeCardCount).toBe(
+        1
+      );
     });
   });
 
@@ -131,6 +141,181 @@ describe("OCC contention behavior", () => {
           getSubscription: async () => null,
         })
       ).rejects.toBeInstanceOf(ConvexError);
+    });
+  });
+
+  test("enforces the exact free-tier limit across bounded usage shards", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const userId = "user-sharded-limit";
+      const usage = await insertExactUsage(ctx, userId, FREE_TIER_LIMIT - 1);
+      expect(await initializeCardUsageShards(ctx, usage)).toBe(true);
+      expect(await ctx.db.query("userCardUsageShards").collect()).toHaveLength(
+        CARD_USAGE_TOTAL_SHARDS
+      );
+
+      const finalFreeCard = await insertCard(ctx, userId);
+      await recordActiveCardCreated(ctx, userId, finalFreeCard);
+      expect((await getCardUsageSnapshot(ctx, userId))?.activeCardCount).toBe(
+        FREE_TIER_LIMIT
+      );
+
+      const overLimitCard = await insertCard(ctx, userId);
+      await expect(
+        recordActiveCardCreated(ctx, userId, overLimitCard)
+      ).rejects.toMatchObject({
+        data: expect.objectContaining({ code: "CARD_LIMIT_REACHED" }),
+      });
+      expect((await getCardUsageSnapshot(ctx, userId))?.activeCardCount).toBe(
+        FREE_TIER_LIMIT
+      );
+    });
+  });
+
+  test("initializes shards before the first canonical card insert", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const userId = "user-first-canonical-create";
+      const authorization = await authorizeCardCreation(ctx, userId, {
+        getSubscription: async () => null,
+        rateLimiter: {
+          limit: async () => ({ ok: true, retryAfter: 0 }),
+        } as any,
+      });
+      expect((await getCardUsageSnapshot(ctx, userId))?.activeCardCount).toBe(
+        0
+      );
+
+      const cardId = await insertCard(ctx, userId);
+      await recordActiveCardCreated(ctx, userId, cardId, authorization);
+      expect((await getCardUsageSnapshot(ctx, userId))?.activeCardCount).toBe(
+        1
+      );
+    });
+  });
+
+  test("preserves premium overflow and drains it before base usage", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const userId = "user-sharded-premium";
+      const usage = await insertExactUsage(ctx, userId, FREE_TIER_LIMIT);
+      await initializeCardUsageShards(ctx, usage);
+
+      const premiumCard = await insertCard(ctx, userId);
+      await recordActiveCardCreated(ctx, userId, premiumCard, {
+        hasPremium: true,
+      });
+      expect((await getCardUsageSnapshot(ctx, userId))?.activeCardCount).toBe(
+        FREE_TIER_LIMIT + 1
+      );
+
+      await recordActiveCardRemoved(ctx, userId, premiumCard);
+      expect((await getCardUsageSnapshot(ctx, userId))?.activeCardCount).toBe(
+        FREE_TIER_LIMIT
+      );
+      const overflowCount = (
+        await ctx.db.query("userCardUsageShards").collect()
+      )
+        .filter((usage) => usage.shard >= CARD_USAGE_BASE_SHARDS)
+        .reduce((sum, usage) => sum + usage.activeCardCount, 0);
+      expect(overflowCount).toBe(0);
+    });
+  });
+
+  test("initializes saturated accounts without losing overflow usage", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const userId = "user-sharded-saturated";
+      const saturatedCount = FREE_TIER_LIMIT + 17;
+      const usage = await insertExactUsage(ctx, userId, saturatedCount);
+      await initializeCardUsageShards(ctx, usage);
+      const snapshot = await getCardUsageSnapshot(ctx, userId);
+      expect(snapshot?.activeCardCount).toBe(saturatedCount);
+      expect(snapshot?.isSaturated).toBe(true);
+
+      const cardId = await insertCard(ctx, userId);
+      await expect(
+        recordActiveCardCreated(ctx, userId, cardId)
+      ).rejects.toMatchObject({
+        data: expect.objectContaining({ code: "CARD_LIMIT_REACHED" }),
+      });
+    });
+  });
+
+  test("backfills, repairs, rolls back, and removes usage shards", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const userId = "user-shard-migration";
+      const usage = await insertExactUsage(ctx, userId, 37);
+      await ctx.db.insert("userCardUsageShards", {
+        userId,
+        shard: 0,
+        activeCardCount: 999,
+        updatedAt: Date.now(),
+      });
+
+      await backfillUserCardUsageShardsHandler(ctx, usage);
+      expect((await getCardUsageSnapshot(ctx, userId))?.activeCardCount).toBe(
+        37
+      );
+      expect(
+        await ctx.db
+          .query("userCardUsageShards")
+          .withIndex("by_userId_and_shard", (query) =>
+            query.eq("userId", userId)
+          )
+          .collect()
+      ).toHaveLength(CARD_USAGE_TOTAL_SHARDS);
+
+      const shardedUsage = await ctx.db.get("userCardUsage", usage._id);
+      expect(shardedUsage).not.toBeNull();
+      await rollbackUserCardUsageShardsHandler(
+        ctx,
+        shardedUsage as Doc<"userCardUsage">
+      );
+      const rolledBackUsage = await ctx.db.get("userCardUsage", usage._id);
+      expect(rolledBackUsage).toMatchObject({
+        activeCardCount: 37,
+        isCountExact: true,
+      });
+      expect(rolledBackUsage?.shardVersion).toBeUndefined();
+      expect(await ctx.db.query("userCardUsageShards").collect()).toHaveLength(
+        0
+      );
+
+      await backfillUserCardUsageShardsHandler(
+        ctx,
+        rolledBackUsage as Doc<"userCardUsage">
+      );
+      await removeCardUsage(ctx, userId);
+      expect(await ctx.db.get("userCardUsage", usage._id)).toBeNull();
+      expect(await ctx.db.query("userCardUsageShards").collect()).toHaveLength(
+        0
+      );
+    });
+  });
+
+  test("rejects a versioned but incomplete shard set", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const userId = "user-incomplete-shards";
+      const usage = await insertExactUsage(ctx, userId, 4);
+      await initializeCardUsageShards(ctx, usage);
+      const shard = await ctx.db
+        .query("userCardUsageShards")
+        .withIndex("by_userId_and_shard", (query) =>
+          query.eq("userId", userId).eq("shard", 0)
+        )
+        .unique();
+      expect(shard).not.toBeNull();
+      await ctx.db.delete(
+        "userCardUsageShards",
+        shard?._id as Id<"userCardUsageShards">
+      );
+      const versionedUsage = await ctx.db.get("userCardUsage", usage._id);
+      await expect(
+        initializeCardUsageShards(ctx, versionedUsage as Doc<"userCardUsage">)
+      ).rejects.toThrow("incomplete");
     });
   });
 
@@ -164,9 +349,9 @@ describe("OCC contention behavior", () => {
       const cardId = await insertCard(ctx, userId);
       const usageId = await ctx.db.insert("userCardUsage", {
         userId,
-        activeCardCount: CARD_USAGE_SCAN_LIMIT,
-        isCountExact: false,
-        isSaturated: true,
+        activeCardCount: 1,
+        isCountExact: true,
+        isSaturated: false,
         migrationActiveCardCount: 1,
         migrationCountStartedAt: Date.now(),
         updatedAt: Date.now(),
@@ -177,21 +362,20 @@ describe("OCC contention behavior", () => {
         countedActive: true,
         createdAt: Date.now(),
       });
+      const usage = await ctx.db.get("userCardUsage", usageId);
+      await initializeCardUsageShards(ctx, usage as Doc<"userCardUsage">);
 
       await ctx.db.patch("cards", cardId, { isDeleted: true });
       await recordActiveCardRemoved(ctx, userId, cardId);
-      let usage = await ctx.db.get("userCardUsage", usageId);
-      expect(usage?.migrationActiveCardCount).toBe(0);
+      expect((await getCardUsageSnapshot(ctx, userId))?.activeCardCount).toBe(
+        0
+      );
 
       await ctx.db.patch("cards", cardId, { isDeleted: undefined });
       await recordActiveCardCreated(ctx, userId, cardId);
-      usage = await ctx.db.get("userCardUsage", usageId);
-      expect(usage?.migrationActiveCardCount).toBe(1);
-      const entry = await ctx.db
-        .query("cardUsageMigrationEntries")
-        .withIndex("by_cardId", (query) => query.eq("cardId", cardId))
-        .unique();
-      expect(entry?.countedActive).toBe(true);
+      expect((await getCardUsageSnapshot(ctx, userId))?.activeCardCount).toBe(
+        1
+      );
     });
   });
 
@@ -297,6 +481,7 @@ describe("OCC contention behavior", () => {
       expect(usage.migrationBackfilledAt).toBeTypeOf("number");
       expect(document?.migrationBackfilledAt).toBeTypeOf("number");
 
+      await initializeCardUsageShards(ctx, usage);
       await recordActiveCardCreated(ctx, userId, cardId);
       await syncCardSearchDocumentHandler(ctx, cardId);
       const liveUsage = await ctx.db.get("userCardUsage", usage._id);

--- a/packages/convex/occContention.test.ts
+++ b/packages/convex/occContention.test.ts
@@ -222,6 +222,35 @@ describe("OCC contention behavior", () => {
     });
   });
 
+  test("allows downgraded users below the limit despite residual overflow", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const userId = "user-sharded-downgraded";
+      const usage = await insertExactUsage(ctx, userId, FREE_TIER_LIMIT + 1);
+      await initializeCardUsageShards(ctx, usage);
+
+      const baseShard = await ctx.db
+        .query("userCardUsageShards")
+        .withIndex("by_userId_and_shard", (query) =>
+          query.eq("userId", userId).eq("shard", 0)
+        )
+        .unique();
+      expect(baseShard).not.toBeNull();
+      await ctx.db.patch("userCardUsageShards", baseShard!._id, {
+        activeCardCount: baseShard!.activeCardCount - 2,
+      });
+      expect((await getCardUsageSnapshot(ctx, userId))?.activeCardCount).toBe(
+        FREE_TIER_LIMIT - 1
+      );
+
+      const freeCard = await insertCard(ctx, userId);
+      await recordActiveCardCreated(ctx, userId, freeCard);
+      expect((await getCardUsageSnapshot(ctx, userId))?.activeCardCount).toBe(
+        FREE_TIER_LIMIT
+      );
+    });
+  });
+
   test("initializes saturated accounts without losing overflow usage", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {

--- a/packages/convex/schema.ts
+++ b/packages/convex/schema.ts
@@ -562,8 +562,16 @@ export default defineSchema({
     migrationActiveCardCount: v.optional(v.number()),
     migrationBackfilledAt: v.optional(v.number()),
     migrationCountStartedAt: v.optional(v.number()),
+    shardVersion: v.optional(v.number()),
+    shardedAt: v.optional(v.number()),
     updatedAt: v.number(),
   }).index("by_userId", ["userId"]),
+  userCardUsageShards: defineTable({
+    userId: v.string(),
+    shard: v.number(),
+    activeCardCount: v.number(),
+    updatedAt: v.number(),
+  }).index("by_userId_and_shard", ["userId", "shard"]),
   cardUsageMigrationEntries: defineTable({
     cardId: v.id("cards"),
     userId: v.string(),


### PR DESCRIPTION
## Summary

- replace the singular per-user card usage write hotspot with 16 bounded base shards and 8 premium overflow shards
- preserve the exact 200-card free-tier limit while distributing concurrent create/delete/restore writes deterministically
- initialize and repair shard state in canonical write paths so deploy-before-backfill and newly provisioned users are safe
- add reversible, resumable migration handlers and remove shard records during account cleanup
- route quota/status reads through a canonical usage snapshot

## Production cause

The PR #367 production concurrency replay produced 7 successful creates and 1 permanent HTTP 500. Convex logs showed raycast:quickSaveForUser exhausting all retries while writing the single userCardUsage row. This change removes that row from normal card-count mutations.

## Safety and rollout

1. Deploy schema and dual-compatible code.
2. Run migrations:runCardUsageShardBackfill as a production dry run.
3. Run the resumable production backfill and verify shard sums match aggregate usage.
4. Re-run the full Production E2E workflow, including the eight-way create concurrency harness.
5. Continue the planned seven-day OCC soak before removing compatibility paths.

Rollback recomputes aggregate usage from shards, clears the shard marker, and removes shard rows.

## Verification

- 1,517 Convex Bun tests
- 19 OCC Vitest tests
- Convex TypeScript check
- scoped Ultracite check for all 16 changed files
- full affected pre-commit pipeline: 18/18 typecheck, lint, and build tasks
- Convex development schema deployment and migration dry run
- separate Standards and Spec reviews; all actionable findings fixed

No public API, MCP, Raycast, CLI, or UI contract changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved card usage tracking for higher concurrency and more accurate active-card counts.
  - Added support for premium overflow capacity while enforcing free-tier limits.
  - Added migration and rollback support for existing usage records.
  - Card creation, deletion, restoration, and default-card flows now maintain usage data consistently.

- **Bug Fixes**
  - Improved quota handling and usage initialization across card operations.
  - Added safeguards for incomplete or inconsistent usage data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->