### PR TITLE
chore(dev): remove portless, pin local dev to localhost:3000/3001

### DIFF
--- a/apps/desktop/src/__tests__/desktopConfig.test.ts
+++ b/apps/desktop/src/__tests__/desktopConfig.test.ts
@@ -14,7 +14,7 @@ describe("desktop config", () => {
       DEV: true,
     });
 
-    expect(config.webBaseUrl).toBe("http://app.teak.localhost:1355");
+    expect(config.webBaseUrl).toBe("http://localhost:3000");
   });
 
   it("uses the production web fallback when VITE_WEB_URL is missing", () => {

--- a/apps/docs/content/docs/(developers)/api.mdx
+++ b/apps/docs/content/docs/(developers)/api.mdx
@@ -19,7 +19,7 @@ Teak provides a public REST API for saving, querying, and syncing cards. Use thi
 | Environment | REST API |
 | --- | --- |
 | Production | `https://teakvault.com/api/v1` |
-| Local development | `http://docs.teak.localhost:1355/api/v1` |
+| Local development | `http://localhost:3001/api/v1` |
 
 The machine-readable OpenAPI document is available at `https://teakvault.com/api/openapi.json`.
 

--- a/apps/docs/content/docs/(developers)/development.mdx
+++ b/apps/docs/content/docs/(developers)/development.mdx
@@ -34,14 +34,14 @@ description: Setup and development workflow for Teak
 
 ## Access Points
 
-- Web App: http://app.teak.localhost:1355
-- Public API: http://docs.teak.localhost:1355/api/v1
-- MCP Endpoint: http://docs.teak.localhost:1355/mcp
+- Web App: http://localhost:3000
+- Public API: http://localhost:3001/api/v1
+- MCP Endpoint: http://localhost:3001/mcp
 - Convex Dashboard: opens after `bunx convex dev`
 - Mobile: Expo Go or simulator
 - Extension: Chrome dev mode
 - Safari Extension: Xcode
-- Docs: http://docs.teak.localhost:1355
+- Docs: http://localhost:3001
 
 ## Project Layout
 
@@ -136,7 +136,7 @@ bun run clean            # Clear Turborepo caches
   </Step>
   <Step title="Point Convex at your local Next.js origin">
     ```bash
-    bunx convex env set SITE_URL http://app.teak.localhost:1355
+    bunx convex env set SITE_URL http://localhost:3000
     ```
   </Step>
 </Steps>
@@ -171,4 +171,4 @@ Follow the CLI prompt to add the DNS TXT record, then publish once verification 
 
 See **[Self-Hosting → Environment settings](/docs/self-hosting#detailed-environment-reference)** for every env var required across web, mobile, extension, and the Convex backend.
 
-Optional local overrides: `TEAK_DEV_APP_URL` (default: `http://app.teak.localhost:1355`), `TEAK_DEV_API_URL` (only needed when your Convex dev site differs from the repo default), `TEAK_DEV_DOCS_URL` (default: `http://docs.teak.localhost:1355`).
+Optional local overrides: `TEAK_DEV_APP_URL` (default: `http://localhost:3000`), `TEAK_DEV_API_URL` (only needed when your Convex dev site differs from the repo default), `TEAK_DEV_DOCS_URL` (default: `http://localhost:3001`).

--- a/apps/docs/content/docs/(developers)/mcp.mdx
+++ b/apps/docs/content/docs/(developers)/mcp.mdx
@@ -8,7 +8,7 @@ Teak provides a remote MCP server at `https://teakvault.com/mcp`.
 ## Base URLs
 
 - Production: `https://teakvault.com/mcp`
-- Local development: `http://docs.teak.localhost:1355/mcp`
+- Local development: `http://localhost:3001/mcp`
 - Discovery manifest: `https://teakvault.com/.well-known/mcp.json`
 
 ## Authentication

--- a/apps/docs/content/docs/(developers)/self-hosting.mdx
+++ b/apps/docs/content/docs/(developers)/self-hosting.mdx
@@ -39,7 +39,7 @@ public domain at it.
     ```bash
     # Security & Auth
     npx convex env set BETTER_AUTH_SECRET $(openssl rand -base64 32)
-    npx convex env set SITE_URL http://app.teak.localhost:1355
+    npx convex env set SITE_URL http://localhost:3000
     npx convex env set TEAK_ADMIN_EMAIL you@example.com
 
     # Optional: AI (if you want card processing)
@@ -98,7 +98,7 @@ Add these to your env files before running locally or deploying.
 ### Backend (`packages/convex/.env.local`)
 
 ```bash
-SITE_URL=http://app.teak.localhost:1355
+SITE_URL=http://localhost:3000
 BETTER_AUTH_SECRET=your-secret               # Better Auth security
 TEAK_ADMIN_EMAIL=you@example.com             # Explicit administrator account
 FILES_BASE=https://files.yourdomain.com      # Files Worker origin
@@ -143,7 +143,7 @@ worker's public origin.
 CONVEX_DEPLOY_KEY=
 NEXT_PUBLIC_CONVEX_URL=https://deployment.convex.cloud
 NEXT_PUBLIC_CONVEX_SITE_URL=https://deployment.convex.site
-TEAK_DEV_APP_URL=http://app.teak.localhost:1355   # Optional local override
+TEAK_DEV_APP_URL=http://localhost:3000   # Optional local override
 # Origin your R2 files are served from, so the Content-Security-Policy allows
 # loading images and documents. Set this to your bucket's public/signed-URL
 # origin (e.g. https://your-bucket.<account>.r2.cloudflarestorage.com).
@@ -157,7 +157,7 @@ Mobile, Extension, and Desktop share the same base variables (use `EXPO_PUBLIC_`
 ```bash
 VITE_PUBLIC_CONVEX_URL=https://deployment.convex.cloud
 VITE_PUBLIC_CONVEX_SITE_URL=https://deployment.convex.site
-TEAK_DEV_APP_URL=http://app.teak.localhost:1355   # Optional local override
+TEAK_DEV_APP_URL=http://localhost:3000   # Optional local override
 ```
 
 #### Desktop-only
@@ -184,7 +184,7 @@ Convex serves the REST API at `/api/v1`, the MCP endpoint at `/mcp`, plus `/heal
 - **Convex URLs**: Run `bunx convex dev`. It prints both `CONVEX_URL` (for the client) and `CONVEX_SITE_URL` (for the site/auth endpoint). You can also find these in the Convex Dashboard under "Settings" -> "Deployment".
 - **Better Auth**:
   - `BETTER_AUTH_SECRET`: Generate a random string (e.g., via `openssl rand -base64 32`).
-  - `SITE_URL`: This is the URL where your Next.js app is running. Locally, it's `http://app.teak.localhost:1355`.
+  - `SITE_URL`: This is the URL where your Next.js app is running. Locally, it's `http://localhost:3000`.
   - `TEAK_ADMIN_EMAIL`: The normalized email address of the one account allowed to use administrative functions. Configure this independently for development and production.
 - **Optional Features**:
   - `R2_*`: Create a private Cloudflare R2 bucket and an API token/S3 credentials with object read, write, and delete access.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,7 @@
     "audit": "bun run build:site && blume audit --fail-on error",
     "build": "bun run build:site && blume audit --fail-on error",
     "build:site": "bun run generate:openapi && blume build",
-    "dev": "bun run generate:openapi && PORTLESS_PORT=1355 portless docs.teak blume dev",
+    "dev": "bun run generate:openapi && blume dev --port 3001 --host 127.0.0.1",
     "generate:openapi": "bun run scripts/generate-openapi.ts",
     "lint": "biome check blume.config.ts lib scripts styles vercel.json package.json turbo.json tsconfig.json tsconfig.typecheck.json",
     "preview": "blume preview",

--- a/apps/extension/__tests__/background.test.ts
+++ b/apps/extension/__tests__/background.test.ts
@@ -605,8 +605,7 @@ describe("Background Service Worker", () => {
     });
 
     test("accepts a localhost dev host only in dev builds", () => {
-      const devUrl =
-        "http://app.teak.localhost:1355/native/auth/complete?state=abc";
+      const devUrl = "http://localhost:3000/native/auth/complete?state=abc";
       expect(isAllowedSender(devUrl, true)).toBe(true);
       expect(isAllowedSender(devUrl, false)).toBe(false);
     });

--- a/apps/extension/__tests__/hooks/useAutoSaveUrl.test.ts
+++ b/apps/extension/__tests__/hooks/useAutoSaveUrl.test.ts
@@ -173,7 +173,7 @@ describe("useAutoSaveUrl Hook", () => {
     });
 
     test("should handle localhost URLs", () => {
-      const url = "http://app.teak.localhost:1355";
+      const url = "http://localhost:3000";
 
       const isValid = url.startsWith("http://") || url.startsWith("https://");
 

--- a/apps/extension/__tests__/lib/nativeAuth.test.ts
+++ b/apps/extension/__tests__/lib/nativeAuth.test.ts
@@ -233,8 +233,8 @@ describe("nativeAuth session lifecycle", () => {
     await signOut();
 
     const [calledUrl, init] = fetchMock.mock.calls[0];
-    // Sign-out hits the Convex site URL directly (avoids the http->https
-    // redirect that would strip the bearer header).
+    // Sign-out hits the Convex site URL directly (no redirect in between to
+    // strip the bearer header).
     expect(calledUrl).toBe(
       "https://test-deployment.convex.site/api/auth/sign-out"
     );

--- a/apps/extension/entrypoints/native-auth-complete.content.ts
+++ b/apps/extension/entrypoints/native-auth-complete.content.ts
@@ -5,17 +5,16 @@ const COMPLETE_PATHNAME = "/native/auth/complete";
 
 // Match patterns ignore ports, and `import.meta.env.DEV` is a build-time
 // constant (WXT executes this module to read the config), so production ships
-// only the exact prod pattern while dev also matches the local app host. The
-// `*://` scheme covers both http and the https that portless serves locally
-// (the app upgrades http->https), and the runtime pathname guard in main()
-// scopes the dev host pattern to the completion page.
+// only the exact prod pattern while dev also matches the local app host. Local
+// dev serves plain http with no upgrade, and the runtime pathname guard in
+// main() scopes the dev host pattern to the completion page.
 const buildMatches = (): string[] => {
   const prodPattern = "https://app.teakvault.com/native/auth/complete*";
   if (!import.meta.env.DEV) {
     return [prodPattern];
   }
   const devHost = new URL(resolveTeakDevAppUrl(import.meta.env)).hostname;
-  return [prodPattern, `*://${devHost}/*`];
+  return [prodPattern, `http://${devHost}/*`];
 };
 
 export default defineContentScript({

--- a/apps/extension/lib/nativeAuth.ts
+++ b/apps/extension/lib/nativeAuth.ts
@@ -34,11 +34,10 @@ export interface PendingNativeAuth {
 export type PollOutcome = "authenticated" | "pending" | "error" | "no-pending";
 
 // Better Auth + native-auth endpoints are hit on the Convex site URL (https),
-// NOT the web app URL. In dev the web app is served over https and force-
-// upgrades http->https; browsers strip the `Authorization: Bearer` header on
-// that cross-scheme redirect, so bearer-authenticated calls to the web app URL
-// silently lose auth. The Convex site is hit directly (no redirect), matching
-// how the desktop and Safari clients call these endpoints.
+// NOT the web app URL. Hitting the site origin directly avoids any redirect in
+// between (a cross-scheme http->https redirect would strip the `Authorization:
+// Bearer` header, so bearer-authenticated calls would silently lose auth),
+// matching how the desktop and Safari clients call these endpoints.
 export const getConvexSiteUrl = (): string => {
   const url = import.meta.env.VITE_PUBLIC_CONVEX_SITE_URL;
   if (!url) {

--- a/apps/raycast/src/__tests__/constants.test.ts
+++ b/apps/raycast/src/__tests__/constants.test.ts
@@ -7,10 +7,10 @@ const loadLocalConstants = () =>
   import(`../lib/constants?local=${crypto.randomUUID()}`);
 
 describe("raycast local constants", () => {
-  test("uses the canonical portless app URL in development", async () => {
+  test("uses the canonical local app URL in development", async () => {
     const { TEAK_DEV_APP_URL, TEAK_SETTINGS_URL } = await loadLocalConstants();
-    expect(TEAK_DEV_APP_URL).toBe("http://app.teak.localhost:1355");
-    expect(TEAK_SETTINGS_URL).toBe("http://app.teak.localhost:1355/settings");
+    expect(TEAK_DEV_APP_URL).toBe("http://localhost:3000");
+    expect(TEAK_SETTINGS_URL).toBe("http://localhost:3000/settings");
   });
 
   test("uses the canonical Convex API URL in development", async () => {
@@ -20,10 +20,10 @@ describe("raycast local constants", () => {
     );
   });
 
-  test("builds local card URLs from the portless app origin", async () => {
+  test("builds local card URLs from the local app origin", async () => {
     const { getTeakCardUrl } = await loadLocalConstants();
     expect(getTeakCardUrl("card_123")).toBe(
-      "http://app.teak.localhost:1355/?card=card_123",
+      "http://localhost:3000/?card=card_123",
     );
   });
 });

--- a/apps/raycast/src/lib/api.ts
+++ b/apps/raycast/src/lib/api.ts
@@ -282,7 +282,6 @@ export const request = async <T>(
     status: response.status,
     statusText: response.statusText,
     url: response.url || requestUrl,
-    xPortless: response.headers.get("x-portless"),
   });
 
   throw new RaycastApiError(code, response.status);

--- a/apps/raycast/src/lib/constants.ts
+++ b/apps/raycast/src/lib/constants.ts
@@ -1,6 +1,6 @@
 import { environment } from "@raycast/api";
 
-const DEFAULT_TEAK_DEV_APP_URL = "http://app.teak.localhost:1355";
+const DEFAULT_TEAK_DEV_APP_URL = "http://localhost:3000";
 // Dev Convex deployment that `convex dev` targets and where the OAuth server
 // (Better Auth `mcp` plugin) and its seeded clients live. The token exchange
 // must reach THIS deployment — see getOAuthTokenBaseUrl. Overridable via
@@ -79,13 +79,12 @@ const resolveDevConvexSiteUrl = (): string => {
 
 // Base origin for the OAuth token exchange (POST `/api/auth/mcp/token`).
 //
-// The token POST must reach Better Auth without crossing a redirecting proxy.
-// In local dev, portless upgrades http -> https with a 302 that Raycast's token
-// fetch (undici, default redirect: "follow") replays as a GET, so the POST 404s
-// and sign-in bounces back. Convex's own site origin serves the same endpoint
-// over publicly-trusted HTTPS with no redirect, so we hit it directly in dev.
-// In production the app origin already serves the token endpoint without any
-// redirect, so it stays there.
+// The token POST must reach Better Auth directly with no redirect in between.
+// (A proxy that upgrades http -> https with a 302 would replay the POST as a
+// GET, so the exchange 404s and sign-in bounces back.) Convex's own site
+// origin serves the same endpoint over publicly-trusted HTTPS with no
+// redirect, so we hit it directly in dev. In production the app origin already
+// serves the token endpoint without any redirect, so it stays there.
 export const getOAuthTokenBaseUrl = (): string =>
   environment.isDevelopment ? resolveDevConvexSiteUrl() : TEAK_APP_URL;
 

--- a/apps/raycast/src/lib/oauth.ts
+++ b/apps/raycast/src/lib/oauth.ts
@@ -10,8 +10,8 @@ import { getAppBaseUrl, getOAuthTokenBaseUrl } from "./constants";
 // `authorize` runs in the browser and must hit the web origin so the session
 // cookie authenticates the request. The `token`/refresh exchange is a
 // server-to-server POST that only needs to reach Better Auth, so it targets the
-// token base URL directly — avoiding the dev-only proxy redirect that would
-// otherwise downgrade the POST to a GET (see getOAuthTokenBaseUrl).
+// token base URL directly with no redirect in between (see
+// getOAuthTokenBaseUrl).
 const authorizeUrl = `${getAppBaseUrl()}/api/auth/mcp/authorize`;
 const tokenUrl = `${getOAuthTokenBaseUrl()}/api/auth/mcp/token`;
 

--- a/apps/safari-extension/Shared (App)/Shared (Core)/TeakSafariService.swift
+++ b/apps/safari-extension/Shared (App)/Shared (Core)/TeakSafariService.swift
@@ -4,7 +4,7 @@ import Foundation
 actor TeakSafariService {
     static let shared = TeakSafariService()
     #if DEBUG
-    static let appBaseURL = URL(string: "http://app.teak.localhost:1355")!
+    static let appBaseURL = URL(string: "http://localhost:3000")!
     private static let siteURL = URL(string: "https://reminiscent-kangaroo-59.convex.site")!
     #else
     static let appBaseURL = URL(string: "https://app.teakvault.com")!

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -57,7 +57,7 @@ export const nextConfig: NextConfig = {
     turbopackFileSystemCacheForBuild: true,
     turbopackRustReactCompiler: true,
   },
-  allowedDevOrigins: ["app.teak.localhost"],
+  allowedDevOrigins: [],
   turbopack: {
     resolveAlias: turbopackSingletonAliases,
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "portless app.teak next dev",
+    "dev": "next dev --port 3000",
     "lint": "biome check .",
     "start": "next start",
     "test": "CLAUDECODE=1 AGENT=1 bun test src/__tests__ --coverage --dots",

--- a/apps/web/src/__tests__/publicAppUrl.test.ts
+++ b/apps/web/src/__tests__/publicAppUrl.test.ts
@@ -5,25 +5,21 @@ import {
 } from "@/lib/public-app-url";
 
 describe("public app URL resolution", () => {
-  test("pins local requests to the public dev app origin", () => {
+  test("pins local requests to the local dev app origin", () => {
     const requestUrl = new URL("http://localhost:4015/login?next=%2Fsettings");
 
-    expect(resolvePublicAppOrigin(requestUrl)).toBe(
-      "http://app.teak.localhost:1355"
-    );
+    expect(resolvePublicAppOrigin(requestUrl)).toBe("http://localhost:3000");
     expect(buildPublicAppUrl("/login", requestUrl).toString()).toBe(
-      "http://app.teak.localhost:1355/login"
+      "http://localhost:3000/login"
     );
   });
 
-  test("preserves HTTPS when Portless terminates TLS", () => {
-    const requestUrl = new URL("https://app.teak.localhost:1355/settings");
+  test("preserves the request protocol for local origins", () => {
+    const requestUrl = new URL("https://localhost:3000/settings");
 
-    expect(resolvePublicAppOrigin(requestUrl)).toBe(
-      "https://app.teak.localhost:1355"
-    );
+    expect(resolvePublicAppOrigin(requestUrl)).toBe("https://localhost:3000");
     expect(buildPublicAppUrl("/login", requestUrl).toString()).toBe(
-      "https://app.teak.localhost:1355/login"
+      "https://localhost:3000/login"
     );
   });
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,6 @@
       "devDependencies": {
         "@biomejs/biome": "2.5.8",
         "lru-cache": "11.5.2",
-        "portless": "0.15.5",
         "simple-git-hooks": "^2.13.1",
         "turbo": "^2.10.9",
         "ultracite": "7.10.4",
@@ -3980,8 +3979,6 @@
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "pony-cause": ["pony-cause@1.1.1", "", {}, "sha512-PxkIc/2ZpLiEzQXu5YRDOUgBlfGYBY8156HY5ZcRAwwonMk5W/MrJP2LLkG/hF7GEQzaHo2aS7ho6ZLCOvf+6g=="],
-
-    "portless": ["portless@0.15.5", "", { "os": [ "linux", "win32", "darwin", ], "bin": { "portless": "dist/cli.js" } }, "sha512-zmJu4Q8/fY54oVUT/5NnmF4Ih8wTdCvCf6JCN783dRYl9mXkJBzXSckX2lztGCLIbM70varDjCudAbGKT73XPg=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 

--- a/docs/agents/headless-development.md
+++ b/docs/agents/headless-development.md
@@ -20,10 +20,11 @@ bun run dev
 Start the web app from `apps/web` in another persistent session:
 
 ```bash
-bunx portless app.teak next dev
+bun run dev
 ```
 
-Use the localhost URL printed by Portless. Do not assume a fixed port.
+The web app serves at the fixed URL `http://localhost:3000`. The port is pinned,
+so every agent and developer shares the same origin.
 
 Create `apps/web/.env.local` from the active Convex deployment values. A local anonymous deployment normally uses:
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.8",
     "lru-cache": "11.5.2",
-    "portless": "0.15.5",
     "simple-git-hooks": "^2.13.1",
     "turbo": "^2.10.9",
     "ultracite": "7.10.4"

--- a/packages/convex/__tests__/dev-urls.test.ts
+++ b/packages/convex/__tests__/dev-urls.test.ts
@@ -35,7 +35,7 @@ describe("dev URL config", () => {
     expect(isLocalDevelopmentHostname("127.0.0.1")).toBe(true);
     expect(isLocalDevelopmentHostname("app.teak.localhost")).toBe(true);
     expect(isLocalDevelopmentHostname("app.teakvault.com")).toBe(false);
-    expect(isLocalDevelopmentUrl("http://app.teak.localhost:1355")).toBe(true);
+    expect(isLocalDevelopmentUrl("http://localhost:3000")).toBe(true);
     expect(isLocalDevelopmentUrl("https://app.teakvault.com")).toBe(false);
   });
 });

--- a/packages/convex/__tests__/oauthSecurity.test.ts
+++ b/packages/convex/__tests__/oauthSecurity.test.ts
@@ -41,7 +41,7 @@ describe("assertAllowedAuthCallbackUrl", () => {
     expect(() =>
       assertAllowedAuthCallbackUrl(
         "exp://192.168.1.4:8081",
-        "http://app.teak.localhost:1355"
+        "http://localhost:3000"
       )
     ).not.toThrow();
   });

--- a/packages/convex/__tests__/trustedOrigins.test.ts
+++ b/packages/convex/__tests__/trustedOrigins.test.ts
@@ -18,11 +18,11 @@ describe("buildTrustedOrigins", () => {
   });
 
   test("local deployments keep Expo wildcards and the local app origin", () => {
-    const origins = buildTrustedOrigins("http://app.teak.localhost:1355", {
-      TEAK_DEV_APP_URL: "http://app.teak.localhost:1355",
+    const origins = buildTrustedOrigins("http://localhost:3000", {
+      TEAK_DEV_APP_URL: "http://localhost:3000",
     });
 
-    expect(origins).toContain("http://app.teak.localhost:1355");
+    expect(origins).toContain("http://localhost:3000");
     expect(origins).toContain("http://localhost:1420");
     expect(origins).toContain("exp+teak://*");
     expect(origins).toContain(EXACT_TEAK_CALLBACK_URL);

--- a/packages/convex/auth.ts
+++ b/packages/convex/auth.ts
@@ -63,7 +63,7 @@ const siteUrl = process.env.SITE_URL;
 if (!siteUrl) {
   throw new Error(
     "SITE_URL environment variable is required. " +
-      "Run: bunx convex env set SITE_URL http://app.teak.localhost:1355"
+      "Run: bunx convex env set SITE_URL http://localhost:3000"
   );
 }
 let usesSecureCookies: boolean;
@@ -72,7 +72,7 @@ try {
 } catch {
   throw new Error(
     `SITE_URL environment variable is not a valid URL (received: "${siteUrl}"). ` +
-      "Example: http://app.teak.localhost:1355"
+      "Example: http://localhost:3000"
   );
 }
 const APPLE_CLIENT_SECRET_TTL_SECONDS = 180 * 24 * 60 * 60;

--- a/packages/convex/devUrls.ts
+++ b/packages/convex/devUrls.ts
@@ -1,8 +1,8 @@
-export const DEFAULT_TEAK_DEV_APP_URL = "http://app.teak.localhost:1355";
+export const DEFAULT_TEAK_DEV_APP_URL = "http://localhost:3000";
 export const DEFAULT_TEAK_DEV_CONVEX_SITE_URL =
   "https://reminiscent-kangaroo-59.convex.site";
 export const DEFAULT_TEAK_DEV_API_URL = DEFAULT_TEAK_DEV_CONVEX_SITE_URL;
-export const DEFAULT_TEAK_DEV_DOCS_URL = "http://docs.teak.localhost:1355";
+export const DEFAULT_TEAK_DEV_DOCS_URL = "http://localhost:3001";
 
 export interface DevUrlEnv {
   TEAK_DEV_API_URL?: unknown;

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -27,7 +27,7 @@
   "types": "./index.ts",
   "scripts": {
     "dev": "convex dev",
-    "test": "export GOOGLE_CLIENT_ID=test GOOGLE_CLIENT_SECRET=test SITE_URL=http://app.teak.localhost:1355; bun test __tests__ --coverage --dots && vitest run --config vitest.config.ts",
+    "test": "export GOOGLE_CLIENT_ID=test GOOGLE_CLIENT_SECRET=test SITE_URL=http://localhost:3000; bun test __tests__ --coverage --dots && vitest run --config vitest.config.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/convex/safariOAuth.test.ts
+++ b/packages/convex/safariOAuth.test.ts
@@ -13,7 +13,7 @@ const accessToken = "a".repeat(32);
 const refreshToken = "r".repeat(32);
 
 beforeEach(() => {
-  vi.stubEnv("SITE_URL", "http://app.teak.localhost:1355");
+  vi.stubEnv("SITE_URL", "http://localhost:3000");
   vi.stubEnv("GOOGLE_CLIENT_ID", "test");
   vi.stubEnv("GOOGLE_CLIENT_SECRET", "test");
   vi.stubEnv("APPLE_CLIENT_ID", "test-client");


### PR DESCRIPTION
Removes the portless reverse proxy and makes local dev deterministic:

- Web serves at fixed `http://localhost:3000` (`next dev --port 3000`)
- Docs/API/MCP serve at fixed `http://localhost:3001` (`blume dev --port 3001`)
- Drops the http->https upgrade workarounds in Raycast (`x-portless` logging, split token base URL comment) and extension auth paths (explicit `http://` content-script match)
- Syncs all dev URL defaults (`@teak/convex` dev-urls, Raycast constants, Safari DEBUG URL), tests, and docs (development, self-hosting, API, MCP, headless-development)
- Convex dev deployment env updated separately: `SITE_URL` and `TEAK_DEV_APP_URL` now `http://localhost:3000`

Verified: full test suite 12/12, full build 7/7, typecheck 12/12, lint clean, and both dev servers return 200 on their pinned ports with the docs→Convex API/MCP proxy responding correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Local web development now runs directly at `http://localhost:3000`.
  - Local documentation, API, and MCP services now use port `3001`.

- **Documentation**
  - Updated development, API, MCP, self-hosting, and headless development guides with the new local URLs.

- **Bug Fixes**
  - Local browser extension matching now targets plain HTTP development pages only.

- **Chores**
  - Removed the Portless development setup and updated related defaults and tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->