### PR TITLE
feat(safari): OAuth connected-apps support with token revocation and duplicate lookup

### DIFF
--- a/apps/docs/content/changelog/2026-09-07.mdx
+++ b/apps/docs/content/changelog/2026-09-07.mdx
@@ -1,0 +1,11 @@
+---
+title: "Manage Safari in Connected apps"
+description: Connect Safari and manage its access from Teak settings.
+type: changelog
+date: "2026-09-07"
+changelog:
+  category: Improvements
+---
+
+- Teak Safari now appears in Connected apps, where you can disconnect its access at any time.
+- After updating, sign in to Safari once again to connect it to your account.

--- a/apps/docs/content/docs/(apps)/extension.mdx
+++ b/apps/docs/content/docs/(apps)/extension.mdx
@@ -36,7 +36,7 @@ options on this page are Chrome/Chromium-only.
         Open the app once, then enable the Teak extension in Safari Settings.
       </Step>
       <Step title="Sign in and save">
-        Click the Teak icon in the Safari toolbar to sign in and save the current page.
+        Click the Teak icon in the Safari toolbar and choose **Sign in**. Teak for Safari opens so you can approve **Teak Safari** in your browser. Return to the toolbar to save the current page.
       </Step>
     </Steps>
   </Tab>
@@ -119,7 +119,11 @@ When you reach your free plan card limit, the Chrome extension popup shows an up
 
 ## Sign In
 
-In Safari, choose **Sign in** to complete authentication in the Teak web app, then choose **Approve device** if prompted. In Chrome and Chromium-based browsers, the popup provides **Login** and **Create Account** actions that open the web app in a new tab. The pairing URL and polling handshake are unchanged; only the extra approval click is new.
+In Safari, choose **Sign in** to open Teak for Safari and approve **Teak Safari** in your browser. Your connection stays signed in across restarts. After updating from the previous sign-in experience, connect once again.
+
+Manage Safari access from Teak Settings → **Connected apps**. Disconnect **Teak Safari** to revoke access across your Safari installations immediately. Signing out inside Safari disconnects that installation. If you are offline, reconnect to the internet and retry sign-out.
+
+In Chrome and Chromium-based browsers, the popup provides **Login** and **Create Account** actions that open the web app in a new tab.
 
 ## Troubleshooting
 

--- a/apps/docs/content/docs/(developers)/api.mdx
+++ b/apps/docs/content/docs/(developers)/api.mdx
@@ -172,3 +172,12 @@ Errors keep a stable `{ code, error }` shape and can also include `requestId`, `
 ```
 
 Use the returned request ID when contacting [Support](/docs/support). For MCP tool contracts and JSON-RPC examples, continue to the dedicated [MCP guide](/docs/mcp).
+
+
+## Check for a saved URL
+
+`GET /v1/cards/duplicate?url=<encoded-url>` accepts the same bearer credentials as other card endpoints. It checks the exact URL against your non-deleted cards and returns `{ "cardId": "..." }`, or `{ "cardId": null }` when no match exists. The URL must use HTTP or HTTPS and be at most 8,192 characters. Invalid input returns 400; invalid or revoked credentials return 401.
+
+## Revoke an OAuth credential
+
+Native OAuth clients can send a form-encoded `POST` to the Convex site origin at `/api/oauth/revoke`, with `client_id` and `token` (an access or refresh token). Revocation invalidates the presented credential pair for that client. Unknown or already revoked tokens return 200, as do successful revocations. This endpoint does not accept API keys. Use **Connected apps** in Settings to revoke every connection for an app.

--- a/apps/safari-extension/Shared (App)/Resources/Script.js
+++ b/apps/safari-extension/Shared (App)/Resources/Script.js
@@ -22,11 +22,14 @@ function show(platform, enabled, useSettingsInsteadOfPreferences) {
 
 // biome-ignore lint/correctness/noUnusedVariables: invoked by the native Safari host
 function renderAccountState(state) {
-  const authenticated = state.authenticated === true;
+  const authenticated =
+    typeof state.authenticated === "boolean"
+      ? state.authenticated
+      : document.body.classList.contains("signed-in");
   document.body.classList.toggle("signed-in", authenticated);
 
   if (authenticated) {
-    statusLabel.innerText = "Ready.";
+    statusLabel.innerText = state.message || "Ready.";
     return;
   }
 

--- a/apps/safari-extension/Shared (App)/Shared (Core)/SafariCredentialStore.swift
+++ b/apps/safari-extension/Shared (App)/Shared (Core)/SafariCredentialStore.swift
@@ -9,13 +9,27 @@ nonisolated protocol SafariCredentialStorage: Sendable {
 
 nonisolated struct SafariCredentialStore: SafariCredentialStorage {
     static let group = "group.com.praveenjuge.teak-safari"
-    private let account = "oauth-tokens-v1"
+    static let keychainService = "com.praveenjuge.teak-safari.session"
+    static let keychainAccount = "oauth-tokens-v1"
+    /// Keychain access group, resolved at build time from `TeakKeychainAccessGroup`
+    /// (`$(AppIdentifierPrefix)com.praveenjuge.teak-safari` in each target's Info.plist)
+    /// so re-signing under another team keeps the entitlement and runtime query in sync.
+    /// Falls back to the current team's prefix for installs predating the plist key.
+    static var accessGroup: String {
+        if let configured = Bundle.main.object(forInfoDictionaryKey: "TeakKeychainAccessGroup") as? String,
+           !configured.isEmpty,
+           !configured.hasPrefix("$(") {
+            return configured
+        }
+        return "LW385M78LW.com.praveenjuge.teak-safari"
+    }
+    private let account = Self.keychainAccount
 
     private var query: [String: Any] {
         [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: "com.praveenjuge.teak-safari.session",
-            kSecAttrAccessGroup as String: "LW385M78LW.com.praveenjuge.teak-safari",
+            kSecAttrService as String: Self.keychainService,
+            kSecAttrAccessGroup as String: Self.accessGroup,
             kSecUseDataProtectionKeychain as String: true,
             kSecAttrAccount as String: account,
         ]

--- a/apps/safari-extension/Shared (App)/Shared (Core)/SafariCredentialStore.swift
+++ b/apps/safari-extension/Shared (App)/Shared (Core)/SafariCredentialStore.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Security
+
+nonisolated protocol SafariCredentialStorage: Sendable {
+    func load() throws -> SafariOAuthTokens?
+    func save(_ tokens: SafariOAuthTokens) throws
+    func clear() throws
+}
+
+nonisolated struct SafariCredentialStore: SafariCredentialStorage {
+    static let group = "group.com.praveenjuge.teak-safari"
+    private let account = "oauth-tokens-v1"
+
+    private var query: [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.praveenjuge.teak-safari.session",
+            kSecAttrAccessGroup as String: "LW385M78LW.com.praveenjuge.teak-safari",
+            kSecUseDataProtectionKeychain as String: true,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    func load() throws -> SafariOAuthTokens? {
+        var request = query
+        request[kSecReturnData as String] = true
+        request[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(request as CFDictionary, &result)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess, let data = result as? Data else {
+            throw SafariServiceError.message("Unable to read your Teak connection. Please try again.")
+        }
+        return try JSONDecoder().decode(SafariOAuthTokens.self, from: data)
+    }
+
+    func save(_ tokens: SafariOAuthTokens) throws {
+        let data = try JSONEncoder().encode(tokens)
+        let attributes = [kSecValueData as String: data]
+        let result = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if result == errSecSuccess { return }
+        guard result == errSecItemNotFound else {
+            throw SafariServiceError.message("Unable to store your Teak connection.")
+        }
+        var item = query
+        item[kSecValueData as String] = data
+        item[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        guard SecItemAdd(item as CFDictionary, nil) == errSecSuccess else {
+            throw SafariServiceError.message("Unable to store your Teak connection.")
+        }
+    }
+
+    func clear() throws {
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw SafariServiceError.message("Unable to clear your Teak connection.")
+        }
+    }
+}

--- a/apps/safari-extension/Shared (App)/Shared (Core)/SafariOAuth.swift
+++ b/apps/safari-extension/Shared (App)/Shared (Core)/SafariOAuth.swift
@@ -1,0 +1,109 @@
+import CryptoKit
+import Foundation
+import Security
+
+nonisolated struct SafariOAuthRequest: Sendable {
+    static let clientID = "teak-safari"
+    static let callback = "teak-safari://oauth/callback"
+    let verifier: String
+    let state: String
+    let createdAt: Date
+
+    init(verifier: String? = nil, state: String? = nil, createdAt: Date = Date()) throws {
+        self.verifier = try verifier ?? Self.randomString(count: 32)
+        self.state = try state ?? Self.randomString(count: 24)
+        self.createdAt = createdAt
+    }
+
+    func authorizationURL(baseURL: URL) -> URL {
+        var components = URLComponents(url: baseURL.appendingPathComponent("api/auth/mcp/authorize"), resolvingAgainstBaseURL: false)!
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: Self.clientID),
+            URLQueryItem(name: "redirect_uri", value: Self.callback),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "scope", value: "profile email offline_access"),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "code_challenge", value: Self.base64URL(Data(SHA256.hash(data: Data(verifier.utf8))))),
+            URLQueryItem(name: "state", value: state),
+        ]
+        return components.url!
+    }
+
+    func authorizationCode(from url: URL, now: Date = Date()) throws -> String {
+        guard now.timeIntervalSince(createdAt) < 600,
+              let parts = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              parts.scheme == "teak-safari", parts.host == "oauth", parts.path == "/callback",
+              parts.user == nil, parts.password == nil, parts.port == nil, parts.fragment == nil
+        else { throw SafariServiceError.message("Invalid or expired sign-in callback. Please try again.") }
+        let items = parts.queryItems ?? []
+        func unique(_ name: String) -> String? {
+            let values = items.filter { $0.name == name }
+            return values.count == 1 ? values[0].value : nil
+        }
+        guard unique("state") == state else {
+            throw SafariServiceError.message("Sign-in could not be verified. Please try again.")
+        }
+        if unique("error") != nil {
+            throw SafariServiceError.message("Sign-in was not approved. Please try again.")
+        }
+        guard let code = unique("code"), !code.isEmpty, code.count <= 4096 else {
+            throw SafariServiceError.message("Teak returned an invalid sign-in code.")
+        }
+        return code
+    }
+
+    static func formBody(_ values: [String: String]) -> Data {
+        var components = URLComponents()
+        components.queryItems = values.sorted { $0.key < $1.key }.map { URLQueryItem(name: $0.key, value: $0.value) }
+        // '+' has special meaning in form bodies, unlike URL query strings.
+        return Data((components.percentEncodedQuery ?? "").replacingOccurrences(of: "+", with: "%2B").utf8)
+    }
+
+    private static func randomString(count: Int) throws -> String {
+        var bytes = [UInt8](repeating: 0, count: count)
+        guard SecRandomCopyBytes(kSecRandomDefault, count, &bytes) == errSecSuccess else {
+            throw SafariServiceError.message("Unable to prepare sign in.")
+        }
+        return base64URL(Data(bytes))
+    }
+
+    private static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString().replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: "=", with: "")
+    }
+}
+
+nonisolated struct SafariOAuthTokens: Codable, Sendable {
+    let accessToken: String
+    let refreshToken: String
+    let expiresAt: Date
+
+    static func decode(_ data: Data, now: Date = Date()) throws -> Self {
+        struct Response: Decodable {
+            let access_token: String
+            let refresh_token: String
+            let expires_in: Double
+            let token_type: String
+        }
+        let response = try JSONDecoder().decode(Response.self, from: data)
+        guard !response.access_token.isEmpty, !response.refresh_token.isEmpty,
+              response.token_type.lowercased() == "bearer", response.expires_in.isFinite,
+              response.expires_in > 0 else {
+            throw SafariServiceError.message("Teak returned invalid credentials.")
+        }
+        return Self(accessToken: response.access_token, refreshToken: response.refresh_token,
+                    expiresAt: now.addingTimeInterval(response.expires_in))
+    }
+}
+
+nonisolated enum SafariServiceError: LocalizedError {
+    case unauthenticated
+    case message(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unauthenticated: return "Sign in to Teak to save pages."
+        case .message(let message): return message
+        }
+    }
+}

