### PR TITLE
Stabilize production E2E browser journeys

### DIFF
--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -161,6 +161,24 @@ export const clickVisibleControl = async (
   }
 };
 
+export const fillAndSubmitTextCard = async (page: Page, content: string) => {
+  const creationForm = page.locator("form[data-card-creation-status]");
+  const readyCreationForm = page.locator(
+    'form[data-card-creation-status="ready"]'
+  );
+  const editor = creationForm.getByRole("textbox", {
+    name: "Markdown content",
+  });
+  await expect(async () => {
+    await expect(readyCreationForm).toBeVisible({ timeout: 5000 });
+    await editor.fill(content);
+    await expect(editor).toHaveText(content, { timeout: 5000 });
+  }).toPass({ intervals: [250, 500, 1000], timeout: 30_000 });
+  await creationForm
+    .getByRole("button", { name: "Save", exact: true })
+    .click({ timeout: 15_000 });
+};
+
 const settingsRow = (page: Page, label: string) =>
   page
     .getByText(label, { exact: true })

--- a/packages/tests/src/journey/06-security.e2e.ts
+++ b/packages/tests/src/journey/06-security.e2e.ts
@@ -3,7 +3,13 @@ import { expect, request as playwrightRequest, test } from "@playwright/test";
 import { apiFetch } from "../helpers/api";
 import { cleanupE2EAccounts } from "../helpers/e2e-cleanup";
 import { env } from "../helpers/env";
