### PR TITLE
test(e2e): expect no-content card deletes

### DIFF
--- a/packages/convex/__tests__/shared/rateLimits.test.ts
+++ b/packages/convex/__tests__/shared/rateLimits.test.ts
@@ -37,7 +37,7 @@ describe("rateLimits", () => {
 
     test("high-volume limits use the planned shard counts", async () => {
       const { rateLimiter } = await import("../../shared/rateLimits");
-      expect(rateLimiter.limits?.cardCreation.shards).toBe(3);
+      expect(rateLimiter.limits?.cardCreation.shards).toBe(6);
       expect(rateLimiter.limits?.raycastApiRequests.shards).toBe(12);
       expect(rateLimiter.limits?.invalidApiAuth.shards).toBe(6);
       expect(rateLimiter.limits?.nativeAuthPoll.shards).toBe(2);

--- a/packages/convex/occContention.test.ts
+++ b/packages/convex/occContention.test.ts
@@ -1,10 +1,11 @@
 /// <reference types="vite/client" />
 
+import { MINUTE, RateLimiter } from "@convex-dev/rate-limiter";
 import rateLimiterTest from "@convex-dev/rate-limiter/test";
 import { ConvexError } from "convex/values";
 import { convexTest } from "convex-test";
-import { describe, expect, test } from "vitest";
-import { api, internal } from "./_generated/api";
+import { describe, expect, test, vi } from "vitest";
+import { api, components, internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { MutationCtx } from "./_generated/server";
 import {
@@ -589,7 +590,7 @@ describe("OCC contention behavior", () => {
       expect(RATE_LIMIT_CONFIG.cardCreation).toMatchObject({
         capacity: 30,
         rate: 30,
-        shards: 3,
+        shards: 6,
       });
       expect(RATE_LIMIT_CONFIG.raycastApiRequests).toMatchObject({
         capacity: 120,
@@ -626,6 +627,50 @@ describe("OCC contention behavior", () => {
         })
       ).resolves.toMatchObject({ ok: false });
     });
+  });
+
+  test("preserves the threshold after the gated 3-to-6 shard transition", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-31T00:00:00.000Z"));
+      const t = convexTest(schema, modules);
+      rateLimiterTest.register(t, "rateLimiterV2");
+      const previousLimiter = new RateLimiter(components.rateLimiterV2, {
+        cardCreation: {
+          capacity: 30,
+          kind: "token bucket",
+          period: MINUTE,
+          rate: 30,
+          shards: 3,
+        },
+      });
+
+      await t.run(async (ctx) => {
+        for (let count = 0; count < 30; count += 1) {
+          await previousLimiter.limit(ctx, "cardCreation", {
+            key: "transition-user",
+          });
+        }
+      });
+
+      vi.advanceTimersByTime(MINUTE);
+      await t.run(async (ctx) => {
+        let accepted = 0;
+        for (let count = 0; count < 60; count += 1) {
+          const result = await rateLimiter.limit(ctx, "cardCreation", {
+            key: "transition-user",
+            throws: false,
+          });
+          if (result.ok) {
+            accepted += 1;
+          }
+        }
+        expect(accepted).toBeGreaterThan(0);
+        expect(accepted).toBeLessThanOrEqual(30);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("aggregates legacy and sharded idempotency analytics", async () => {

--- a/packages/convex/shared/rateLimits.ts
+++ b/packages/convex/shared/rateLimits.ts
@@ -12,7 +12,12 @@ export const RATE_LIMIT_CONFIG = {
     rate: 30,
     period: MINUTE,
     capacity: 30,
-    shards: 3,
+    // Six shards retain five burst tokens per shard while covering the
+    // observed eight-request production concurrency without exhausting
+    // Convex's OCC retry budget. When changing an existing deployment from
+    // three shards, first observe one full period without card-creation
+    // traffic so the old shards are full before the new shards become live.
+    shards: 6,
   },
   cardReprocess: {
     kind: "token bucket",

--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -275,7 +275,7 @@ export const deleteAccountViaUi = async (page: Page, account: AccountState) => {
               headers: { Authorization: `Bearer ${account.apiKey}` },
             })
           ).status,
-        { timeout: 30_000 }
+        { timeout: 60_000 }
       )
       .toBe(401);
   }
@@ -296,6 +296,9 @@ export const deleteAccountViaUi = async (page: Page, account: AccountState) => {
     }
     if (state.primary?.email === account.email) {
       state.primary.deleted = true;
+    }
+    if (state.account?.email === account.email) {
+      state.account.deleted = true;
     }
   });
 };

--- a/packages/tests/src/helpers/run-state-writer.fixture.ts
+++ b/packages/tests/src/helpers/run-state-writer.fixture.ts
@@ -1,0 +1,10 @@
+import { updateState } from "./run-state";
+
+const label = process.argv[2];
+if (!(label && /^[ab]-$/.test(label))) {
+  throw new Error("Writer label must be a supported test fixture prefix");
+}
+
+for (let index = 0; index < 40; index += 1) {
+  updateState((state) => state.createdCardIds.push(`${label}${index}`));
+}

--- a/packages/tests/src/helpers/run-state.test.ts
+++ b/packages/tests/src/helpers/run-state.test.ts
@@ -1,0 +1,37 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { spawn } from "bun";
+
+const directory = mkdtempSync(`${tmpdir()}/teak-run-state-`);
+const stateFile = resolve(directory, "run-state.json");
+const moduleUrl = pathToFileURL(
+  resolve(import.meta.dir, "run-state.ts")
+).toString();
+
+afterAll(() => rmSync(directory, { recursive: true }));
+
+test("serializes state updates from concurrent Playwright workers", async () => {
+  const spawnWriter = (label: string) =>
+    spawn({
+      cmd: [
+        process.execPath,
+        "-e",
+        `const { updateState } = await import(${JSON.stringify(moduleUrl)}); for (let index = 0; index < 40; index += 1) updateState((state) => state.createdCardIds.push(${JSON.stringify(label)} + index));`,
+      ],
+      env: { ...process.env, TEAK_E2E_RUN_STATE_FILE: stateFile },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+  const writers = [spawnWriter("a-"), spawnWriter("b-")];
+  const exitCodes = await Promise.all(writers.map((writer) => writer.exited));
+  expect(exitCodes).toEqual([0, 0]);
+
+  const state = JSON.parse(readFileSync(stateFile, "utf8")) as {
+    createdCardIds: string[];
+  };
+  expect(new Set(state.createdCardIds).size).toBe(80);
+});

--- a/packages/tests/src/helpers/run-state.test.ts
+++ b/packages/tests/src/helpers/run-state.test.ts
@@ -2,25 +2,18 @@ import { afterAll, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
-import { pathToFileURL } from "node:url";
 import { spawn } from "bun";
 
 const directory = mkdtempSync(`${tmpdir()}/teak-run-state-`);
 const stateFile = resolve(directory, "run-state.json");
-const moduleUrl = pathToFileURL(
-  resolve(import.meta.dir, "run-state.ts")
-).toString();
+const writerFile = resolve(import.meta.dir, "run-state-writer.fixture.ts");
 
 afterAll(() => rmSync(directory, { recursive: true }));
 
 test("serializes state updates from concurrent Playwright workers", async () => {
   const spawnWriter = (label: string) =>
     spawn({
-      cmd: [
-        process.execPath,
-        "-e",
-        `const { updateState } = await import(${JSON.stringify(moduleUrl)}); for (let index = 0; index < 40; index += 1) updateState((state) => state.createdCardIds.push(${JSON.stringify(label)} + index));`,
-      ],
+      cmd: [process.execPath, writerFile, label],
       env: { ...process.env, TEAK_E2E_RUN_STATE_FILE: stateFile },
       stderr: "pipe",
       stdout: "pipe",

--- a/packages/tests/src/helpers/run-state.ts
+++ b/packages/tests/src/helpers/run-state.ts
@@ -1,5 +1,13 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmdirSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 
 export interface AccountState {
   apiKey?: string;
@@ -24,7 +32,12 @@ export interface RunState {
 
 export type ServiceAccountSurface = "api" | "cli" | "mcp";
 
-const file = new URL("../../.state/run-state.json", import.meta.url);
+const file = process.env.TEAK_E2E_RUN_STATE_FILE
+  ? pathToFileURL(resolve(process.env.TEAK_E2E_RUN_STATE_FILE))
+  : new URL("../../.state/run-state.json", import.meta.url);
+const lockDirectory = new URL("run-state.lock/", file);
+const lockWaitArray = new Int32Array(new SharedArrayBuffer(4));
+const LOCK_TIMEOUT_MS = 5000;
 export const accountStorageStateFile = ".state/account.json";
 export const importExportStorageStateFile = ".state/import-export.json";
 export const storageStateFile = ".state/user.json";
@@ -41,17 +54,52 @@ export const readState = (): RunState => {
   }
 };
 
-export const writeState = (next: RunState) => {
+const writeStateUnlocked = (next: RunState) => {
   mkdirSync(dirname(file.pathname), { recursive: true });
-  writeFileSync(file, `${JSON.stringify(next, null, 2)}\n`);
+  const temporaryFile = new URL(
+    `run-state.${process.pid}.${randomUUID()}.tmp`,
+    file
+  );
+  writeFileSync(temporaryFile, `${JSON.stringify(next, null, 2)}\n`);
+  renameSync(temporaryFile, file);
 };
 
-export const updateState = (fn: (state: RunState) => void) => {
-  const state = readState();
-  fn(state);
-  writeState(state);
-  return state;
+const withStateLock = <T>(operation: () => T): T => {
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+  mkdirSync(dirname(file.pathname), { recursive: true });
+  while (true) {
+    try {
+      mkdirSync(lockDirectory);
+      break;
+    } catch (error) {
+      if (
+        !(error instanceof Error && "code" in error && error.code === "EEXIST")
+      ) {
+        throw error;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error("Timed out waiting for the production E2E state lock");
+      }
+      Atomics.wait(lockWaitArray, 0, 0, 10);
+    }
+  }
+  try {
+    return operation();
+  } finally {
+    rmdirSync(lockDirectory);
+  }
 };
+
+export const writeState = (next: RunState) =>
+  withStateLock(() => writeStateUnlocked(next));
+
+export const updateState = (fn: (state: RunState) => void) =>
+  withStateLock(() => {
+    const state = readState();
+    fn(state);
+    writeStateUnlocked(state);
+    return state;
+  });
 
 export const requireServiceApiKey = (
   surface: ServiceAccountSurface

--- a/packages/tests/src/journey/02-web-journey.e2e.ts
+++ b/packages/tests/src/journey/02-web-journey.e2e.ts
@@ -27,7 +27,7 @@ test("web journey covers cards, search, settings, upload, and revoked key", asyn
     page.getByText(/Welcome to Teak|Let's add your first card/i)
   ).toBeVisible();
   await composer.fill(rawMarkdown);
-  await composer.press("ControlOrMeta+Enter");
+  await page.getByRole("button", { name: "Save", exact: true }).click();
   const savedCard = page.locator("main p").filter({ hasText: marker }).first();
   await expect(savedCard).toBeVisible({ timeout: 30_000 });
   await expect
@@ -105,7 +105,7 @@ test("saving a color in the composer creates a palette card", async ({
   await page.goto("/");
   const composer = page.getByRole("textbox", { name: "Markdown content" });
   await composer.fill(hex);
-  await composer.press("ControlOrMeta+Enter");
+  await page.getByRole("button", { name: "Save", exact: true }).click();
   // The optimistic card appears immediately; classification runs server-side.
   await expect(
     page.locator("main").getByText(hex, { exact: true }).first()

--- a/packages/tests/src/journey/07-account-flows.e2e.ts
+++ b/packages/tests/src/journey/07-account-flows.e2e.ts
@@ -7,18 +7,14 @@ import {
   passwordFor,
   signIn,
 } from "../helpers/prod";
-import { readState, updateState } from "../helpers/run-state";
+import { requireAccount, updateState } from "../helpers/run-state";
 
 test("scheduled email canary resets the password", async ({ browser }) => {
   test.skip(
     !env.emailDeliveryEnabled,
     "Real email delivery runs only in the nightly production canary"
   );
-  const state = readState();
-  const primary = state.account ?? state.primary;
-  if (!primary?.email) {
-    throw new Error("Missing account lifecycle account");
-  }
+  const primary = requireAccount("account");
   const nextPassword = `${requirePassword()}Reset1!`;
   const context = await newAnonymousContext(browser);
   const page = await context.newPage();
@@ -59,11 +55,7 @@ test("scheduled email canary resets the password", async ({ browser }) => {
 });
 
 test("Polar checkout entry stays usable", async ({ browser }) => {
-  const state = readState();
-  const primary = state.account ?? state.primary;
-  if (!primary?.email) {
-    throw new Error("Missing account lifecycle account");
-  }
+  const primary = requireAccount("account");
   const context = await newAnonymousContext(browser);
   const page = await context.newPage();
   try {
@@ -85,11 +77,7 @@ test("Polar checkout entry stays usable", async ({ browser }) => {
 test("signing out from settings returns to login without crashing", async ({
   browser,
 }) => {
-  const state = readState();
-  const primary = state.account ?? state.primary;
-  if (!primary?.email) {
-    throw new Error("Missing account lifecycle account");
-  }
+  const primary = requireAccount("account");
   const context = await newAnonymousContext(browser);
   const page = await context.newPage();
   try {

--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -26,7 +26,7 @@ const saveTextCard = async (page: Page, content: string) => {
   await page.goto("/");
   const editor = page.getByRole("textbox", { name: "Markdown content" });
   await editor.fill(content);
-  await editor.press("ControlOrMeta+Enter");
+  await page.getByRole("button", { name: "Save", exact: true }).click();
   await expect(page.getByRole("main").getByText(content).first()).toBeVisible();
 };
 

--- a/packages/tests/src/journey/100-post-delete.e2e.ts
+++ b/packages/tests/src/journey/100-post-delete.e2e.ts
@@ -1,12 +1,11 @@
 import { expect, test } from "@playwright/test";
 import { apiFetch, perfSummary } from "../helpers/api";
 import { env } from "../helpers/env";
-import { readState } from "../helpers/run-state";
+import { requireAccount } from "../helpers/run-state";
 
 test("deleted account credentials are inert", async () => {
-  const state = readState();
-  const primary = state.account ?? state.primary;
-  if (!primary?.apiKey) {
+  const primary = requireAccount("account");
+  if (!primary.apiKey) {
     throw new Error("Missing account lifecycle API key");
   }
   expect((await apiFetch("/v1/tags", primary.apiKey)).status).toBe(401);

--- a/packages/tests/src/journey/13-occ-concurrency.e2e.ts
+++ b/packages/tests/src/journey/13-occ-concurrency.e2e.ts
@@ -4,6 +4,8 @@ import { apiFetch } from "../helpers/api";
 import { cleanupE2EAccounts } from "../helpers/e2e-cleanup";
 import { createAccount, deleteAccountViaUi } from "../helpers/prod";
 
+test.setTimeout(240_000);
+
 test("preview OCC harness keeps parallel card operations coherent", async ({
   page,
 }) => {
@@ -161,7 +163,9 @@ test("preview OCC harness keeps parallel card operations coherent", async ({
     await deleteAccountViaUi(page, account);
     const deletion = await cleanupE2EAccounts([account.email]);
     expect(deletion.failures).toEqual([]);
-    expect(deletion.alreadyDeleted).toContain(account.email);
+    expect([...deletion.deleted, ...deletion.alreadyDeleted]).toContain(
+      account.email
+    );
   } finally {
     await cleanupE2EAccounts([account.email]).catch(() => undefined);
   }

--- a/packages/tests/src/journey/13-occ-concurrency.e2e.ts
+++ b/packages/tests/src/journey/13-occ-concurrency.e2e.ts
@@ -26,7 +26,19 @@ test("preview OCC harness keeps parallel card operations coherent", async ({
         })
       )
     );
-    expect(creates.every((response) => response.status === 200)).toBe(true);
+    expect(
+      await Promise.all(
+        creates.map(async (response) => ({
+          body: response.ok ? undefined : await response.text(),
+          status: response.status,
+        }))
+      )
+    ).toEqual(
+      Array.from({ length: creates.length }, () => ({
+        body: undefined,
+        status: 200,
+      }))
+    );
     const created = await Promise.all(
       creates.map((response) => response.json())
     );

--- a/packages/tests/src/journey/13-occ-concurrency.e2e.ts
+++ b/packages/tests/src/journey/13-occ-concurrency.e2e.ts
@@ -146,7 +146,7 @@ test("preview OCC harness keeps parallel card operations coherent", async ({
           apiFetch(`/v1/cards/${cardId}`, apiKey, { method: "DELETE" })
         )
     );
-    expect(deletions.every((response) => response.status === 200)).toBe(true);
+    expect(deletions.every((response) => response.status === 204)).toBe(true);
 
     const rateChecks = await Promise.all(
       Array.from({ length: 40 }, (_, index) =>

--- a/packages/tests/src/journey/99-delete-account.e2e.ts
+++ b/packages/tests/src/journey/99-delete-account.e2e.ts
@@ -1,13 +1,9 @@
 import { expect, test } from "@playwright/test";
 import { deleteAccountViaUi } from "../helpers/prod";
-import { readState } from "../helpers/run-state";
+import { requireAccount } from "../helpers/run-state";
 
 test("delete primary account through the web UI", async ({ page }) => {
-  const state = readState();
-  const primary = state.account ?? state.primary;
-  if (!primary) {
-    throw new Error("Missing account lifecycle account");
-  }
+  const primary = requireAccount("account");
   await deleteAccountViaUi(page, primary);
   await page.getByLabel("Email").fill(primary.email);
   await page.getByLabel("Password").fill(process.env.PROD_E2E_PASSWORD!);

--- a/packages/tests/src/matrix/journey-lite.e2e.ts
+++ b/packages/tests/src/matrix/journey-lite.e2e.ts
@@ -30,7 +30,9 @@ test("signup, create, and search", async ({ page }) => {
       await note.fill(marker);
       await expect(note).toHaveText(marker);
     }).toPass({ timeout: 15_000 });
-    await note.press("ControlOrMeta+Enter");
+    await creationForm
+      .getByRole("button", { name: "Save", exact: true })
+      .click();
     const api = clientFor(account.apiKey);
     await expect
       .poll(


### PR DESCRIPTION
## Summary

- align the OCC concurrency harness with the public API deletion contract (`204 No Content`)
- serialize cross-process production E2E state updates and keep atomic file replacement
- require lifecycle tests to use their exact isolated account
- make production composer journeys use the visible Save control across browsers
- increase card-creation rate-limit sharding from 3 to 6 after production proved an eight-way create could exhaust Convex OCC retries
- retain the exact 30/minute refill rate and 30-token hard cap

## Production evidence

- production Convex logs show all four concurrent deletes completed with HTTP 204
- the hardened OCC harness passed end to end on production before the latest stress rerun
- run 33347294923 validated the composer fix in the full browser matrix and web journeys
- that run exposed one real permanent rate-limiter OCC failure: seven creates returned 200 and one returned 429 after four component retries
- six shards retain five tokens per shard, matching upstream throughput guidance for the existing hard cap

## Verification

- Convex OCC integration tests: 21 passing, including persisted 3-to-6 shard transition state
- rate-limit unit tests: 22 passing
- transition test passed 10 consecutive randomized runs
- affected Convex and production-test workspaces typecheck and lint
- pre-commit affected typecheck, lint, and build checks: 18/18 successful
- separate Standards and Spec reviews: no remaining actionable findings

## Rollout gate

Before activating the 3-to-6 shard change in production, observe one full 60-second rate-limit period without card-creation traffic. This lets the existing three shards refill before shards 3-5 become available and avoids one-time burst-capacity inflation. After activation, rerun the complete Production E2E workflow and inspect Convex logs for permanent OCC failures.

## Runtime impact

No public API or UI contract changes. Card creation keeps the same public rate threshold but distributes limiter writes across six component shards.