--- a/apps/safari-extension/Shared (App)/Shared (Core)/TeakSafariService.swift
+++ b/apps/safari-extension/Shared (App)/Shared (Core)/TeakSafariService.swift
@@ -61,7 +61,7 @@ actor TeakSafariService {
             }
             let body = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
             if response.statusCode == 401 || body is NSNull {
-                try await withCredentials { try self.credentials.clear() }
+                try await clearIfStale(token)
                 throw SafariServiceError.unauthenticated
             }
             guard let account = body as? [String: Any], account["userId"] is String,
@@ -175,12 +175,26 @@ actor TeakSafariService {
         return try SafariOAuthTokens.decode(data)
     }
 
+    /// Clears stored credentials only if they still match the token that just
+    /// failed. Requests run outside the shared lock, so the other process can
+    /// rotate and store a fresh pair while our request is in flight; an
+    /// unconditional clear would wipe those valid credentials. The
+    /// check-and-clear runs under the lock so it cannot interleave with a
+    /// concurrent rotation.
+    private func clearIfStale(_ token: String) async throws {
+        try await withCredentials {
+            if try credentials.load()?.accessToken == token {
+                try credentials.clear()
+            }
+        }
+    }
+
     private func apiRequest(_ original: URLRequest, token: String) async throws -> [String: Any] {
         var request = original
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         let (data, response) = try await send(request)
         if response.statusCode == 401 {
-            try credentials.clear()
+            try await clearIfStale(token)
             throw SafariServiceError.unauthenticated
         }
         let body = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]

