### PR TITLE
test(e2e): isolate security journey session

### DIFF
--- a/packages/tests/playwright.config.test.ts
+++ b/packages/tests/playwright.config.test.ts
@@ -62,6 +62,9 @@ describe("production E2E project graph", () => {
       "journey-setup",
       "journey-web-core",
     ]);
+    expect(projects.get("journey-security")?.use?.storageState).toBe(
+      ".state/security.json"
+    );
     expect(projects.get("journey-account")?.dependencies).toEqual([
       "journey-setup",
     ]);

--- a/packages/tests/playwright.config.ts
+++ b/packages/tests/playwright.config.ts
@@ -124,7 +124,7 @@ export default defineConfig({
       workers: 1,
       use: {
         ...devices["Desktop Chrome"],
-        storageState: ".state/user.json",
+        storageState: ".state/security.json",
       },
     },
     {

--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -162,11 +162,10 @@ export const clickVisibleControl = async (
 };
 
 export const fillAndSubmitTextCard = async (page: Page, content: string) => {
-  const creationForm = page.locator("form[data-card-creation-status]");
   const readyCreationForm = page.locator(
     'form[data-card-creation-status="ready"]'
   );
-  const editor = creationForm.getByRole("textbox", {
+  const editor = readyCreationForm.getByRole("textbox", {
     name: "Markdown content",
   });
   await expect(async () => {
@@ -174,9 +173,9 @@ export const fillAndSubmitTextCard = async (page: Page, content: string) => {
     await editor.fill(content);
     await expect(editor).toHaveText(content, { timeout: 5000 });
   }).toPass({ intervals: [250, 500, 1000], timeout: 30_000 });
-  await creationForm
-    .getByRole("button", { name: "Save", exact: true })
-    .click({ timeout: 15_000 });
+  await clickVisibleControl(
+    readyCreationForm.getByRole("button", { name: "Save", exact: true })
+  );
 };
 
 const settingsRow = (page: Page, label: string) =>

--- a/packages/tests/src/helpers/run-state.ts
+++ b/packages/tests/src/helpers/run-state.ts
@@ -40,6 +40,7 @@ const lockWaitArray = new Int32Array(new SharedArrayBuffer(4));
 const LOCK_TIMEOUT_MS = 5000;
 export const accountStorageStateFile = ".state/account.json";
 export const importExportStorageStateFile = ".state/import-export.json";
+export const securityStorageStateFile = ".state/security.json";
 export const storageStateFile = ".state/user.json";
 export const webCoreStorageStateFile = ".state/web-core.json";
 export const webFilesStorageStateFile = ".state/web-files.json";

--- a/packages/tests/src/journey/01-signup.setup.ts
+++ b/packages/tests/src/journey/01-signup.setup.ts
@@ -4,6 +4,7 @@ import { createAccount } from "../helpers/prod";
 import {
   accountStorageStateFile,
   importExportStorageStateFile,
+  securityStorageStateFile,
   storageStateFile,
   updateState,
   webCoreStorageStateFile,
@@ -54,6 +55,7 @@ test("create isolated verified production accounts and API keys", async ({
     cli,
     mcp,
     importExport,
+    security,
   ] = await Promise.all([
     createIsolatedAccount("web-core", webCoreStorageStateFile),
     createIsolatedAccount("web-surfaces", webSurfacesStorageStateFile),
@@ -64,6 +66,7 @@ test("create isolated verified production accounts and API keys", async ({
     createIsolatedAccount("service-cli"),
     createIsolatedAccount("service-mcp"),
     createIsolatedAccount("import-export", importExportStorageStateFile),
+    createIsolatedAccount("security", securityStorageStateFile),
   ]);
   updateState((state) => {
     state.accounts.push(
@@ -75,7 +78,8 @@ test("create isolated verified production accounts and API keys", async ({
       api,
       cli,
       mcp,
-      importExport
+      importExport,
+      security
     );
     state.webCore = webCore;
     state.webSurfaces = webSurfaces;


### PR DESCRIPTION
## Summary
- give the security journey its own Better Auth account and browser storage state
- retry the card submit against the currently ready form when React remounts it
- retain the existing OAuth, API-key, card-save, search, and teardown assertions

## Root cause
Production traces showed the security project landing on `/login` while it shared one saved session with concurrent projects. The matrix trace showed the Save button detaching during Playwright actionability checks.

## Verification
- `bun run --cwd packages/tests test`
- `bun run --cwd packages/tests typecheck`
- `bun run --cwd packages/tests lint`
- `git diff --check`
- Standards review: no actionable findings
- Spec review: no actionable findings

The repository-wide `bun run check` still reports two pre-existing issues outside this diff in `packages/convex/__tests__/polarPlans.test.ts` and `packages/convex/workflows/steps/linkMetadata/fetchMetadata.ts`.

No public contract or changelog change.