-import { clientFor, createAccount, newAnonymousContext } from "../helpers/prod";
+import {
+  clientFor,
+  createAccount,
+  generateApiKey,
+  newAnonymousContext,
+  revokeVisibleKey,
+} from "../helpers/prod";
 import { readState } from "../helpers/run-state";
 
 test("native pairing shows an approve step instead of minting on GET", async ({
@@ -77,7 +83,10 @@ test("external OAuth requires explicit full-vault consent and can be revoked", a
     state: "oauth-security-e2e",
   }).toString();
   await page.goto(authorize.toString());
-  await expect(page.getByText(clientName)).toBeVisible();
+  await expect(async () => {
+    await page.reload();
+    await expect(page.getByText(clientName)).toBeVisible({ timeout: 5000 });
+  }).toPass({ intervals: [500, 1000, 2000], timeout: 15_000 });
   await expect(
     page.getByText(/read, create, edit, and delete your cards/i)
   ).toBeVisible();
@@ -134,9 +143,7 @@ test("cross-tenant, revoked-key, hostile input, headers, and cookie security", a
   context,
 }) => {
   const state = readState();
-  if (!state.primary?.apiKey) {
-    throw new Error("Missing primary API key");
-  }
+  const securityApiKey = await generateApiKey(page);
   const secondContext = await newAnonymousContext(browser);
   const secondPage = await secondContext.newPage();
   const second = await createAccount(secondPage, "tenant-b", {
@@ -154,7 +161,7 @@ test("cross-tenant, revoked-key, hostile input, headers, and cookie security", a
     expect(state.revokedKey, "web-core should have revoked a key").toBeTruthy();
     expect((await apiFetch("/v1/tags", state.revokedKey!)).status).toBe(401);
     const hostile = `<img src=x onerror="window.__teakXss=1"> javascript:alert(1) שלום ${"x".repeat(100_000)}`;
-    await clientFor(state.primary.apiKey).cards.create({
+    await clientFor(securityApiKey).cards.create({
       content: hostile,
       source: "prod-e2e",
       tags: ["xss"],
@@ -184,7 +191,11 @@ test("cross-tenant, revoked-key, hostile input, headers, and cookie security", a
       )
     ).toBe(true);
   } finally {
-    await secondContext.close();
-    await cleanupE2EAccounts([second.email]);
+    try {
+      await revokeVisibleKey(page, securityApiKey);
+    } finally {
+      await secondContext.close();
+      await cleanupE2EAccounts([second.email]);
+    }
   }
 });

--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -5,7 +5,7 @@ import { MAX_FILE_SIZE } from "@teak/convex/shared";
 import { strFromU8, strToU8, unzipSync, zipSync } from "fflate";
 import { apiFetch } from "../helpers/api";
 import { validWebmAudio } from "../helpers/file-formats";
-import { clientFor } from "../helpers/prod";
+import { clientFor, fillAndSubmitTextCard } from "../helpers/prod";
 import { readState, updateState } from "../helpers/run-state";
 
 const png = Buffer.from(
@@ -24,18 +24,7 @@ const pdf = Buffer.from(
 
 const saveTextCard = async (page: Page, content: string) => {
   await page.goto("/");
-  const creationForm = page.locator('form[data-card-creation-status="ready"]');
-  const editor = creationForm.getByRole("textbox", {
-    name: "Markdown content",
-  });
-  await expect(async () => {
-    await expect(creationForm).toBeVisible({ timeout: 5000 });
-    await editor.fill(content);
-    await expect(editor).toHaveText(content, { timeout: 5000 });
-  }).toPass({ intervals: [250, 500, 1000], timeout: 30_000 });
-  await creationForm
-    .getByRole("button", { name: "Save", exact: true })
-    .click({ timeout: 5000 });
+  await fillAndSubmitTextCard(page, content);
   await expect(page.getByRole("main").getByText(content).first()).toBeVisible();
 };
 

--- a/packages/tests/src/matrix/journey-lite.e2e.ts
+++ b/packages/tests/src/matrix/journey-lite.e2e.ts
@@ -1,6 +1,10 @@
 import { expect, test } from "@playwright/test";
 import { cleanupE2EAccounts } from "../helpers/e2e-cleanup";
-import { clientFor, createAccount } from "../helpers/prod";
+import {
+  clientFor,
+  createAccount,
+  fillAndSubmitTextCard,
+} from "../helpers/prod";
 
 test.setTimeout(180_000);
 
@@ -19,21 +23,7 @@ test("signup, create, and search", async ({ page }) => {
         { exact: true }
       )
     ).toBeVisible();
-    const creationForm = page.locator(
-      'form[data-card-creation-status="ready"]'
-    );
-    await expect(creationForm).toBeVisible();
-    const note = creationForm.getByRole("textbox", {
-      name: "Markdown content",
-    });
-    await expect(async () => {
-      await expect(creationForm).toBeVisible({ timeout: 5000 });
-      await note.fill(marker);
-      await expect(note).toHaveText(marker, { timeout: 5000 });
-    }).toPass({ intervals: [250, 500, 1000], timeout: 30_000 });
-    await creationForm
-      .getByRole("button", { name: "Save", exact: true })
-      .click({ timeout: 5000 });
+    await fillAndSubmitTextCard(page, marker);
     const api = clientFor(account.apiKey);
     await expect
       .poll(


### PR DESCRIPTION
## Summary
- centralize card composer readiness and perform one stable Save click
- reload the non-mutating OAuth consent GET while a newly registered client propagates
- generate a fresh security-test API key instead of depending on setup-time key state

## Failure evidence
Production E2E run 33471767183 proved the bounded OCC harness itself passed with zero permanent Convex OCC failures, but Chromium matrix hit a detached Save form and the security project saw stale OAuth/API-key state.

## Verification
- `bunx ultracite check` on all changed files
- `bun run --cwd packages/tests typecheck`
- `bun test packages/tests` (23 passed)
- affected pre-commit typecheck/lint (2/2 green)
- separate Spec reviewer: no findings
- separate Standards finding addressed by extracting the shared composer helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for creating and saving text cards.
  * Increased reliability of security-related workflows by using fresh API credentials during testing.
  * Added more resilient verification for external OAuth consent flows.
  * Standardized card creation checks across product surface and journey tests, including retry handling for asynchronous form readiness and content entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->