### PR TITLE
test(e2e): read workflow status from card list

### DIFF
--- a/packages/tests/src/journey/13-occ-concurrency.e2e.ts
+++ b/packages/tests/src/journey/13-occ-concurrency.e2e.ts
@@ -98,12 +98,18 @@ test("preview OCC harness keeps parallel card operations coherent", async ({
     await expect
       .poll(
         async () => {
-          const response = await apiFetch(`/v1/cards/${target}`, apiKey);
+          const response = await apiFetch(
+            "/v1/cards?include=processing&limit=100",
+            apiKey
+          );
           if (!response.ok) {
             return "request-failed";
           }
-          const status = (await response.json()).processingStatus?.metadata
-            ?.status;
+          const payload = await response.json();
+          const targetCard = payload.items?.find(
+            (card: { id?: string }) => card.id === target
+          );
+          const status = targetCard?.processingStatus?.metadata?.status;
           return status ?? "missing";
         },
         { intervals: [500, 1000, 2000, 3000], timeout: 30_000 }


### PR DESCRIPTION
## Summary

- fix the Production E2E OCC harness to read workflow status from the card-list contract that exposes processingStatus
- request include=processing and select the exact target card by ID
- keep the poll bounded to the isolated account's 100 newest cards

## Cause

The single-card GET response intentionally does not serialize processingStatus, so the previous poll always returned missing even when the workflow completed. In production run 33336754365, all eight parallel creates and later concurrent writes succeeded; this incorrect assertion was the only failed test.

## Verification

- scoped Ultracite check
- full 12-package typecheck
- affected @teak/tests typecheck and lint hooks
- separate Standards and Spec reviews with no actionable findings