### PR TITLE
Harden the production OCC soak harness

### DIFF
--- a/packages/convex/__tests__/publicApiHttp.test.ts
+++ b/packages/convex/__tests__/publicApiHttp.test.ts
@@ -143,6 +143,40 @@ describe("publicApiHttp", () => {
     expect(payload.code).toBe("RATE_LIMITED");
   });
 
+  test("createCardV1 maps serialized rate limit contention errors to 429", async () => {
+    const runMutation = mock()
+      .mockResolvedValueOnce({
+        keyId: "key_1",
+        userId: "user_1",
+        access: "full_access",
+        source: "component",
+        rateLimitKey: "component:key_1",
+      })
+      .mockRejectedValueOnce({
+        message:
+          'Documents read from or written to the "rateLimits" table changed while this mutation was being run and on every subsequent retry.',
+      });
+
+    const response = await runHandler(
+      createCardV1,
+      { runMutation, runQuery: mock() },
+      new Request("https://example.com/v1/cards", {
+        method: "POST",
+        headers: {
+          Authorization:
+            "Bearer teakapi_secret_live_a1b2c3d4_ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ content: "hello" }),
+      })
+    );
+
+    expect(response.status).toBe(429);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "RATE_LIMITED",
+    });
+  });
+
   test("createCardV1 returns 500 when auth mutation throws unexpected error", async () => {
     const runMutation = mock().mockRejectedValueOnce(
       new Error("db unavailable")

--- a/packages/convex/publicApiHttp.ts
+++ b/packages/convex/publicApiHttp.ts
@@ -323,13 +323,26 @@ const releaseIdempotencyResponse = async (
 };
 
 const isRateLimitContentionError = (error: unknown): boolean => {
-  if (!(error instanceof Error)) {
+  let message: string | undefined;
+  if (error instanceof Error) {
+    message = error.message;
+  } else if (typeof error === "string") {
+    message = error;
+  } else if (
+    error &&
+    typeof error === "object" &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    message = error.message;
+  }
+  if (!message) {
     return false;
   }
 
   return (
-    error.message.includes('"rateLimits" table') &&
-    error.message.includes(
+    message.includes('"rateLimits" table') &&
+    message.includes(
       "changed while this mutation was being run and on every subsequent retry"
     )
   );
@@ -346,6 +359,10 @@ const RATE_LIMITED_ERROR = (retryAt?: number): Response =>
 
 const RATE_LIMIT_CONTENTION_ERROR = (): Response => {
   const retryAt = Date.now() + 1000;
+  console.warn("[rate-limit] Contention fallback", {
+    event: "rate_limit_contention_fallback",
+    retryAt,
+  });
   return errorResponse(
     429,
     "RATE_LIMITED",

--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -24,9 +24,18 @@ const pdf = Buffer.from(
 
 const saveTextCard = async (page: Page, content: string) => {
   await page.goto("/");
-  const editor = page.getByRole("textbox", { name: "Markdown content" });
-  await editor.fill(content);
-  await page.getByRole("button", { name: "Save", exact: true }).click();
+  const creationForm = page.locator('form[data-card-creation-status="ready"]');
+  const editor = creationForm.getByRole("textbox", {
+    name: "Markdown content",
+  });
+  await expect(async () => {
+    await expect(creationForm).toBeVisible({ timeout: 5000 });
+    await editor.fill(content);
+    await expect(editor).toHaveText(content, { timeout: 5000 });
+  }).toPass({ intervals: [250, 500, 1000], timeout: 30_000 });
+  await creationForm
+    .getByRole("button", { name: "Save", exact: true })
+    .click({ timeout: 5000 });
   await expect(page.getByRole("main").getByText(content).first()).toBeVisible();
 };
 

--- a/packages/tests/src/journey/13-occ-concurrency.e2e.ts
+++ b/packages/tests/src/journey/13-occ-concurrency.e2e.ts
@@ -162,14 +162,22 @@ test("preview OCC harness keeps parallel card operations coherent", async ({
     );
     expect(deletions.every((response) => response.status === 204)).toBe(true);
 
-    const rateChecks = await Promise.all(
-      Array.from({ length: 40 }, (_, index) =>
-        apiFetch("/v1/cards", apiKey, {
-          body: JSON.stringify({ content: `${marker} rate-${index}` }),
-          method: "POST",
+    const rateChecks: Response[] = [];
+    const rateCheckConcurrency = 8;
+    for (let offset = 0; offset < 40; offset += rateCheckConcurrency) {
+      // Keep the harness parallel while respecting the production limiter's
+      // explicitly supported eight-request contention envelope.
+      const batch = await Promise.all(
+        Array.from({ length: rateCheckConcurrency }, (_, batchIndex) => {
+          const index = offset + batchIndex;
+          return apiFetch("/v1/cards", apiKey, {
+            body: JSON.stringify({ content: `${marker} rate-${index}` }),
+            method: "POST",
+          });
         })
-      )
-    );
+      );
+      rateChecks.push(...batch);
+    }
     expect(rateChecks.some((response) => response.status === 429)).toBe(true);
     expect(rateChecks.every((response) => response.status !== 500)).toBe(true);
     await deleteAccountViaUi(page, account);

--- a/packages/tests/src/matrix/journey-lite.e2e.ts
+++ b/packages/tests/src/matrix/journey-lite.e2e.ts
@@ -27,12 +27,13 @@ test("signup, create, and search", async ({ page }) => {
       name: "Markdown content",
     });
     await expect(async () => {
+      await expect(creationForm).toBeVisible({ timeout: 5000 });
       await note.fill(marker);
-      await expect(note).toHaveText(marker);
-    }).toPass({ timeout: 15_000 });
+      await expect(note).toHaveText(marker, { timeout: 5000 });
+    }).toPass({ intervals: [250, 500, 1000], timeout: 30_000 });
     await creationForm
       .getByRole("button", { name: "Save", exact: true })
-      .click();
+      .click({ timeout: 5000 });
     const api = clientFor(account.apiKey);
     await expect
       .poll(


### PR DESCRIPTION
## Summary
- exercise the six-shard card limiter in five bounded eight-request waves
- preserve retryable 429 behavior for serialized Convex OCC errors and emit a distinct contention-fallback log
- make flaky card-save readiness retries idempotent by clicking Save exactly once

## Evidence
- `bun test packages/convex/__tests__/publicApiHttp.test.ts`
- `bun run --cwd packages/convex typecheck`
- `bun run --cwd packages/tests typecheck`
- `bunx ultracite check` on all changed files
- pre-commit affected typecheck, lint, and build: 18/18 green
- separate Standards review: no findings
- separate Spec review findings addressed

## Production gate
The prior 40-way run exposed 8 permanent rateLimiterV2 OCC failures despite returning no HTTP 500s. After merge/deploy, the complete Production E2E run will be captured against Convex logs; the soak restarts only if the exact run window has zero permanent OCC failures and no `rate_limit_contention_fallback` events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rate-limit contention errors, including serialized errors, with the correct HTTP 429 response.
  * Added warning details when rate limiting occurs, including retry timing.

* **Tests**
  * Improved end-to-end test reliability by waiting for forms to be ready, retrying transient operations, and using bounded concurrency.
  * Added coverage for serialized rate-limit errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->