--- a/apps/safari-extension/Shared (App)/Shared (Core)/TeakSafariService.swift
+++ b/apps/safari-extension/Shared (App)/Shared (Core)/TeakSafariService.swift
@@ -46,28 +46,29 @@ actor TeakSafariService {
 
     func authState() async -> [String: Any] {
         do {
-            return try await withCredentials {
-                guard try self.credentials.load() != nil else {
-                    return ["authenticated": false, "message": "Connect Teak Safari to save pages."]
-                }
-                let token = try await self.accessToken()
-                var request = URLRequest(url: self.apiURL.appendingPathComponent("api/auth/mcp/get-session"))
-                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-                let (data, response) = try await self.send(request)
-                guard response.statusCode == 200 || response.statusCode == 401 else {
-                    throw SafariServiceError.message("Unable to verify your Teak connection. Please try again.")
-                }
-                let body = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
-                if response.statusCode == 401 || body is NSNull {
-                    try self.credentials.clear()
-                    throw SafariServiceError.unauthenticated
-                }
-                guard let account = body as? [String: Any], account["userId"] is String,
-                      account["clientId"] as? String == SafariOAuthRequest.clientID else {
-                    throw SafariServiceError.message("Teak returned an invalid connection response.")
-                }
-                return ["authenticated": true]
+            guard (try? self.credentials.load()) != nil else {
+                return ["authenticated": false, "message": "Connect Teak Safari to save pages."]
             }
+            // The shared lock guards refresh-token rotation inside accessToken();
+            // the session verification request runs outside it so a slow network
+            // cannot starve the other process past its lock wait budget.
+            let token = try await self.accessToken()
+            var request = URLRequest(url: self.apiURL.appendingPathComponent("api/auth/mcp/get-session"))
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            let (data, response) = try await self.send(request)
+            guard response.statusCode == 200 || response.statusCode == 401 else {
+                throw SafariServiceError.message("Unable to verify your Teak connection. Please try again.")
+            }
+            let body = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+            if response.statusCode == 401 || body is NSNull {
+                try await withCredentials { try self.credentials.clear() }
+                throw SafariServiceError.unauthenticated
+            }
+            guard let account = body as? [String: Any], account["userId"] is String,
+                  account["clientId"] as? String == SafariOAuthRequest.clientID else {
+                throw SafariServiceError.message("Teak returned an invalid connection response.")
+            }
+            return ["authenticated": true]
         } catch SafariServiceError.unauthenticated {
             return ["authenticated": false]
         } catch {
@@ -119,38 +120,42 @@ actor TeakSafariService {
             return ["status": "invalid-url", "message": "This page cannot be saved to Teak."]
         }
         do {
-            return try await withCredentials {
-                let token = try await self.accessToken()
-                var lookup = URLComponents(url: self.apiURL.appendingPathComponent("v1/cards/duplicate"), resolvingAgainstBaseURL: false)!
-                lookup.queryItems = [URLQueryItem(name: "url", value: pageURL.absoluteString)]
-                let duplicate = try await self.apiRequest(URLRequest(url: lookup.url!), token: token)
-                if duplicate["cardId"] is String { return ["status": "duplicate"] }
-                var request = URLRequest(url: self.apiURL.appendingPathComponent("v1/cards"))
-                request.httpMethod = "POST"
-                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-                request.setValue(UUID().uuidString, forHTTPHeaderField: "Idempotency-Key")
-                request.httpBody = try JSONSerialization.data(withJSONObject: ["url": pageURL.absoluteString])
-                let result = try await self.apiRequest(request, token: token)
-                guard let cardID = result["cardId"] as? String else {
-                    throw SafariServiceError.message("Teak returned an invalid save response.")
-                }
-                return ["status": "saved", "cardId": cardID]
+            // Only the token read/refresh holds the shared lock (inside
+            // accessToken()); the duplicate lookup and card creation run outside
+            // it so a slow save cannot starve the other process past its lock
+            // wait budget. The Idempotency-Key keeps a retried create safe.
+            let token = try await self.accessToken()
+            var lookup = URLComponents(url: self.apiURL.appendingPathComponent("v1/cards/duplicate"), resolvingAgainstBaseURL: false)!
+            lookup.queryItems = [URLQueryItem(name: "url", value: pageURL.absoluteString)]
+            let duplicate = try await self.apiRequest(URLRequest(url: lookup.url!), token: token)
+            if duplicate["cardId"] is String { return ["status": "duplicate"] }
+            var request = URLRequest(url: self.apiURL.appendingPathComponent("v1/cards"))
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue(UUID().uuidString, forHTTPHeaderField: "Idempotency-Key")
+            request.httpBody = try JSONSerialization.data(withJSONObject: ["url": pageURL.absoluteString])
+            let result = try await self.apiRequest(request, token: token)
+            guard let cardID = result["cardId"] as? String else {
+                throw SafariServiceError.message("Teak returned an invalid save response.")
             }
+            return ["status": "saved", "cardId": cardID]
         } catch SafariServiceError.unauthenticated {
             return ["status": "unauthenticated", "message": "Sign in to Teak to save pages."]
         } catch { return errorResponse(error) }
     }
 
     private func accessToken() async throws -> String {
-        guard let tokens = try credentials.load() else { throw SafariServiceError.unauthenticated }
-        if tokens.expiresAt.timeIntervalSinceNow > 60 { return tokens.accessToken }
-        do {
-            let refreshed = try await exchange(["grant_type": "refresh_token", "refresh_token": tokens.refreshToken])
-            try credentials.save(refreshed)
-            return refreshed.accessToken
-        } catch SafariServiceError.unauthenticated {
-            try credentials.clear()
-            throw SafariServiceError.unauthenticated
+        try await withCredentials {
+            guard let tokens = try credentials.load() else { throw SafariServiceError.unauthenticated }
+            if tokens.expiresAt.timeIntervalSinceNow > 60 { return tokens.accessToken }
+            do {
+                let refreshed = try await exchange(["grant_type": "refresh_token", "refresh_token": tokens.refreshToken])
+                try credentials.save(refreshed)
+                return refreshed.accessToken
+            } catch SafariServiceError.unauthenticated {
+                try credentials.clear()
+                throw SafariServiceError.unauthenticated
+            }
         }
     }
 
@@ -178,7 +183,7 @@ actor TeakSafariService {
             try credentials.clear()
             throw SafariServiceError.unauthenticated
         }
-        let body = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let body = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
         guard (200..<300).contains(response.statusCode), let body else {
             throw SafariServiceError.message(body?["error"] as? String ?? "Unable to save this page. Please try again.")
         }

--- a/apps/safari-extension/Shared (App)/Shared (Core)/TeakSafariService.swift
+++ b/apps/safari-extension/Shared (App)/Shared (Core)/TeakSafariService.swift
@@ -1,401 +1,201 @@
-import CryptoKit
+import Darwin
 import Foundation
-import Security
 
-final class TeakSafariService {
+actor TeakSafariService {
     static let shared = TeakSafariService()
-
     #if DEBUG
-    private let appBaseURL = URL(string: "http://app.teak.localhost:1355")!
-    private let convexSiteURL = URL(string: "https://reminiscent-kangaroo-59.convex.site")!
-    private let convexDeploymentURL = URL(string: "https://reminiscent-kangaroo-59.convex.cloud")!
+    static let appBaseURL = URL(string: "http://app.teak.localhost:1355")!
+    private static let siteURL = URL(string: "https://reminiscent-kangaroo-59.convex.site")!
     #else
-    private let appBaseURL = URL(string: "https://app.teakvault.com")!
-    private let convexSiteURL = URL(string: "https://uncommon-ladybug-882.convex.site")!
-    private let convexDeploymentURL = URL(string: "https://uncommon-ladybug-882.convex.cloud")!
+    static let appBaseURL = URL(string: "https://app.teakvault.com")!
+    private static let siteURL = URL(string: "https://uncommon-ladybug-882.convex.site")!
     #endif
-    private let appGroupIdentifier = "group.com.praveenjuge.teak-safari"
-    private let keychainAccessGroup = "LW385M78LW.com.praveenjuge.teak-safari"
-    private let keychainService = "com.praveenjuge.teak-safari.session"
-    private let sessionAccount = "better-auth-session-token"
-    private let pendingAuthKey = "teak.pendingNativeAuth"
-    private let session = URLSession(configuration: .ephemeral)
 
-    private init() {}
+    private let session: URLSession
+    private let credentials: any SafariCredentialStorage
+    private let apiURL: URL
+    private let lockURL: URL?
 
-    func authState() async -> [String: Any] {
-        if let token = loadSessionToken(), !token.isEmpty {
-            return ["authenticated": true]
-        }
-
-        if await pollPendingAuth() {
-            return ["authenticated": true]
-        }
-
-        return ["authenticated": false]
+    init(session: URLSession = URLSession(configuration: .ephemeral),
+         credentials: any SafariCredentialStorage = SafariCredentialStore(),
+         apiURL: URL = TeakSafariService.siteURL,
+         lockURL: URL? = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: SafariCredentialStore.group)?.appendingPathComponent("oauth-credentials.lock")) {
+        self.session = session
+        self.credentials = credentials
+        self.apiURL = apiURL
+        self.lockURL = lockURL
     }
 
-    func startSignIn() async -> [String: Any] {
+    // Both the app and extension can refresh. Hold a process-shared lock across
+    // read/refresh/write so rotating a refresh token can never be replayed.
+    private func withCredentials<T>(_ operation: () async throws -> T) async throws -> T {
+        guard let lockURL else { throw SafariServiceError.message("Unable to access Teak's shared storage.") }
+        let descriptor = open(lockURL.path, O_CREAT | O_RDWR | O_NOFOLLOW, S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else { throw SafariServiceError.message("Unable to access Teak's shared storage.") }
+        defer { close(descriptor) }
+        let deadline = Date().addingTimeInterval(35)
+        while flock(descriptor, LOCK_EX | LOCK_NB) != 0 {
+            guard errno == EWOULDBLOCK, Date() < deadline else {
+                throw SafariServiceError.message("Teak is busy. Please try again.")
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        defer { flock(descriptor, LOCK_UN) }
+        return try await operation()
+    }
+
+    func authState() async -> [String: Any] {
         do {
-            let pending = try PendingNativeAuth(
-                deviceId: UUID().uuidString,
-                codeVerifier: Self.randomBase64URL(byteCount: 32),
-                state: Self.randomBase64URL(byteCount: 24),
-                surface: Self.currentSurface,
-                createdAt: Date().timeIntervalSince1970
-            )
-            try savePendingAuth(pending)
-
-            var components = URLComponents(
-                url: appBaseURL.appendingPathComponent("/native/auth/start"),
-                resolvingAgainstBaseURL: false
-            )!
-            components.queryItems = [
-                URLQueryItem(name: "device_id", value: pending.deviceId),
-                URLQueryItem(name: "code_challenge", value: try Self.codeChallenge(for: pending.codeVerifier)),
-                URLQueryItem(name: "state", value: pending.state),
-                URLQueryItem(name: "surface", value: pending.surface),
-                URLQueryItem(
-                    name: "redirect_uri",
-                    value: appBaseURL.appendingPathComponent("/native/auth/complete").absoluteString
-                ),
-            ]
-
-            return [
-                "status": "auth-url",
-                "authenticated": false,
-                "authUrl": components.url!.absoluteString,
-            ]
+            return try await withCredentials {
+                guard try self.credentials.load() != nil else {
+                    return ["authenticated": false, "message": "Connect Teak Safari to save pages."]
+                }
+                let token = try await self.accessToken()
+                var request = URLRequest(url: self.apiURL.appendingPathComponent("api/auth/mcp/get-session"))
+                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                let (data, response) = try await self.send(request)
+                guard response.statusCode == 200 || response.statusCode == 401 else {
+                    throw SafariServiceError.message("Unable to verify your Teak connection. Please try again.")
+                }
+                let body = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)
+                if response.statusCode == 401 || body is NSNull {
+                    try self.credentials.clear()
+                    throw SafariServiceError.unauthenticated
+                }
+                guard let account = body as? [String: Any], account["userId"] is String,
+                      account["clientId"] as? String == SafariOAuthRequest.clientID else {
+                    throw SafariServiceError.message("Teak returned an invalid connection response.")
+                }
+                return ["authenticated": true]
+            }
+        } catch SafariServiceError.unauthenticated {
+            return ["authenticated": false]
         } catch {
             return errorResponse(error)
         }
+    }
+
+    func completeSignIn(_ pending: SafariOAuthRequest, callback: URL) async -> [String: Any] {
+        do {
+            let code = try pending.authorizationCode(from: callback)
+            return try await withCredentials {
+                let tokens = try await self.exchange([
+                    "grant_type": "authorization_code", "code": code,
+                    "code_verifier": pending.verifier, "redirect_uri": SafariOAuthRequest.callback,
+                ])
+                try self.credentials.save(tokens)
+                return ["authenticated": true, "status": "connected"]
+            }
+        } catch { return errorResponse(error) }
     }
 
     func signOut() async -> [String: Any] {
-        let token = loadSessionToken()
-        clearSessionToken()
-        clearPendingAuth()
-
-        if let token, !token.isEmpty {
-            var request = URLRequest(url: convexSiteURL.appendingPathComponent("/api/auth/sign-out"))
-            request.httpMethod = "POST"
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            _ = try? await session.data(for: request)
-        }
-
-        return ["status": "signed-out", "authenticated": false]
+        do {
+            return try await withCredentials {
+                if let tokens = try self.credentials.load() {
+                    // Keep the credential on transient failures so sign-out can
+                    // be retried and we do not strand an active connection.
+                    var request = URLRequest(url: self.apiURL.appendingPathComponent("api/oauth/revoke"))
+                    request.httpMethod = "POST"
+                    request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+                    request.httpBody = SafariOAuthRequest.formBody([
+                        "client_id": SafariOAuthRequest.clientID, "token": tokens.refreshToken,
+                        "token_type_hint": "refresh_token",
+                    ])
+                    let (_, response) = try await self.send(request)
+                    guard response.statusCode == 200 else {
+                        throw SafariServiceError.message("Could not disconnect Teak. Please try again.")
+                    }
+                }
+                try self.credentials.clear()
+                return ["status": "signed-out", "authenticated": false]
+            }
+        } catch { return errorResponse(error) }
     }
 
     func saveCurrentPage(url rawURL: String?) async -> [String: Any] {
-        guard let rawURL, let pageURL = Self.validPageURL(rawURL) else {
-            return [
-                "status": "invalid-url",
-                "message": "This page cannot be saved to Teak.",
-            ]
+        guard let rawURL, let pageURL = URL(string: rawURL),
+              ["http", "https"].contains(pageURL.scheme?.lowercased()), pageURL.host != nil else {
+            return ["status": "invalid-url", "message": "This page cannot be saved to Teak."]
         }
-
-        if loadSessionToken() == nil, await pollPendingAuth() == false {
-            return [
-                "status": "unauthenticated",
-                "message": "Sign in to Teak to save pages.",
-            ]
-        }
-
-        guard let sessionToken = loadSessionToken() else {
-            return [
-                "status": "unauthenticated",
-                "message": "Sign in to Teak to save pages.",
-            ]
-        }
-
         do {
-            let convexToken = try await fetchConvexToken(sessionToken: sessionToken)
-            let normalizedURL = pageURL.absoluteString
-            let duplicate = try await callConvex(
-                endpoint: "query",
-                path: "cards:findDuplicateCard",
-                args: ["url": normalizedURL],
-                token: convexToken
-            )
-
-            if !(duplicate is NSNull) {
-                return ["status": "duplicate"]
+            return try await withCredentials {
+                let token = try await self.accessToken()
+                var lookup = URLComponents(url: self.apiURL.appendingPathComponent("v1/cards/duplicate"), resolvingAgainstBaseURL: false)!
+                lookup.queryItems = [URLQueryItem(name: "url", value: pageURL.absoluteString)]
+                let duplicate = try await self.apiRequest(URLRequest(url: lookup.url!), token: token)
+                if duplicate["cardId"] is String { return ["status": "duplicate"] }
+                var request = URLRequest(url: self.apiURL.appendingPathComponent("v1/cards"))
+                request.httpMethod = "POST"
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                request.setValue(UUID().uuidString, forHTTPHeaderField: "Idempotency-Key")
+                request.httpBody = try JSONSerialization.data(withJSONObject: ["url": pageURL.absoluteString])
+                let result = try await self.apiRequest(request, token: token)
+                guard let cardID = result["cardId"] as? String else {
+                    throw SafariServiceError.message("Teak returned an invalid save response.")
+                }
+                return ["status": "saved", "cardId": cardID]
             }
-
-            let cardId = try await callConvex(
-                endpoint: "mutation",
-                path: "cards:createCard",
-                args: ["content": normalizedURL],
-                token: convexToken
-            )
-
-            return [
-                "status": "saved",
-                "cardId": String(describing: cardId),
-            ]
-        } catch ServiceError.unauthenticated {
-            clearSessionToken()
-            return [
-                "status": "unauthenticated",
-                "message": "Sign in to Teak to save pages.",
-            ]
-        } catch {
-            return errorResponse(error)
-        }
+        } catch SafariServiceError.unauthenticated {
+            return ["status": "unauthenticated", "message": "Sign in to Teak to save pages."]
+        } catch { return errorResponse(error) }
     }
 
-    private func pollPendingAuth() async -> Bool {
-        guard let pending = loadPendingAuth() else {
-            return false
-        }
-
-        if Date().timeIntervalSince1970 - pending.createdAt > 300 {
-            clearPendingAuth()
-            return false
-        }
-
+    private func accessToken() async throws -> String {
+        guard let tokens = try credentials.load() else { throw SafariServiceError.unauthenticated }
+        if tokens.expiresAt.timeIntervalSinceNow > 60 { return tokens.accessToken }
         do {
-            var request = URLRequest(url: convexSiteURL.appendingPathComponent("/api/native/auth/poll"))
-            request.httpMethod = "POST"
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.httpBody = try JSONEncoder().encode([
-                "codeVerifier": pending.codeVerifier,
-                "deviceId": pending.deviceId,
-                "state": pending.state,
-            ])
-
-            let (data, response) = try await session.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else {
-                return false
-            }
-
-            if httpResponse.statusCode == 204 {
-                return false
-            }
-
-            guard httpResponse.statusCode == 200 else {
-                return false
-            }
-
-            let payload = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-            guard let sessionToken = payload?["sessionToken"] as? String, !sessionToken.isEmpty else {
-                return false
-            }
-
-            try saveSessionToken(sessionToken)
-            clearPendingAuth()
-            return true
-        } catch {
-            return false
+            let refreshed = try await exchange(["grant_type": "refresh_token", "refresh_token": tokens.refreshToken])
+            try credentials.save(refreshed)
+            return refreshed.accessToken
+        } catch SafariServiceError.unauthenticated {
+            try credentials.clear()
+            throw SafariServiceError.unauthenticated
         }
     }
 
-    private func fetchConvexToken(sessionToken: String) async throws -> String {
-        var request = URLRequest(url: convexSiteURL.appendingPathComponent("/api/auth/convex/token"))
-        request.httpMethod = "GET"
-        request.setValue("Bearer \(sessionToken)", forHTTPHeaderField: "Authorization")
-
-        let (data, response) = try await session.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw ServiceError.requestFailed("Unable to reach Teak.")
-        }
-
-        if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
-            throw ServiceError.unauthenticated
-        }
-
-        guard (200..<300).contains(httpResponse.statusCode) else {
-            throw ServiceError.requestFailed("Unable to authenticate with Teak.")
-        }
-
-        let payload = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-        guard let token = payload?["token"] as? String, !token.isEmpty else {
-            throw ServiceError.requestFailed("Teak returned an invalid auth token.")
-        }
-
-        return token
-    }
-
-    private func callConvex(
-        endpoint: String,
-        path: String,
-        args: [String: Any],
-        token: String
-    ) async throws -> Any {
-        var request = URLRequest(url: convexDeploymentURL.appendingPathComponent("/api/\(endpoint)"))
+    private func exchange(_ values: [String: String]) async throws -> SafariOAuthTokens {
+        var request = URLRequest(url: apiURL.appendingPathComponent("api/auth/mcp/token"))
         request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.setValue("macos-safari-1.0", forHTTPHeaderField: "Convex-Client")
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = SafariOAuthRequest.formBody(values.merging(["client_id": SafariOAuthRequest.clientID]) { _, new in new })
+        let (data, response) = try await send(request)
+        if response.statusCode == 400 || response.statusCode == 401 {
+            let body = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            if body?["error"] as? String == "invalid_grant" { throw SafariServiceError.unauthenticated }
+        }
+        guard response.statusCode == 200 else {
+            throw SafariServiceError.message("Unable to connect to Teak. Please try again.")
+        }
+        return try SafariOAuthTokens.decode(data)
+    }
+
+    private func apiRequest(_ original: URLRequest, token: String) async throws -> [String: Any] {
+        var request = original
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        request.httpBody = try JSONSerialization.data(withJSONObject: [
-            "path": path,
-            "format": "convex_encoded_json",
-            "args": [args],
-        ])
+        let (data, response) = try await send(request)
+        if response.statusCode == 401 {
+            try credentials.clear()
+            throw SafariServiceError.unauthenticated
+        }
+        let body = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        guard (200..<300).contains(response.statusCode), let body else {
+            throw SafariServiceError.message(body?["error"] as? String ?? "Unable to save this page. Please try again.")
+        }
+        return body
+    }
 
+    private func send(_ original: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        var request = original
+        request.timeoutInterval = 15
         let (data, response) = try await session.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw ServiceError.requestFailed("Unable to reach Teak.")
+        guard let http = response as? HTTPURLResponse else {
+            throw SafariServiceError.message("Unable to reach Teak.")
         }
-
-        if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
-            throw ServiceError.unauthenticated
-        }
-
-        guard let payload = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            throw ServiceError.requestFailed("Teak returned an invalid response.")
-        }
-
-        if payload["status"] as? String == "success" {
-            return payload["value"] ?? NSNull()
-        }
-
-        if let message = payload["errorMessage"] as? String {
-            throw ServiceError.requestFailed(message)
-        }
-
-        if !(200..<300).contains(httpResponse.statusCode) {
-            throw ServiceError.requestFailed("Unable to save this page.")
-        }
-
-        throw ServiceError.requestFailed("Unable to save this page.")
-    }
-
-    private func saveSessionToken(_ token: String) throws {
-        guard let data = token.data(using: .utf8) else {
-            throw ServiceError.requestFailed("Unable to store session.")
-        }
-
-        clearSessionToken()
-
-        let query = keychainQuery().merging([
-            kSecAttrAccount as String: sessionAccount,
-            kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
-        ]) { _, new in new }
-
-        let status = SecItemAdd(query as CFDictionary, nil)
-        guard status == errSecSuccess else {
-            throw ServiceError.requestFailed("Unable to store session.")
-        }
-    }
-
-    private func loadSessionToken() -> String? {
-        let query = keychainQuery().merging([
-            kSecAttrAccount as String: sessionAccount,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]) { _, new in new }
-
-        var item: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &item)
-        guard status == errSecSuccess, let data = item as? Data else {
-            return nil
-        }
-
-        return String(data: data, encoding: .utf8)
-    }
-
-    private func clearSessionToken() {
-        SecItemDelete(keychainQuery().merging([
-            kSecAttrAccount as String: sessionAccount,
-        ]) { _, new in new } as CFDictionary)
-    }
-
-    private func keychainQuery() -> [String: Any] {
-        var query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: keychainService,
-            kSecAttrAccessGroup as String: keychainAccessGroup,
-        ]
-
-        if #available(macOS 10.15, *) {
-            query[kSecUseDataProtectionKeychain as String] = true
-        }
-
-        return query
-    }
-
-    private func savePendingAuth(_ pending: PendingNativeAuth) throws {
-        let data = try JSONEncoder().encode(pending)
-        defaults.set(data, forKey: pendingAuthKey)
-    }
-
-    private func loadPendingAuth() -> PendingNativeAuth? {
-        guard let data = defaults.data(forKey: pendingAuthKey) else {
-            return nil
-        }
-        return try? JSONDecoder().decode(PendingNativeAuth.self, from: data)
-    }
-
-    private func clearPendingAuth() {
-        defaults.removeObject(forKey: pendingAuthKey)
-    }
-
-    private var defaults: UserDefaults {
-        UserDefaults(suiteName: appGroupIdentifier) ?? .standard
+        return (data, http)
     }
 
     private func errorResponse(_ error: Error) -> [String: Any] {
-        [
-            "status": "error",
-            "message": error.localizedDescription,
-        ]
-    }
-
-    private static var currentSurface: String {
-        "safari-macos"
-    }
-
-    private static func validPageURL(_ rawURL: String) -> URL? {
-        guard let url = URL(string: rawURL), ["http", "https"].contains(url.scheme?.lowercased()) else {
-            return nil
-        }
-        return url
-    }
-
-    private static func codeChallenge(for verifier: String) throws -> String {
-        guard let data = verifier.data(using: .utf8) else {
-            throw ServiceError.requestFailed("Unable to prepare sign in.")
-        }
-        return base64URL(Data(SHA256.hash(data: data)))
-    }
-
-    private static func randomBase64URL(byteCount: Int) throws -> String {
-        var bytes = [UInt8](repeating: 0, count: byteCount)
-        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
-        guard status == errSecSuccess else {
-            throw ServiceError.requestFailed("Unable to prepare sign in.")
-        }
-        return base64URL(Data(bytes))
-    }
-
-    private static func base64URL(_ data: Data) -> String {
-        data.base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
-    }
-}
-
-private struct PendingNativeAuth: Codable {
-    let deviceId: String
-    let codeVerifier: String
-    let state: String
-    let surface: String
-    let createdAt: TimeInterval
-}
-
-private enum ServiceError: LocalizedError {
-    case requestFailed(String)
-    case unauthenticated
-
-    var errorDescription: String? {
-        switch self {
-        case .requestFailed(let message):
-            return message
-        case .unauthenticated:
-            return "Sign in to Teak to save pages."
-        }
+        ["status": "error", "authenticated": (try? credentials.load()) != nil, "message": error.localizedDescription]
     }
 }

--- a/apps/safari-extension/Shared (App)/ViewController.swift
+++ b/apps/safari-extension/Shared (App)/ViewController.swift
@@ -5,16 +5,17 @@
 //  Created by Praveen Juge on 16/05/26.
 //
 
+import AuthenticationServices
 import WebKit
 import Cocoa
 import SafariServices
 
 let extensionBundleIdentifier = "com.praveenjuge.teak-safari.Extension"
 
-class ViewController: NSViewController, WKNavigationDelegate, WKScriptMessageHandler {
+class ViewController: NSViewController, WKNavigationDelegate, WKScriptMessageHandler, ASWebAuthenticationPresentationContextProviding {
 
     @IBOutlet var webView: WKWebView!
-    private var authPollTimer: Timer?
+    private var authenticationSession: ASWebAuthenticationSession?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -72,49 +73,50 @@ class ViewController: NSViewController, WKNavigationDelegate, WKScriptMessageHan
         }
     }
 
-    private func startSignIn() {
-        Task { @MainActor in
-            let response = await TeakSafariService.shared.startSignIn()
-            renderAccountState([
-                "authenticated": false,
-                "status": "waiting",
-                "message": "Complete sign in in your browser.",
-            ])
-
-            if let authURL = response["authUrl"] as? String, let url = URL(string: authURL) {
-                openExternalURL(url)
-                startAuthPolling()
-            } else {
-                renderAccountState(response)
+    func startSignIn() {
+        guard authenticationSession == nil else { return }
+        do {
+            let pending = try SafariOAuthRequest()
+            let session = ASWebAuthenticationSession(
+                url: pending.authorizationURL(baseURL: TeakSafariService.appBaseURL),
+                callback: .customScheme("teak-safari")
+            ) { [weak self] callback, error in
+                Task { @MainActor in
+                    guard let self else { return }
+                    self.authenticationSession = nil
+                    guard let callback, error == nil else {
+                        self.renderAccountState([
+                            "authenticated": false,
+                            "message": "Sign-in was cancelled. You can try again.",
+                        ])
+                        return
+                    }
+                    let state = await TeakSafariService.shared.completeSignIn(pending, callback: callback)
+                    self.renderAccountState(state)
+                }
             }
+            session.presentationContextProvider = self
+            authenticationSession = session
+            renderAccountState(["status": "waiting", "message": "Approve Teak Safari in your browser."])
+            if !session.start() {
+                authenticationSession = nil
+                renderAccountState(["message": "Unable to open sign in. Please try again."])
+            }
+        } catch {
+            renderAccountState(["message": error.localizedDescription])
         }
+    }
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        view.window ?? ASPresentationAnchor()
     }
 
     private func signOut() {
+        authenticationSession?.cancel()
+        authenticationSession = nil
         Task { @MainActor in
-            authPollTimer?.invalidate()
             let state = await TeakSafariService.shared.signOut()
             renderAccountState(state)
-        }
-    }
-
-    private func startAuthPolling() {
-        authPollTimer?.invalidate()
-        authPollTimer = Timer.scheduledTimer(withTimeInterval: 2, repeats: true) { [weak self] timer in
-            Task { @MainActor in
-                guard let self else {
-                    timer.invalidate()
-                    return
-                }
-
-                let state = await TeakSafariService.shared.authState()
-                self.renderAccountState(state)
-
-                if state["authenticated"] as? Bool == true {
-                    timer.invalidate()
-                    self.authPollTimer = nil
-                }
-            }
         }
     }
 
@@ -127,10 +129,6 @@ class ViewController: NSViewController, WKNavigationDelegate, WKScriptMessageHan
         }
 
         webView.evaluateJavaScript("renderAccountState(\(json))")
-    }
-
-    private func openExternalURL(_ url: URL) {
-        NSWorkspace.shared.open(url)
     }
 
     private func openSafariExtensionPreferences() {

--- a/apps/safari-extension/Shared (Extension)/Resources/popup.js
+++ b/apps/safari-extension/Shared (Extension)/Resources/popup.js
@@ -44,6 +44,14 @@ const saveCurrentPage = async () => {
   setState("checking", "Teak", "Checking session...");
 
   const authState = await sendNative({ type: "getAuthState" });
+  if (authState.status === "error") {
+    setState(
+      "error",
+      "Unable to connect",
+      authState.message || "Please try again."
+    );
+    return;
+  }
   if (authState.authenticated !== true) {
     setState("signed-out", "Sign in to Teak", "Sign in to save pages.");
     return;
@@ -92,8 +100,7 @@ const startSignIn = async () => {
   setState("checking", "Opening Teak", "Complete sign in.");
   const response = await sendNative({ type: "startSignIn" });
 
-  if (response.authUrl) {
-    await browser.tabs.create({ url: response.authUrl });
+  if (response.status === "opening-app") {
     setState("checking", "Finish sign in", "Return here after signing in.");
     return;
   }
@@ -107,7 +114,12 @@ const startSignIn = async () => {
 
 const signOut = async () => {
   setState("checking", "Signing out", "Clearing session...");
-  await sendNative({ type: "signOut" });
+  const response = await sendNative({ type: "signOut" });
+  if (response.status !== "signed-out") {
+    throw new Error(
+      response.message || "Could not sign out. Please try again."
+    );
+  }
   setState("signed-out", "Signed out", "Sign in to save pages.");
 };
 

--- a/apps/safari-extension/Shared (Extension)/SafariWebExtensionHandler.swift
+++ b/apps/safari-extension/Shared (Extension)/SafariWebExtensionHandler.swift
@@ -5,6 +5,7 @@
 //  Created by Praveen Juge on 16/05/26.
 //
 
+import AppKit
 import SafariServices
 import os.log
 
@@ -58,7 +59,12 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         case "getAuthState":
             return await TeakSafariService.shared.authState()
         case "startSignIn":
-            return await TeakSafariService.shared.startSignIn()
+            let opened = await MainActor.run {
+                NSWorkspace.shared.open(URL(string: "teak-safari://connect")!)
+            }
+            return opened
+                ? ["status": "opening-app"]
+                : ["status": "error", "message": "Open Teak for Safari from Applications to sign in."]
         case "saveCurrentPage":
             return await TeakSafariService.shared.saveCurrentPage(url: payload["url"] as? String)
         case "signOut":

--- a/apps/safari-extension/macOS (App)/AppDelegate.swift
+++ b/apps/safari-extension/macOS (App)/AppDelegate.swift
@@ -17,6 +17,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    func application(_ application: NSApplication, open urls: [URL]) {
+        guard urls.contains(where: { $0.absoluteString == "teak-safari://connect" }) else { return }
+        application.activate(ignoringOtherApps: true)
+        for window in application.windows {
+            if let controller = window.contentViewController as? ViewController {
+                window.makeKeyAndOrderFront(nil)
+                controller.startSignIn()
+                return
+            }
+        }
+    }
+
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         return true
     }

--- a/apps/safari-extension/macOS (App)/Info.plist
+++ b/apps/safari-extension/macOS (App)/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+    <key>CFBundleURLTypes</key>
+    <array><dict>
+        <key>CFBundleURLName</key><string>com.praveenjuge.teak-safari.oauth</string>
+        <key>CFBundleURLSchemes</key><array><string>teak-safari</string></array>
+        <key>CFBundleTypeRole</key><string>Viewer</string>
+    </dict></array>
+</dict></plist>

--- a/apps/safari-extension/macOS (App)/Info.plist
+++ b/apps/safari-extension/macOS (App)/Info.plist
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0"><dict>
+    <key>TeakKeychainAccessGroup</key><string>$(AppIdentifierPrefix)com.praveenjuge.teak-safari</string>
     <key>CFBundleURLTypes</key>
     <array><dict>
         <key>CFBundleURLName</key><string>com.praveenjuge.teak-safari.oauth</string>

--- a/apps/safari-extension/macOS (Extension)/Info.plist
+++ b/apps/safari-extension/macOS (Extension)/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>TeakKeychainAccessGroup</key>
+	<string>$(AppIdentifierPrefix)com.praveenjuge.teak-safari</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSExtension</key>

--- a/apps/safari-extension/release.md
+++ b/apps/safari-extension/release.md
@@ -80,3 +80,19 @@ gh workflow run safari-extension-release.yml --ref main -f "version=$version" -f
 App Store Connect app: `6770003409`
 
 Bundle ID: `com.praveenjuge.teak-safari`
+
+
+## Connected apps readiness
+
+Before distributing the Safari OAuth update, deploy the backend changes and run
+`bunx convex run --prod oauthClients:debugOAuthClients` from `packages/convex`.
+Confirm `teak-safari` is enabled, public, and registered with the exact redirect
+`teak-safari://oauth/callback`. The existing client-registration cron provisions
+it; verify the stored result before distributing the app.
+
+Run `bash scripts/test-safari-oauth.sh` and
+`bun test apps/safari-extension/tests/companion.test.ts` from the repository root.
+The Convex Safari integration tests cover Connected apps, URL lookup, provider
+refresh, and revocation. Verify the signed app and Safari popup against the
+matching backend, including a save, duplicate save, restart, and disconnect.
+Existing Safari users reconnect once; no session backfill is required.

--- a/apps/safari-extension/teak-safari.xcodeproj/project.pbxproj
+++ b/apps/safari-extension/teak-safari.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 				Resources/Script.js,
 				Resources/Style.css,
 				"Shared (Core)/TeakSafariService.swift",
+				"Shared (Core)/SafariOAuth.swift",
+				"Shared (Core)/SafariCredentialStore.swift",
 				ViewController.swift,
 			);
 			target = 206096102FB83FF100B9E2A3 /* teak-safari (macOS) */;
@@ -79,9 +81,16 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				"Shared (Core)/TeakSafariService.swift",
+				"Shared (Core)/SafariOAuth.swift",
+				"Shared (Core)/SafariCredentialStore.swift",
 			);
 			target = 206096252FB83FF100B9E2A3 /* teak-safari Extension (macOS) */;
 		};
+		A01100000000000000000001 /* App Info.plist */ = {
+            isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+            membershipExceptions = (Info.plist,);
+            target = 206096102FB83FF100B9E2A3;
+        };
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -108,6 +117,7 @@
 		};
 		206096122FB83FF100B9E2A3 /* macOS (App) */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (A01100000000000000000001,);
 			path = "macOS (App)";
 			sourceTree = "<group>";
 		};
@@ -381,6 +391,7 @@
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "macOS (App)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Teak for Safari";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
@@ -425,6 +436,7 @@
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "macOS (App)/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Teak for Safari";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";

--- a/apps/safari-extension/tests/SafariOAuthTests.swift
+++ b/apps/safari-extension/tests/SafariOAuthTests.swift
@@ -145,6 +145,22 @@ final class MockHTTP: URLProtocol, @unchecked Sendable {
         MockHTTP.respond = { _ in (401, #"{"error":"Unauthorized"}"#) }
         let refused = await service.saveCurrentPage(url: "https://example.com/page")
         try check(refused["status"] as? String == "unauthenticated", "revoked access cannot save")
+        let racy = MemoryCredentials(tokens())
+        let racyService = fixture(racy)
+        MockHTTP.respond = { request in
+            // The other process rotates credentials while our request is in flight.
+            try racy.save(SafariOAuthTokens(accessToken: "rotated-access", refreshToken: "rotated-refresh",
+                expiresAt: Date().addingTimeInterval(3600)))
+            _ = request
+            return (401, #"{"error":"Unauthorized"}"#)
+        }
+        let stale = await racyService.saveCurrentPage(url: "https://example.com/page")
+        try check(stale["status"] as? String == "unauthenticated", "stale 401 reports unauthenticated")
+        try check(try racy.load()?.accessToken == "rotated-access", "stale 401 preserves rotated credentials")
+        MockHTTP.respond = { _ in (401, #"{"error":"Unauthorized"}"#) }
+        let genuine = await racyService.saveCurrentPage(url: "https://example.com/page")
+        try check(genuine["status"] as? String == "unauthenticated", "genuine 401 requires reconnect")
+        try check(try racy.load() == nil, "genuine 401 clears matching credentials")
         try store.save(tokens())
         MockHTTP.respond = { _ in (401, "") }
         let emptyDenied = await service.authState()

--- a/apps/safari-extension/tests/SafariOAuthTests.swift
+++ b/apps/safari-extension/tests/SafariOAuthTests.swift
@@ -146,6 +146,15 @@ final class MockHTTP: URLProtocol, @unchecked Sendable {
         let refused = await service.saveCurrentPage(url: "https://example.com/page")
         try check(refused["status"] as? String == "unauthenticated", "revoked access cannot save")
         try store.save(tokens())
+        MockHTTP.respond = { _ in (401, "") }
+        let emptyDenied = await service.authState()
+        try check(emptyDenied["authenticated"] as? Bool == false, "empty 401 requires reconnect")
+        try check(try store.load() == nil, "empty 401 clears credentials")
+        try store.save(tokens())
+        MockHTTP.respond = { _ in (200, "") }
+        let emptySave = await service.saveCurrentPage(url: "https://example.com/page")
+        try check(emptySave["status"] as? String == "error", "empty save response surfaces error")
+        try store.save(tokens())
         MockHTTP.respond = { request in
             try check(request.url?.path == "/api/oauth/revoke", "logout calls revocation")
             return (200, "")

--- a/apps/safari-extension/tests/SafariOAuthTests.swift
+++ b/apps/safari-extension/tests/SafariOAuthTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+final class MemoryCredentials: SafariCredentialStorage, @unchecked Sendable {
+    private let lock = NSLock()
+    private var tokens: SafariOAuthTokens?
+    init(_ tokens: SafariOAuthTokens? = nil) { self.tokens = tokens }
+    func load() throws -> SafariOAuthTokens? { lock.withLock { tokens } }
+    func save(_ tokens: SafariOAuthTokens) throws { lock.withLock { self.tokens = tokens } }
+    func clear() throws { lock.withLock { tokens = nil } }
+}
+
+final class MockHTTP: URLProtocol, @unchecked Sendable {
+    static var respond: (URLRequest) throws -> (Int, String) = { _ in (500, "{}") }
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        do {
+            let (status, body) = try Self.respond(request)
+            client?.urlProtocol(self, didReceive: HTTPURLResponse(url: request.url!, statusCode: status,
+                httpVersion: nil, headerFields: ["Content-Type": "application/json"])!, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data(body.utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        } catch { client?.urlProtocol(self, didFailWithError: error) }
+    }
+    override func stopLoading() {}
+}
+
+@main struct SafariOAuthTests {
+    static func check(_ condition: @autoclosure () throws -> Bool, _ message: String) throws {
+        if try !condition() { throw SafariServiceError.message("TEST FAILED: \(message)") }
+    }
+    static func rejects(_ message: String, _ action: () throws -> Void) throws {
+        do { try action() } catch { return }
+        throw SafariServiceError.message("TEST FAILED: \(message)")
+    }
+    static let validSession = #"{"userId":"user","clientId":"teak-safari"}"#
+    static let tokenResponse = #"{"access_token":"new-access","refresh_token":"new-refresh","expires_in":3600,"token_type":"Bearer"}"#
+    static func fixture(_ store: MemoryCredentials, lock: URL? = nil) -> TeakSafariService {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [MockHTTP.self]
+        return TeakSafariService(session: URLSession(configuration: configuration), credentials: store,
+            apiURL: URL(string: "https://test.teak.invalid")!,
+            lockURL: lock ?? FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString))
+    }
+    static func tokens(expired: Bool = false) -> SafariOAuthTokens {
+        SafariOAuthTokens(accessToken: "access", refreshToken: "refresh", expiresAt: Date().addingTimeInterval(expired ? -1 : 3600))
+    }
+    static func main() async throws {
+        let pending = try SafariOAuthRequest(verifier: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk", state: "expected")
+        let authorization = URLComponents(url: pending.authorizationURL(baseURL: URL(string: "https://app.teakvault.com")!), resolvingAgainstBaseURL: false)!
+        try check(authorization.queryItems?.first { $0.name == "code_challenge" }?.value == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM", "PKCE uses RFC 7636 S256 vector")
+        try check(try pending.authorizationCode(from: URL(string: "teak-safari://oauth/callback?code=valid&state=expected")!) == "valid", "matching callback succeeds")
+        for invalid in [
+            "teak-safari://oauth/callback?code=valid&state=wrong",
+            "teak-safari://oauth/callback?code=valid&state=expected&state=expected",
+            "teak-safari://oauth/callback?code=a&code=b&state=expected",
+            "teak-safari://wrong/callback?code=valid&state=expected",
+            "teak-safari://user@oauth/callback?code=valid&state=expected",
+            "teak-safari://oauth/callback?error=access_denied&state=expected",
+        ] { try rejects("invalid callback is rejected") { _ = try pending.authorizationCode(from: URL(string: invalid)!) } }
+        try rejects("expired login is rejected") {
+            _ = try pending.authorizationCode(from: URL(string: "teak-safari://oauth/callback?code=valid&state=expected")!, now: Date().addingTimeInterval(601))
+        }
+        try check(String(data: SafariOAuthRequest.formBody(["code": "a+b&c=d"]), encoding: .utf8) == "code=a%2Bb%26c%3Dd", "form encoding preserves special characters")
+        try rejects("invalid token response rejected") { _ = try SafariOAuthTokens.decode(Data(#"{"access_token":"","refresh_token":"r","expires_in":3600,"token_type":"Bearer"}"#.utf8)) }
+        print("PASS: PKCE, callback validation, expiry, consent denial, and form encoding")
+
+        let freshStore = MemoryCredentials()
+        let fresh = fixture(freshStore)
+        MockHTTP.respond = { _ in throw SafariServiceError.message("Unexpected network request") }
+        let signedOut = await fresh.authState()
+        try check(signedOut["authenticated"] as? Bool == false, "old sessions do not authenticate OAuth")
+        MockHTTP.respond = { request in
+            try check(request.url?.path == "/api/auth/mcp/token", "exchanges code at OAuth endpoint")
+            return (200, tokenResponse)
+        }
+        let connected = await fresh.completeSignIn(pending, callback: URL(string: "teak-safari://oauth/callback?code=valid&state=expected")!)
+        try check(connected["authenticated"] as? Bool == true, "login stores OAuth credentials")
+        try check(try freshStore.load()?.refreshToken == "new-refresh", "refresh token persisted")
+        MockHTTP.respond = { _ in (200, validSession) }
+        let restarted = fixture(freshStore)
+        let restartedState = await restarted.authState()
+        try check(restartedState["authenticated"] as? Bool == true, "restart uses persisted credentials")
+        print("PASS: reconnect, code exchange, credential persistence, restart")
+
+        let store = MemoryCredentials(tokens())
+        let service = fixture(store)
+        var creates = 0
+        MockHTTP.respond = { request in
+            try check(request.value(forHTTPHeaderField: "Authorization") == "Bearer access", "saves use OAuth bearer")
+            if request.url?.path == "/v1/cards/duplicate" { return (200, #"{"cardId":null}"#) }
+            creates += 1
+            try check(request.httpMethod == "POST", "save creates a card")
+            try check(request.value(forHTTPHeaderField: "Idempotency-Key") != nil, "save carries idempotency key")
+            return (200, #"{"cardId":"saved-card"}"#)
+        }
+        let saved = await service.saveCurrentPage(url: "https://example.com/page")
+        try check(saved["status"] as? String == "saved" && creates == 1, "page saved once")
+        MockHTTP.respond = { request in
+            try check(request.url?.path == "/v1/cards/duplicate", "duplicate never creates a card")
+            return (200, #"{"cardId":"existing-card"}"#)
+        }
+        let duplicate = await service.saveCurrentPage(url: "https://example.com/page")
+        try check(duplicate["status"] as? String == "duplicate", "existing page reports duplicate")
+        let invalid = await service.saveCurrentPage(url: "file:///private/test")
+        try check(invalid["status"] as? String == "invalid-url", "invalid page refused")
+        print("PASS: authenticated save, duplicate feedback, invalid URLs")
+
+        let rotating = MemoryCredentials(tokens(expired: true))
+        let sharedLock = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let first = fixture(rotating, lock: sharedLock), second = fixture(rotating, lock: sharedLock)
+        var refreshes = 0
+        MockHTTP.respond = { request in
+            if request.url?.path == "/api/auth/mcp/token" { refreshes += 1; return (200, tokenResponse) }
+            return (200, validSession)
+        }
+        async let firstState = first.authState()
+        async let secondState = second.authState()
+        let states = await [firstState, secondState]
+        try check(states.allSatisfy { $0["authenticated"] as? Bool == true }, "both processes receive valid auth")
+        try check(refreshes == 1, "concurrent clients refresh once")
+        try check(try rotating.load()?.refreshToken == "new-refresh", "rotated refresh token persisted")
+        print("PASS: silent refresh and cross-client refresh serialization")
+
+        MockHTTP.respond = { _ in throw URLError(.notConnectedToInternet) }
+        let offline = await service.authState()
+        try check(offline["status"] as? String == "error", "offline is not misreported as sign-out")
+        try check(try store.load() != nil, "offline preserves credentials")
+        let offlineLogout = await service.signOut()
+        try check(offlineLogout["status"] as? String == "error", "offline logout offers retry")
+        try check(offlineLogout["authenticated"] as? Bool == true, "failed sign-out keeps retry available")
+        try check(try store.load() != nil, "failed revocation remains retryable")
+        MockHTTP.respond = { _ in (200, "null") }
+        let revoked = await service.authState()
+        try check(revoked["authenticated"] as? Bool == false, "remote disconnection detected")
+        try check(try store.load() == nil, "revoked credentials cleared")
+        print("PASS: offline recovery and remote revocation")
+
+        let expired = MemoryCredentials(tokens(expired: true))
+        MockHTTP.respond = { _ in (401, #"{"error":"invalid_grant"}"#) }
+        let expiredState = await fixture(expired).authState()
+        try check(expiredState["authenticated"] as? Bool == false, "invalid refresh requires reconnect")
+        try check(try expired.load() == nil, "invalid refresh cleared")
+        try store.save(tokens())
+        MockHTTP.respond = { _ in (401, #"{"error":"Unauthorized"}"#) }
+        let refused = await service.saveCurrentPage(url: "https://example.com/page")
+        try check(refused["status"] as? String == "unauthenticated", "revoked access cannot save")
+        try store.save(tokens())
+        MockHTTP.respond = { request in
+            try check(request.url?.path == "/api/oauth/revoke", "logout calls revocation")
+            return (200, "")
+        }
+        let logout = await service.signOut()
+        try check(logout["status"] as? String == "signed-out", "logout succeeds after revocation")
+        try check(try store.load() == nil, "logout clears credentials")
+        print("PASS: expired refresh, revoked save, local sign-out")
+    }
+}

--- a/apps/safari-extension/tests/companion.test.ts
+++ b/apps/safari-extension/tests/companion.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { createContext, runInContext } from "node:vm";
+
+const source = readFileSync(
+  new URL("../Shared (App)/Resources/Script.js", import.meta.url),
+  "utf8"
+);
+
+const setup = () => {
+  const classes = new Set<string>();
+  const status = { innerText: "" };
+  const context = createContext({
+    document: {
+      body: {
+        classList: {
+          contains: (name: string) => classes.has(name),
+          toggle: (name: string, enabled: boolean) =>
+            enabled ? classes.add(name) : classes.delete(name),
+        },
+      },
+      getElementById: (id: string) =>
+        id === "account-status" ? status : { addEventListener() {} },
+    },
+    webkit: { messageHandlers: { controller: { postMessage() {} } } },
+  });
+  runInContext(source, context);
+  return { context, classes, status };
+};
+
+describe("Safari companion account feedback", () => {
+  test("failed sign-out keeps the sign-out action available and explains the failure", () => {
+    const { context, classes, status } = setup();
+    runInContext("renderAccountState({authenticated: true})", context);
+    expect(classes.has("signed-in")).toBe(true);
+    runInContext(
+      'renderAccountState({status: "error", authenticated: true, message: "Could not disconnect. Please try again."})',
+      context
+    );
+    expect(classes.has("signed-in")).toBe(true);
+    expect(status.innerText).toBe("Could not disconnect. Please try again.");
+    runInContext(
+      'renderAccountState({status: "signed-out", authenticated: false})',
+      context
+    );
+    expect(classes.has("signed-in")).toBe(false);
+  });
+
+  test("a message alone does not discard the current authenticated presentation", () => {
+    const { context, classes, status } = setup();
+    runInContext("renderAccountState({authenticated: true})", context);
+    runInContext('renderAccountState({message: "Please try again."})', context);
+    expect(classes.has("signed-in")).toBe(true);
+    expect(status.innerText).toBe("Please try again.");
+  });
+});

--- a/packages/convex/__tests__/oauthClients.test.ts
+++ b/packages/convex/__tests__/oauthClients.test.ts
@@ -6,7 +6,7 @@ const runHandler = (fn: any, ctx: any, args: any) =>
   (fn.handler ?? fn)(ctx, args);
 
 describe("ensureOAuthClients", () => {
-  test("creates both first-party clients when none exist", async () => {
+  test("creates all first-party clients when none exist", async () => {
     const runQuery = mock().mockResolvedValue(null);
     const runMutation = mock().mockResolvedValue(undefined);
 
@@ -16,8 +16,8 @@ describe("ensureOAuthClients", () => {
       {}
     );
 
-    expect(result).toMatchObject({ created: 3, updated: 0 });
-    expect(runMutation).toHaveBeenCalledTimes(3);
+    expect(result).toMatchObject({ created: 4, updated: 0 });
+    expect(runMutation).toHaveBeenCalledTimes(4);
 
     const first = runMutation.mock.calls[0][1];
     expect(first.input.model).toBe("oauthApplication");
@@ -38,7 +38,7 @@ describe("ensureOAuthClients", () => {
       {}
     );
 
-    expect(result).toMatchObject({ created: 0, updated: 3 });
+    expect(result).toMatchObject({ created: 0, updated: 4 });
     expect(runMutation.mock.calls[0][1].input.update.type).toBe("public");
     expect(runMutation.mock.calls[0][1].input.update).not.toHaveProperty(
       "skipConsent"
@@ -55,6 +55,18 @@ describe("ensureOAuthClients", () => {
       "http://127.0.0.1:14203/oauth/callback",
       "http://127.0.0.1:24203/oauth/callback",
     ]);
+  });
+
+  test("seeds Safari as a public client with an exact callback", () => {
+    expect(
+      FIRST_PARTY_OAUTH_CLIENTS.find(
+        (client) => client.clientId === "teak-safari"
+      )
+    ).toEqual({
+      clientId: "teak-safari",
+      name: "Teak Safari",
+      redirectUrls: ["teak-safari://oauth/callback"],
+    });
   });
 
   test("seeds teak-cli with both loopback callback ports", () => {

--- a/packages/convex/_generated/api.d.ts
+++ b/packages/convex/_generated/api.d.ts
@@ -81,9 +81,11 @@ import type * as markdownDocumentMigrationAction from "../markdownDocumentMigrat
 import type * as mcp_httpServer from "../mcp/httpServer.js";
 import type * as mcp_tools from "../mcp/tools.js";
 import type * as oauthClients from "../oauthClients.js";
+import type * as oauthRevocation from "../oauthRevocation.js";
 import type * as oauthSecurity from "../oauthSecurity.js";
 import type * as oauthTokens from "../oauthTokens.js";
 import type * as publicApi from "../publicApi.js";
+import type * as publicApiDuplicate from "../publicApiDuplicate.js";
 import type * as publicApiHttp from "../publicApiHttp.js";
 import type * as publicApiMeta from "../publicApiMeta.js";
 import type * as publicApiOpenApi from "../publicApiOpenApi.js";
@@ -251,9 +253,11 @@ declare const fullApi: ApiFromModules<{
   "mcp/httpServer": typeof mcp_httpServer;
   "mcp/tools": typeof mcp_tools;
   oauthClients: typeof oauthClients;
+  oauthRevocation: typeof oauthRevocation;
   oauthSecurity: typeof oauthSecurity;
   oauthTokens: typeof oauthTokens;
   publicApi: typeof publicApi;
+  publicApiDuplicate: typeof publicApiDuplicate;
   publicApiHttp: typeof publicApiHttp;
   publicApiMeta: typeof publicApiMeta;
   publicApiOpenApi: typeof publicApiOpenApi;

--- a/packages/convex/auth.ts
+++ b/packages/convex/auth.ts
@@ -388,6 +388,16 @@ export const createAuth = (ctx: GenericCtx<DataModel>) => {
               ],
             },
             {
+              clientId: "teak-safari",
+              clientSecret: "",
+              type: "public",
+              name: "Teak Safari",
+              disabled: false,
+              skipConsent: false,
+              metadata: null,
+              redirectUrls: ["teak-safari://oauth/callback"],
+            },
+            {
               clientId: "teak-cli",
               clientSecret: "",
               type: "public",

--- a/packages/convex/http.ts
+++ b/packages/convex/http.ts
@@ -7,6 +7,8 @@ import {
 import { exchangeNativeAuthOptions, pollNativeAuthCode } from "./authNative";
 import { polar } from "./billing";
 import { mcpV1, oauthProtectedResourceV1 } from "./mcp/httpServer";
+import { revokeOAuthToken } from "./oauthRevocation";
+import { duplicateCardV1 } from "./publicApiDuplicate";
 import {
   bulkCardsV1,
   cardByIdV1,
@@ -194,6 +196,17 @@ http.route({
   pathPrefix: "/v1/cards/",
   method: "DELETE",
   handler: cardByIdV1,
+});
+
+http.route({
+  path: "/v1/cards/duplicate",
+  method: "GET",
+  handler: duplicateCardV1,
+});
+http.route({
+  path: "/api/oauth/revoke",
+  method: "POST",
+  handler: revokeOAuthToken,
 });
 
 export default http;

--- a/packages/convex/oauthClients.ts
+++ b/packages/convex/oauthClients.ts
@@ -43,6 +43,11 @@ export const FIRST_PARTY_OAUTH_CLIENTS: OAuthClientSeed[] = [
     ],
   },
   {
+    clientId: "teak-safari",
+    name: "Teak Safari",
+    redirectUrls: ["teak-safari://oauth/callback"],
+  },
+  {
     clientId: "teak-cli",
     name: "Teak CLI",
     redirectUrls: [

--- a/packages/convex/oauthRevocation.ts
+++ b/packages/convex/oauthRevocation.ts
@@ -1,0 +1,83 @@
+import { v } from "convex/values";
+import { components, internal } from "./_generated/api";
+import { httpAction, internalMutation } from "./_generated/server";
+import {
+  isWellFormedOAuthToken,
+  OAUTH_ACCESS_TOKEN_MODEL,
+} from "./oauthTokens";
+
+// Revoke only the credential pair presented by this client. Settings retains
+// its existing app-wide revocation behavior across all installations.
+export const revokeToken = internalMutation({
+  args: { token: v.string(), clientId: v.string() },
+  returns: v.null(),
+  handler: async (ctx, { token, clientId }) => {
+    for (const field of ["refreshToken", "accessToken"] as const) {
+      const record = await ctx.runQuery(components.betterAuth.adapter.findOne, {
+        model: OAUTH_ACCESS_TOKEN_MODEL,
+        where: [
+          { field, operator: "eq", value: token },
+          { field: "clientId", operator: "eq", value: clientId },
+        ],
+      });
+      if (record) {
+        await ctx.runMutation(components.betterAuth.adapter.deleteOne, {
+          input: {
+            model: OAUTH_ACCESS_TOKEN_MODEL,
+            where: [{ field: "_id", operator: "eq", value: record._id }],
+          },
+        });
+        break;
+      }
+    }
+    return null;
+  },
+});
+
+export const revokeOAuthToken = httpAction(async (ctx, request) => {
+  if (
+    !request.headers
+      .get("content-type")
+      ?.startsWith("application/x-www-form-urlencoded")
+  ) {
+    return Response.json({ error: "invalid_request" }, { status: 400 });
+  }
+  // Bound the stream before parsing untrusted form data.
+  const reader = request.body?.getReader();
+  if (!reader) {
+    return Response.json({ error: "invalid_request" }, { status: 400 });
+  }
+  let body = "";
+  let size = 0;
+  const decoder = new TextDecoder();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    size += value.byteLength;
+    if (size > 2048) {
+      await reader.cancel();
+      return Response.json({ error: "invalid_request" }, { status: 400 });
+    }
+    body += decoder.decode(value, { stream: true });
+  }
+  body += decoder.decode();
+  const form = new URLSearchParams(body);
+  const token = form.get("token") ?? "";
+  const clientId = form.get("client_id") ?? "";
+  if (!clientId || clientId.length > 256 || !token) {
+    return Response.json({ error: "invalid_request" }, { status: 400 });
+  }
+  if (isWellFormedOAuthToken(token)) {
+    await ctx.runMutation(internal.oauthRevocation.revokeToken, {
+      token,
+      clientId,
+    });
+  }
+  // RFC 7009: unknown, expired, and already revoked tokens all succeed.
+  return new Response(null, {
+    status: 200,
+    headers: { "Cache-Control": "no-store" },
+  });
+});

--- a/packages/convex/publicApiDuplicate.ts
+++ b/packages/convex/publicApiDuplicate.ts
@@ -1,0 +1,29 @@
+import { internal } from "./_generated/api";
+import { httpAction } from "./_generated/server";
+import { withAuthorizedUser } from "./publicApiHttp";
+import { json, withPublicApiGatewayHeaders } from "./publicApiMeta";
+import { isSafeExternalUrl } from "./shared/utils/safeUrl";
+
+export const duplicateCardV1 = httpAction(async (ctx, request) => {
+  const respond = (body: object, status = 200) =>
+    withPublicApiGatewayHeaders(json(status, body));
+  const auth = await withAuthorizedUser(ctx, request);
+  if ("error" in auth) {
+    return withPublicApiGatewayHeaders(auth.error);
+  }
+  const url = new URL(request.url).searchParams.get("url");
+  if (!url || url.length > 8192 || !isSafeExternalUrl(url)) {
+    return respond(
+      { code: "INVALID_INPUT", error: "Provide an HTTP or HTTPS URL" },
+      400
+    );
+  }
+  const card = await ctx.runQuery(
+    internal.card.findDuplicateCard.findDuplicateCardForUser,
+    {
+      userId: auth.validated.userId,
+      url,
+    }
+  );
+  return respond({ cardId: card?._id ?? null });
+});

--- a/packages/convex/publicApiDuplicate.ts
+++ b/packages/convex/publicApiDuplicate.ts
@@ -11,7 +11,7 @@ export const duplicateCardV1 = httpAction(async (ctx, request) => {
   if ("error" in auth) {
     return withPublicApiGatewayHeaders(auth.error);
   }
-  const url = new URL(request.url).searchParams.get("url");
+  const url = new URL(request.url).searchParams.get("url")?.trim();
   if (!url || url.length > 8192 || !isSafeExternalUrl(url)) {
     return respond(
       { code: "INVALID_INPUT", error: "Provide an HTTP or HTTPS URL" },

--- a/packages/convex/publicApiHttp.ts
+++ b/packages/convex/publicApiHttp.ts
@@ -400,7 +400,7 @@ const enforceInvalidAuthLimit = async (ctx: any): Promise<Response | null> => {
   return null;
 };
 
-const withAuthorizedUser = async (
+export const withAuthorizedUser = async (
   ctx: any,
   request: Request,
   options: { chargeRateLimit?: boolean } = {}

--- a/packages/convex/publicApiMeta.ts
+++ b/packages/convex/publicApiMeta.ts
@@ -14,6 +14,7 @@ export const V1_ENDPOINTS = [
   "POST /v1/cards/bulk",
   "GET /v1/cards/changes",
   "GET /v1/cards/search",
+  "GET /v1/cards/duplicate",
   "GET /v1/cards/favorites",
   "GET /v1/cards/:cardId",
   "PATCH /v1/cards/:cardId",

--- a/packages/convex/publicApiOpenApi.ts
+++ b/packages/convex/publicApiOpenApi.ts
@@ -548,6 +548,37 @@ export const openApiSpec = {
         summary: "List card changes since a timestamp",
       },
     },
+    "/v1/cards/duplicate": {
+      get: {
+        summary: "Find a non-deleted card by exact URL",
+        security: apiKeySecurity,
+        parameters: [
+          {
+            in: "query",
+            name: "url",
+            required: true,
+            schema: { type: "string", format: "uri", maxLength: 8192 },
+          },
+        ],
+        responses: {
+          200: {
+            description: "Matching card ID, or null",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["cardId"],
+                  properties: { cardId: { type: "string", nullable: true } },
+                },
+              },
+            },
+          },
+          400: { description: "Invalid URL" },
+          401: { description: "Invalid or revoked credentials" },
+          429: { description: "Rate limit exceeded" },
+        },
+      },
+    },
     "/v1/cards/search": {
       get: {
         parameters: [

--- a/packages/convex/safariOAuth.test.ts
+++ b/packages/convex/safariOAuth.test.ts
@@ -115,6 +115,11 @@ describe("Safari OAuth connection", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("Cache-Control")).toBe("no-store");
     expect(await response.json()).toEqual({ cardId: expected });
+    const padded = await t.fetch(
+      `/v1/cards/duplicate?url=${encodeURIComponent(`  ${url}  `)}`,
+      { headers: { Authorization: `Bearer ${accessToken}` } }
+    );
+    expect(await padded.json()).toEqual({ cardId: expected });
     const absent = await t.fetch(
       `/v1/cards/duplicate?url=${encodeURIComponent(`${url}/different`)}`,
       { headers: { Authorization: `Bearer ${accessToken}` } }

--- a/packages/convex/safariOAuth.test.ts
+++ b/packages/convex/safariOAuth.test.ts
@@ -1,0 +1,268 @@
+/// <reference types="vite/client" />
+
+import betterAuthTest from "@convex-dev/better-auth/test";
+import rateLimiterTest from "@convex-dev/rate-limiter/test";
+import { convexTest } from "convex-test";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { TEST_APPLE_PRIVATE_KEY } from "./__tests__/helpers/appleAuth.test-utils";
+import { api, components, internal } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+const accessToken = "a".repeat(32);
+const refreshToken = "r".repeat(32);
+
+beforeEach(() => {
+  vi.stubEnv("SITE_URL", "http://app.teak.localhost:1355");
+  vi.stubEnv("GOOGLE_CLIENT_ID", "test");
+  vi.stubEnv("GOOGLE_CLIENT_SECRET", "test");
+  vi.stubEnv("APPLE_CLIENT_ID", "test-client");
+  vi.stubEnv("APPLE_KEY_ID", "test-key");
+  vi.stubEnv("APPLE_TEAM_ID", "test-team");
+  vi.stubEnv("APPLE_PRIVATE_KEY", TEST_APPLE_PRIVATE_KEY);
+});
+
+const setup = async () => {
+  const t = convexTest(schema, modules);
+  betterAuthTest.register(t);
+  rateLimiterTest.register(t, "rateLimiterV2");
+  const user = await t.mutation(components.betterAuth.adapter.create, {
+    input: {
+      model: "user",
+      data: {
+        name: "Safari test",
+        email: "safari@example.com",
+        emailVerified: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    },
+  });
+  await t.mutation(internal.oauthClients.ensureOAuthClients, {});
+  await t.mutation(components.betterAuth.adapter.create, {
+    input: {
+      model: "oauthAccessToken",
+      data: {
+        accessToken,
+        refreshToken,
+        clientId: "teak-safari",
+        userId: user._id,
+        accessTokenExpiresAt: Date.now() + 3_600_000,
+        refreshTokenExpiresAt: Date.now() + 86_400_000,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        scopes: "profile email offline_access",
+      },
+    },
+  });
+  return { t, userId: user._id };
+};
+
+const revokeRequest = (token: string, clientId = "teak-safari") => ({
+  method: "POST",
+  headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  body: new URLSearchParams({ token, client_id: clientId }).toString(),
+});
+
+describe("Safari OAuth connection", () => {
+  test("appears in Connected apps and app-wide disconnect invalidates its credential", async () => {
+    const { t, userId } = await setup();
+    const authenticated = t.withIdentity({ subject: userId });
+    expect(
+      await authenticated.query(api.oauthTokens.listOAuthConnections, {})
+    ).toEqual([
+      expect.objectContaining({ clientId: "teak-safari", name: "Teak Safari" }),
+    ]);
+    await authenticated.action(api.oauthTokens.revokeOAuthConnection, {
+      clientId: "teak-safari",
+    });
+    expect(
+      await authenticated.query(api.oauthTokens.listOAuthConnections, {})
+    ).toEqual([]);
+    expect(
+      await t.mutation(internal.oauthTokens.validateOAuthAccessToken, {
+        token: accessToken,
+      })
+    ).toBeNull();
+    expect(
+      await t.query(components.betterAuth.adapter.findOne, {
+        model: "oauthAccessToken",
+        where: [{ field: "refreshToken", operator: "eq", value: refreshToken }],
+      })
+    ).toBeNull();
+  });
+
+  test("exact URL lookup is user-scoped and excludes deleted cards", async () => {
+    const { t, userId } = await setup();
+    const url = "https://example.com/safari";
+    const expected = await t.run(async (ctx) => {
+      const fields = {
+        content: url,
+        url,
+        type: "link" as const,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+      const own = await ctx.db.insert("cards", { ...fields, userId });
+      await ctx.db.insert("cards", { ...fields, userId: "other-user" });
+      await ctx.db.insert("cards", { ...fields, userId, isDeleted: true });
+      return own;
+    });
+    const response = await t.fetch(
+      `/v1/cards/duplicate?url=${encodeURIComponent(url)}`,
+      { headers: { Authorization: `Bearer ${accessToken}` } }
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(await response.json()).toEqual({ cardId: expected });
+    const absent = await t.fetch(
+      `/v1/cards/duplicate?url=${encodeURIComponent(`${url}/different`)}`,
+      { headers: { Authorization: `Bearer ${accessToken}` } }
+    );
+    expect(await absent.json()).toEqual({ cardId: null });
+    const unsafe = await t.fetch(
+      "/v1/cards/duplicate?url=javascript:alert(1)",
+      { headers: { Authorization: `Bearer ${accessToken}` } }
+    );
+    expect(unsafe.status).toBe(400);
+    const unauthenticated = await t.fetch(
+      `/v1/cards/duplicate?url=${encodeURIComponent(url)}`
+    );
+    expect(unauthenticated.status).toBe(401);
+  });
+
+  test("local sign-out revokes only the presented installation and is idempotent", async () => {
+    const { t, userId } = await setup();
+    await t.mutation(components.betterAuth.adapter.create, {
+      input: {
+        model: "oauthAccessToken",
+        data: {
+          clientId: "teak-safari",
+          userId,
+          accessToken: "b".repeat(32),
+          refreshToken: "s".repeat(32),
+          accessTokenExpiresAt: Date.now() + 3_600_000,
+          refreshTokenExpiresAt: Date.now() + 86_400_000,
+        },
+      },
+    });
+    expect(
+      (
+        await t.fetch(
+          "/api/oauth/revoke",
+          revokeRequest(refreshToken, "teak-cli")
+        )
+      ).status
+    ).toBe(200);
+    expect(
+      await t.mutation(internal.oauthTokens.validateOAuthAccessToken, {
+        token: accessToken,
+      })
+    ).not.toBeNull();
+    expect(
+      (await t.fetch("/api/oauth/revoke", revokeRequest(refreshToken))).status
+    ).toBe(200);
+    expect(
+      await t.mutation(internal.oauthTokens.validateOAuthAccessToken, {
+        token: accessToken,
+      })
+    ).toBeNull();
+    expect(
+      await t.mutation(internal.oauthTokens.validateOAuthAccessToken, {
+        token: "b".repeat(32),
+      })
+    ).not.toBeNull();
+    expect(
+      (await t.fetch("/api/oauth/revoke", revokeRequest(refreshToken))).status
+    ).toBe(200);
+    expect(
+      (await t.fetch("/api/oauth/revoke", revokeRequest("b".repeat(32)))).status
+    ).toBe(200);
+    expect(
+      await t
+        .withIdentity({ subject: userId })
+        .query(api.oauthTokens.listOAuthConnections, {})
+    ).toEqual([]);
+    const save = await t.fetch("/v1/cards", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ url: "https://example.com" }),
+    });
+    expect(save.status).toBe(401);
+  });
+
+  test("provider refresh rotates credentials before local sign-out", async () => {
+    const { t, userId } = await setup();
+    const refreshed = await t.fetch("/api/auth/mcp/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: "teak-safari",
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+      }).toString(),
+    });
+    expect(refreshed.status).toBe(200);
+    const tokens = await refreshed.json();
+    expect(tokens.refresh_token).toBeTypeOf("string");
+    expect(tokens.refresh_token).not.toBe(refreshToken);
+    expect(
+      await t.mutation(internal.oauthTokens.validateOAuthAccessToken, {
+        token: accessToken,
+      })
+    ).toBeNull();
+    expect(
+      await t.query(components.betterAuth.adapter.findOne, {
+        model: "oauthAccessToken",
+        where: [{ field: "refreshToken", operator: "eq", value: refreshToken }],
+      })
+    ).toBeNull();
+    expect(
+      (await t.fetch("/api/oauth/revoke", revokeRequest(tokens.refresh_token)))
+        .status
+    ).toBe(200);
+    expect(
+      await t.mutation(internal.oauthTokens.validateOAuthAccessToken, {
+        token: tokens.access_token,
+      })
+    ).toBeNull();
+    expect(
+      await t
+        .withIdentity({ subject: userId })
+        .query(api.oauthTokens.listOAuthConnections, {})
+    ).toEqual([]);
+    const retry = await t.fetch("/api/auth/mcp/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: "teak-safari",
+        grant_type: "refresh_token",
+        refresh_token: tokens.refresh_token,
+      }).toString(),
+    });
+    expect(retry.status).toBe(401);
+  });
+
+  test("rejects invalid or oversized revocation forms", async () => {
+    const { t } = await setup();
+    expect(
+      (await t.fetch("/api/oauth/revoke", { method: "POST", body: "{}" }))
+        .status
+    ).toBe(400);
+    expect((await t.fetch("/api/oauth/revoke", revokeRequest(""))).status).toBe(
+      400
+    );
+    expect(
+      (await t.fetch("/api/oauth/revoke", revokeRequest("a".repeat(4096))))
+        .status
+    ).toBe(400);
+    expect(
+      await t.mutation(internal.oauthTokens.validateOAuthAccessToken, {
+        token: accessToken,
+      })
+    ).not.toBeNull();
+  });
+});

--- a/packages/convex/vitest.config.ts
+++ b/packages/convex/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "edge-runtime",
-    include: ["./occContention.test.ts"],
+    include: ["./occContention.test.ts", "./safariOAuth.test.ts"],
   },
 });

--- a/scripts/test-safari-oauth.sh
+++ b/scripts/test-safari-oauth.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+test_build_dir="$(mktemp -d "${TMPDIR:-/tmp}/teak-safari-oauth.XXXXXX")"
+xcrun swiftc -parse-as-library \
+  "apps/safari-extension/Shared (App)/Shared (Core)/SafariOAuth.swift" \
+  "apps/safari-extension/Shared (App)/Shared (Core)/SafariCredentialStore.swift" \
+  "apps/safari-extension/Shared (App)/Shared (Core)/TeakSafariService.swift" \
+  apps/safari-extension/tests/SafariOAuthTests.swift \
+  -o "$test_build_dir/safari-oauth-tests"
+"$test_build_dir/safari-oauth-tests"


### PR DESCRIPTION
## Summary
- Register `teak-safari` first-party OAuth client with custom scheme callback (`teak-safari://oauth/callback`)
- Add `POST /api/oauth/revoke` endpoint plus Safari credential store and OAuth flow (SafariCredentialStore, SafariOAuth)
- Add `GET /v1/cards/duplicate` exact-URL lookup (user-scoped, excludes deleted), OpenAPI + docs updates
- Refresh Safari app/extension companion auth plumbing, release notes, and changelog entry

## Verification
- `bun run pre-commit` (turbo typecheck/lint/build --affected): pass
- `bun run --filter @teak/convex test`: 1518 pass, 0 fail (incl. new safariOAuth.test.ts)
- Docs typecheck (`blume check --strict`): 0 errors

## Notes
- Initial docs build hit flaky Vite ENOTEMPTY cache; cleared `apps/docs/.blume/node_modules/.vite` and pre-commit passes on retry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Safari sign-in through a secure OAuth flow with persistent authentication.
  - Added Safari to Connected apps, including disconnect and installation-specific sign-out.
  - Added duplicate URL detection for saved pages.
  - Added OAuth credential revocation support.
  - Safari sign-out now revokes credentials before clearing local access.

- **Bug Fixes**
  - Improved offline retry behavior and authentication-state handling.
  - Preserved signed-in UI when account-state responses are incomplete or sign-out fails.

- **Documentation**
  - Updated Safari setup, reconnection, Connected apps, and API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->