### PR TITLE
test(e2e): retry remounted card submissions safely

### DIFF
--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -189,11 +189,20 @@ export const fillAndSubmitTextCard = async (page: Page, content: string) => {
     try {
       await expect(saveButton).toBeVisible({ timeout: 5000 });
       await expect(saveButton).toBeEnabled({ timeout: 5000 });
+      await saveButton.click({ timeout: 5000, trial: true });
+    } catch (error) {
+      if (attempt === 3 || !isRetryableActionabilityError(error)) {
+        throw error;
+      }
+      continue;
+    }
+
+    try {
       await saveButton.click({ timeout: 5000 });
       return;
     } catch (error) {
       const didSave = await savedCard
-        .waitFor({ state: "visible", timeout: 5000 })
+        .waitFor({ state: "visible", timeout: 30_000 })
         .then(
           () => true,
           () => false
@@ -201,9 +210,7 @@ export const fillAndSubmitTextCard = async (page: Page, content: string) => {
       if (didSave) {
         return;
       }
-      if (attempt === 3 || !isRetryableActionabilityError(error)) {
-        throw error;
-      }
+      throw error;
     }
   }
 };

--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -134,7 +134,7 @@ export const newAnonymousContext = (browser: Browser) =>
 
 const isRetryableActionabilityError = (error: unknown) =>
   error instanceof Error &&
-  /element (is not stable|was detached)|Timeout .* exceeded/.test(
+  /element (is not stable|was detached)|Timeout .* exceeded|Timeout: \d+ms/.test(
     error.message
   );
 
@@ -169,14 +169,43 @@ export const fillAndSubmitTextCard = async (page: Page, content: string) => {
   const editor = readyCreationForm.getByRole("textbox", {
     name: "Markdown content",
   });
-  await expect(async () => {
-    await expect(readyCreationForm).toBeVisible({ timeout: 5000 });
-    await editor.fill(content);
-    await expect(editor).toHaveText(content, { timeout: 5000 });
-  }).toPass({ intervals: [250, 500, 1000], timeout: 30_000 });
-  await clickVisibleControl(
-    creationForm.getByRole("button", { name: "Save", exact: true })
-  );
+  const savedCard = page
+    .getByRole("main")
+    .getByRole("paragraph")
+    .filter({ hasText: content })
+    .first();
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    await expect(async () => {
+      await expect(readyCreationForm).toBeVisible({ timeout: 5000 });
+      await editor.fill(content);
+      await expect(editor).toHaveText(content, { timeout: 5000 });
+    }).toPass({ intervals: [250, 500, 1000], timeout: 30_000 });
+
+    const saveButton = creationForm
+      .getByRole("button", { name: "Save", exact: true })
+      .filter({ visible: true })
+      .first();
+    try {
+      await expect(saveButton).toBeVisible({ timeout: 5000 });
+      await expect(saveButton).toBeEnabled({ timeout: 5000 });
+      await saveButton.click({ timeout: 5000 });
+      return;
+    } catch (error) {
+      const didSave = await savedCard
+        .waitFor({ state: "visible", timeout: 5000 })
+        .then(
+          () => true,
+          () => false
+        );
+      if (didSave) {
+        return;
+      }
+      if (attempt === 3 || !isRetryableActionabilityError(error)) {
+        throw error;
+      }
+    }
+  }
 };
 
 const settingsRow = (page: Page, label: string) =>


### PR DESCRIPTION
## Summary
- retry content entry when the production editor resets during a React form remount
- perform only one Save click per attempt
- after an ambiguous click failure, detect an already-saved matching card before permitting another attempt
- preserve exact production API search and live UI assertions

## Production evidence
Run 33593332764 passed the complete journey, docs, extension, gate, and sweep jobs. WebKit alone captured a textbox with reset content and no conditional Save button after the fill assertion, confirming that fill and click must be retried together.

## Review finding addressed
The Spec reviewer identified duplicate-submit risk in the initial approach. The final implementation checks for an observable saved card after every ambiguous single-click failure before it can refill or click again. Standards and Spec re-review found no remaining actionable gaps.

## Verification
- `bun run --cwd packages/tests test`
- `bun run --cwd packages/tests typecheck`
- `bun run --cwd packages/tests lint`
- `git diff --check`

No public contract or changelog change.