### PR TITLE
test(e2e): survive card form remounts

### DIFF
--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -162,6 +162,7 @@ export const clickVisibleControl = async (
 };
 
 export const fillAndSubmitTextCard = async (page: Page, content: string) => {
+  const creationForm = page.locator("form[data-card-creation-status]");
   const readyCreationForm = page.locator(
     'form[data-card-creation-status="ready"]'
   );
@@ -174,7 +175,7 @@ export const fillAndSubmitTextCard = async (page: Page, content: string) => {
     await expect(editor).toHaveText(content, { timeout: 5000 });
   }).toPass({ intervals: [250, 500, 1000], timeout: 30_000 });
   await clickVisibleControl(
-    readyCreationForm.getByRole("button", { name: "Save", exact: true })
+    creationForm.getByRole("button", { name: "Save", exact: true })
   );
 };
 


### PR DESCRIPTION
## Summary
- keep readiness gating scoped to the ready card form while filling
- resolve the Save button from the current form so React status remounts do not invalidate submission
- preserve all live card-create and search assertions

## Production evidence
Run 33536528216 confirmed the dedicated security session fix: the complete journey job passed. All three matrix browsers then failed because `form[data-card-creation-status="ready"]` disappeared before the Save click. The previous trace showed the broader Save control detach during actionability checks, so this combines the stable selector with the existing bounded retry helper.

## Verification
- `bun run --cwd packages/tests test`
- `bun run --cwd packages/tests typecheck`
- `bun run --cwd packages/tests lint`
- `git diff --check`
- Standards review: no actionable findings
- Spec review: no actionable findings

No public contract or changelog change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text card creation so the Save action can be completed even when the creation form is not yet marked as ready.
  * Preserved the requirement for the editor itself to be ready before use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->