### PR TITLE
Enforce immediate session and token revocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ apps/mobile/build-*.ipa
 todo/
 .pi/
 .blume/
+.wxt/

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -12,12 +12,12 @@ import { addCard, readStdin } from "./files";
 import { formatCardLine, formatDetail } from "./format";
 import {
   type ClientOptions,
-  clearCredentials,
   client,
   EXIT,
   exitCodeFor,
   type GlobalOptions,
   login,
+  logout,
   readCredentials,
   readJson,
   VERSION,
@@ -192,8 +192,8 @@ program
     write(await login({ ...program.opts(), ...options }), program.opts())
   );
 
-program.command("logout").action(() => {
-  clearCredentials();
+program.command("logout").action(async () => {
+  await logout(program.opts());
   write("Logged out of Teak.", program.opts());
 });
 

--- a/apps/cli/src/logout.test.ts
+++ b/apps/cli/src/logout.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { env, serve, spawn } from "bun";
+
+const directory = mkdtempSync(join(tmpdir(), "teak-logout-"));
+mkdirSync(join(directory, "teak"));
+writeFileSync(join(directory, "security"), "#!/bin/sh\nexit 1\n", {
+  mode: 0o700,
+});
+const credentialsPath = join(directory, "teak/credentials.json");
+let responseStatus = 200;
+let received: URLSearchParams | null = null;
+const server = serve({
+  port: 0,
+  async fetch(request) {
+    expect(new URL(request.url).pathname).toBe("/api/oauth/revoke");
+    expect(request.method).toBe("POST");
+    received = new URLSearchParams(await request.text());
+    return new Response(null, { status: responseStatus });
+  },
+});
+afterAll(() => server.stop());
+
+const runLogout = async (authUrl = server.url.toString()) => {
+  const child = spawn([process.execPath, "run", "src/index.ts", "logout"], {
+    cwd: new URL("..", import.meta.url).pathname,
+    env: {
+      ...env,
+      PATH: `${directory}:${env.PATH}`,
+      XDG_CONFIG_HOME: directory,
+      TEAK_API_URL: authUrl,
+      TEAK_API_KEY: "api-key-must-not-be-revoked",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    code: await child.exited,
+    stdout: await new Response(child.stdout).text(),
+    stderr: await new Response(child.stderr).text(),
+  };
+};
+
+describe("CLI logout", () => {
+  test("revokes this installation before clearing local credentials", async () => {
+    writeFileSync(
+      credentialsPath,
+      JSON.stringify({
+        accessToken: "access",
+        refreshToken: "refresh",
+        expiresAt: 0,
+      })
+    );
+    const result = await runLogout();
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Logged out");
+    expect(received?.get("client_id")).toBe("teak-cli");
+    expect(received?.get("token")).toBe("refresh");
+    expect(readFileSync(credentialsPath, "utf8")).toBe("");
+  });
+
+  test("keeps credentials for retry after a server failure", async () => {
+    const credentials = JSON.stringify({
+      accessToken: "access",
+      refreshToken: "refresh",
+      expiresAt: 0,
+    });
+    writeFileSync(credentialsPath, credentials);
+    responseStatus = 503;
+    const result = await runLogout();
+    responseStatus = 200;
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("run teak logout again");
+    expect(readFileSync(credentialsPath, "utf8")).toBe(credentials);
+  });
+
+  test("keeps credentials for retry when offline", async () => {
+    const credentials = readFileSync(credentialsPath, "utf8");
+    const result = await runLogout("http://127.0.0.1:1");
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("credentials are still saved");
+    expect(readFileSync(credentialsPath, "utf8")).toBe(credentials);
+  });
+
+  test("supports access-token-only and already disconnected sessions", async () => {
+    writeFileSync(credentialsPath, JSON.stringify({ accessToken: "access" }));
+    expect((await runLogout()).code).toBe(0);
+    expect(received?.get("token")).toBe("access");
+    received = null;
+    expect((await runLogout()).code).toBe(0);
+    expect(received).toBeNull();
+  });
+});

--- a/apps/cli/src/runtime.ts
+++ b/apps/cli/src/runtime.ts
@@ -160,6 +160,30 @@ const tokenEndpoint = (options: ClientOptions) =>
 const authorizeEndpoint = (options: ClientOptions) =>
   `${authBaseUrl(options)}/api/auth/mcp/authorize`;
 
+export const logout = async (options: ClientOptions = {}) => {
+  const credentials = readCredentials();
+  const token = credentials?.refreshToken || credentials?.accessToken;
+  if (token) {
+    try {
+      const response = await fetch(`${apiBaseUrl(options)}/api/oauth/revoke`, {
+        body: new URLSearchParams({ client_id: "teak-cli", token }),
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        method: "POST",
+        redirect: "error",
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) {
+        throw new Error("Revocation failed");
+      }
+    } catch {
+      throw new Error(
+        "Could not disconnect Teak CLI. Your credentials are still saved. Check your connection and run teak logout again."
+      );
+    }
+  }
+  clearCredentials();
+};
+
 const exchangeToken = async (
   options: ClientOptions,
   body: Record<string, string>

--- a/apps/desktop/src/__tests__/nativeSessionLogout.test.ts
+++ b/apps/desktop/src/__tests__/nativeSessionLogout.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { createContext, runInContext } from "node:vm";
+import { Transpiler } from "bun";
+
+function fixture(response: Response | Error) {
+  const values = new Map<string, unknown>([
+    ["auth.sessionToken", "device-token"],
+  ]);
+  const requests: RequestInit[] = [];
+  let cancelled = false;
+  const source = readFileSync(
+    new URL("../lib/native-auth.ts", import.meta.url),
+    "utf8"
+  )
+    .replace(/^import .*;\n/gm, "")
+    .replace(/export /g, "");
+  const context = createContext({
+    getDesktopConfig: () => ({ convexSiteBaseUrl: "https://auth.test" }),
+    fetch: (url: string, options: RequestInit) => {
+      expect(url).toBe("https://auth.test/api/auth/sign-out");
+      requests.push(options);
+      if (response instanceof Error) {
+        return Promise.reject(response);
+      }
+      return Promise.resolve(response);
+    },
+    window: {
+      teakDesktop: {
+        store: {
+          read: async (key: string) => values.get(key),
+          write: (key: string, value: unknown) => {
+            values.set(key, value);
+            return Promise.resolve();
+          },
+        },
+        oauth: {
+          cancel: () => {
+            cancelled = true;
+            return Promise.resolve();
+          },
+        },
+      },
+    },
+  });
+  runInContext(new Transpiler({ loader: "ts" }).transformSync(source), context);
+  return {
+    values,
+    requests,
+    cancelled: () => cancelled,
+    logout: () =>
+      runInContext("logoutNativeSession()", context) as Promise<void>,
+  };
+}
+
+describe("desktop device logout", () => {
+  test("revokes only the dedicated bearer session before clearing local state", async () => {
+    const app = fixture(new Response('{"success":true}'));
+    await app.logout();
+    expect(app.requests).toEqual([
+      {
+        method: "POST",
+        credentials: "omit",
+        headers: {
+          Authorization: "Bearer device-token",
+          "Content-Type": "application/json",
+        },
+        body: "{}",
+      },
+    ]);
+    expect(app.values.get("auth.sessionToken")).toBeNull();
+    expect(app.values.get("auth.pendingNativeFlow")).toBeNull();
+    expect(app.cancelled()).toBe(true);
+  });
+  for (const failure of [
+    new Response("", { status: 503 }),
+    new Error("offline"),
+  ]) {
+    test(`preserves credentials for retry on ${failure instanceof Error ? "network failure" : "server failure"}`, async () => {
+      const app = fixture(failure);
+      await expect(app.logout()).rejects.toThrow();
+      expect(app.values.get("auth.sessionToken")).toBe("device-token");
+      expect(app.cancelled()).toBe(false);
+    });
+  }
+});

--- a/apps/desktop/src/lib/native-auth.ts
+++ b/apps/desktop/src/lib/native-auth.ts
@@ -413,22 +413,28 @@ async function fetchConvexJwt(
 
 // ── Logout ─────────────────────────────────────────────────────────────────────
 
-/**
- * Sign out of the desktop app only. This is deliberately local: it clears the
- * dedicated desktop session token, the cached Convex JWT, and any pending OAuth
- * state, but does NOT call the global Better Auth `/sign-out` endpoint. Hitting
- * that endpoint would tear down the shared Better Auth session and could sign
- * the user out of Teak in their browser too. The desktop session is a separate,
- * short-lived server session that expires on its own; dropping the token here
- * makes it unusable from this machine.
- */
+/** Revoke this dedicated device session before discarding its credentials. */
 export async function logoutNativeSession(): Promise<void> {
-  // Invalidate any in-flight OAuth attempt so a callback still exchanging a
-  // code cannot write a fresh session back after the user signs out (see the
-  // attempt guard in completeDesktopOAuth).
   liveOAuthAttempt = null;
+  await ensureInitialized();
+  const sessionToken = getSnapshot().sessionToken;
+  if (sessionToken) {
+    const response = await fetch(`${convexSiteBaseUrl}/api/auth/sign-out`, {
+      method: "POST",
+      credentials: "omit",
+      headers: {
+        Authorization: `Bearer ${sessionToken}`,
+        "Content-Type": "application/json",
+      },
+      body: "{}",
+    });
+    if (!response.ok) {
+      throw new Error("Could not sign out of Teak. Please try again.");
+    }
+  }
   await clearNativeSessionToken();
   await writeStoreValue(PENDING_AUTH_KEY, null);
+  await window.teakDesktop.oauth.cancel();
 }
 
 // ── React hook for ConvexProviderWithAuth ──────────────────────────────────────

--- a/apps/docs/content/changelog/2026-09-08.mdx
+++ b/apps/docs/content/changelog/2026-09-08.mdx
@@ -1,0 +1,12 @@
+---
+title: "More reliable sign-out and app connections"
+description: Revoked devices and apps lose access immediately.
+type: changelog
+date: "2026-09-08"
+changelog:
+  category: Improvements
+---
+
+- Signing out a device in Security now immediately stops it from reading or saving cards.
+- Signing out of desktop, CLI, or Raycast revokes that installation's access. If sign-out fails, you can retry without losing the saved credentials.
+- Disconnecting an app or revoking an API key immediately stops its MCP access, including existing connections.

--- a/apps/docs/content/docs/(apps)/cli.mdx
+++ b/apps/docs/content/docs/(apps)/cli.mdx
@@ -52,7 +52,11 @@ After installing globally, the `teak` command is available on your PATH.
 teak logout
 ```
 
-`teak logout` removes stored credentials from your machine.
+`teak logout` revokes this installation's browser sign-in before removing stored
+credentials from your machine. If Teak cannot be reached, credentials stay saved
+so you can retry. Other CLI installations remain connected. To disconnect them
+all, use **Settings → Security → Connections**. API keys remain managed under
+**Security → API keys**.
 To invalidate the CLI credentials on the server as well, disconnect **Teak CLI**
 from Teak Settings → **Connected apps**.
 

--- a/apps/docs/content/docs/(apps)/cli.mdx
+++ b/apps/docs/content/docs/(apps)/cli.mdx
@@ -57,8 +57,6 @@ credentials from your machine. If Teak cannot be reached, credentials stay saved
 so you can retry. Other CLI installations remain connected. To disconnect them
 all, use **Settings → Security → Connections**. API keys remain managed under
 **Security → API keys**.
-To invalidate the CLI credentials on the server as well, disconnect **Teak CLI**
-from Teak Settings → **Connected apps**.
 
 ## Commands
 

--- a/apps/docs/content/docs/(apps)/raycast.mdx
+++ b/apps/docs/content/docs/(apps)/raycast.mdx
@@ -56,5 +56,5 @@ AI tools use the same sign-in as the extension — no extra setup required.
 
 ## Security
 
-- Browser sign-in connects Raycast to your Teak account without copying a key. Use **Sign Out** from any command's action panel to disconnect.
+- Browser sign-in connects Raycast to your Teak account without copying a key. Use **Sign Out** from any command's action panel to revoke this installation's access. If Teak cannot be reached, your credentials stay saved so you can retry. To disconnect every Raycast installation, use **Settings → Security → Connections**. API keys remain managed under **Security → API keys**.
 - If you use an API key instead, it only connects Raycast to your Teak account. You can have up to 10 active keys. Revoke, regenerate, or revoke all keys from Teak Settings.

--- a/apps/docs/content/docs/(developers)/mcp.mdx
+++ b/apps/docs/content/docs/(developers)/mcp.mdx
@@ -27,7 +27,7 @@ Teak's MCP server supports two authentication methods.
 
     Start the MCP connection, then complete the browser sign-in when prompted.
 
-    You can revoke a connection at any time from Teak Settings → **Connected apps**. Revocation immediately invalidates that app's access and refresh credentials.
+    You can revoke a connection at any time from Teak Settings → **Security** → **Connections**. Disconnecting an app revokes its access across all installations, including its refresh credentials. Every subsequent MCP request checks access again, even in an already-open client. API-key connections are managed under **Security** → **API keys**.
 
     <Prompt
       description="Connect Claude Code to Teak MCP with browser sign-in."

--- a/apps/extension/__tests__/lib/oauthAuth.test.ts
+++ b/apps/extension/__tests__/lib/oauthAuth.test.ts
@@ -12,6 +12,7 @@ let webAuth: ReturnType<typeof mock>;
 let setAccessLevel: ReturnType<typeof mock>;
 
 beforeEach(() => {
+  process.env.BROWSER = "chrome";
   process.env.VITE_PUBLIC_CONVEX_SITE_URL = "https://test.convex.site";
   storage = {};
   let tail: Promise<unknown> = Promise.resolve();
@@ -122,6 +123,31 @@ describe("Chrome OAuth background credentials", () => {
     });
     expect(JSON.stringify(state)).not.toContain(accessToken);
     expect(JSON.stringify(state)).not.toContain(refreshToken);
+  });
+  test("Firefox initializes without exposing credentials through unsupported storage access controls", async () => {
+    process.env.BROWSER = "firefox";
+    Reflect.deleteProperty(chrome.storage.local, "setAccessLevel");
+    const auth = await load();
+    await expect(auth.initializeAuth()).resolves.toBeUndefined();
+    expect(storage[tokenKey]).toBeUndefined();
+  });
+  test("Firefox uses its registered client and native redirect URI", async () => {
+    process.env.BROWSER = "firefox";
+    Reflect.deleteProperty(chrome.storage.local, "setAccessLevel");
+    const redirect =
+      "https://810ad09f1a9233882b69a56ac05bd31b93aad88b.extensions.allizom.org/oauth/callback";
+    chrome.identity.getRedirectURL = () => redirect;
+    webAuth.mockImplementation(({ url }: { url: string }) => {
+      const authorize = new URL(url);
+      expect(authorize.searchParams.get("client_id")).toBe("teak-firefox");
+      expect(authorize.searchParams.get("redirect_uri")).toBe(redirect);
+      return Promise.resolve(`${redirect}?state=wrong&code=code`);
+    });
+    const fetchMock = mock(async () => tokenResponse());
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    await expect((await load()).beginOAuthSignIn()).rejects.toThrow("verified");
+    expect(webAuth).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
   test("rejects a mismatched state without exchanging the code", async () => {
     webAuth.mockResolvedValue(

--- a/apps/extension/lib/oauthAuth.ts
+++ b/apps/extension/lib/oauthAuth.ts
@@ -1,7 +1,8 @@
 import { resolveTeakDevAppUrl } from "@teak/convex/dev-urls";
 
 // Background-worker only. Never import this module from popup/content scripts.
-const CLIENT_ID = "teak-chrome";
+const IS_FIREFOX = import.meta.env.BROWSER === "firefox";
+const CLIENT_ID = IS_FIREFOX ? "teak-firefox" : "teak-chrome";
 const TOKEN_KEY = "teakOAuthCredentials";
 const OWNER_KEY = "teakOAuthOwner";
 export const AUTH_STATE_KEY = "teakOAuthState";
@@ -24,24 +25,56 @@ export function getConvexSiteUrl() {
 }
 
 export function initializeAuth() {
-  ready ??= chrome.storage.local
-    .setAccessLevel({ accessLevel: "TRUSTED_CONTEXTS" })
-    .then(async () => {
-      // The previous dedicated session is deliberately not exchanged. Updating
-      // requires one OAuth reconnect; shared native-session infrastructure stays intact.
-      await chrome.storage.local.remove([
-        "teakSessionToken",
-        "teakPendingNativeAuth",
-      ]);
-    });
+  ready ??= (
+    IS_FIREFOX
+      ? Promise.resolve()
+      : chrome.storage.local.setAccessLevel({ accessLevel: "TRUSTED_CONTEXTS" })
+  ).then(async () => {
+    // The previous dedicated session is deliberately not exchanged. Updating
+    // requires one OAuth reconnect; shared native-session infrastructure stays intact.
+    await chrome.storage.local.remove([
+      "teakSessionToken",
+      "teakPendingNativeAuth",
+    ]);
+  });
   return ready;
+}
+
+// Firefox cannot restrict storage.local to trusted extension contexts. Its
+// extension-origin IndexedDB is inaccessible to page content scripts and durable
+// across background-page restarts. Chromium keeps its existing protected storage.
+async function firefoxCredentials<T>(
+  mode: IDBTransactionMode,
+  operation: (store: IDBObjectStore) => IDBRequest<T>
+): Promise<T> {
+  const database = await new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open("teak-oauth", 1);
+    request.onupgradeneeded = () =>
+      request.result.createObjectStore("credentials");
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+  try {
+    return await new Promise<T>((resolve, reject) => {
+      const transaction = database.transaction("credentials", mode);
+      const request = operation(transaction.objectStore("credentials"));
+      transaction.oncomplete = () => resolve(request.result);
+      transaction.onerror = () => reject(transaction.error);
+      transaction.onabort = () =>
+        reject(transaction.error ?? new Error("Could not store sign-in."));
+    });
+  } finally {
+    database.close();
+  }
 }
 
 async function readCredentials(): Promise<Credentials | null> {
   await initializeAuth();
-  const record = (await chrome.storage.local.get(TOKEN_KEY))[TOKEN_KEY] as
-    | Partial<Credentials>
-    | undefined;
+  const record = (
+    IS_FIREFOX
+      ? await firefoxCredentials("readonly", (store) => store.get(TOKEN_KEY))
+      : (await chrome.storage.local.get(TOKEN_KEY))[TOKEN_KEY]
+  ) as Partial<Credentials> | undefined;
   return record &&
     typeof record.accessToken === "string" &&
     typeof record.refreshToken === "string" &&
@@ -52,10 +85,17 @@ async function readCredentials(): Promise<Credentials | null> {
 
 async function writeCredentials(credentials: Credentials | null) {
   if (credentials) {
+    if (IS_FIREFOX) {
+      await firefoxCredentials("readwrite", (store) =>
+        store.put(credentials, TOKEN_KEY)
+      );
+    }
     await chrome.storage.local.set({
-      [TOKEN_KEY]: credentials,
+      ...(IS_FIREFOX ? {} : { [TOKEN_KEY]: credentials }),
       ...(credentials.userId ? { [OWNER_KEY]: credentials.userId } : {}),
     });
+  } else if (IS_FIREFOX) {
+    await firefoxCredentials("readwrite", (store) => store.delete(TOKEN_KEY));
   } else {
     await chrome.storage.local.remove(TOKEN_KEY);
   }

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from "wxt";
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   modules: ["@wxt-dev/module-react"],
+  manifestVersion: 3,
   manifest: {
     name: "Teak",
     description:
@@ -14,6 +15,9 @@ export default defineConfig({
       email: "hi@praveenjuge.com",
     },
     homepage_url: "https://teakvault.com",
+    browser_specific_settings: {
+      gecko: { id: "teak@teakvault.com", strict_min_version: "140.0" },
+    },
     permissions: [
       "identity",
       "storage",

--- a/apps/raycast/src/__tests__/request.test.ts
+++ b/apps/raycast/src/__tests__/request.test.ts
@@ -5,7 +5,9 @@ import { createRaycastApiMock } from "./raycastApiMock";
 const getPreferenceValuesMock = mock(() => ({ apiKey: "valid-test-key" }));
 const authorizeMock = mock(() => Promise.resolve("oauth-access-token"));
 const removeTokensMock = mock(() => Promise.resolve());
-const getTokensMock = mock(() => Promise.resolve(undefined));
+const getTokensMock = mock<
+  () => Promise<{ accessToken: string; refreshToken?: string } | undefined>
+>(() => Promise.resolve(undefined));
 
 const mockRaycastApi = (isDevelopment: boolean) => {
   mock.module("@raycast/api", () =>
@@ -36,6 +38,8 @@ const {
   softDeleteCard,
   updateCard,
 } = await import("../lib/api");
+const { signOutTeak, authorizeTeak, getStoredTeakAccessToken } =
+  await import("../lib/oauth");
 
 const sampleCard = {
   appUrl: "https://app.teakvault.com/?card=card_123",
@@ -428,5 +432,84 @@ describe("raycast request handling", () => {
 
     expect(removeTokensMock).toHaveBeenCalledTimes(1);
     expect(seenTokens).toEqual(["Bearer stale-token", "Bearer fresh-token"]);
+  });
+});
+
+describe("Raycast sign out", () => {
+  test("revokes the installation before removing its tokens", async () => {
+    getTokensMock.mockResolvedValueOnce({
+      accessToken: "access",
+      refreshToken: "refresh",
+    });
+    globalThis.fetch = mock((input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe("https://teakvault.com/api/api/oauth/revoke");
+      expect(init?.method).toBe("POST");
+      expect(new URLSearchParams(String(init?.body)).get("token")).toBe(
+        "refresh",
+      );
+      expect(new URLSearchParams(String(init?.body)).get("client_id")).toBe(
+        "teak-raycast",
+      );
+      expect(removeTokensMock).not.toHaveBeenCalled();
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as unknown as typeof fetch;
+    await signOutTeak();
+    expect(removeTokensMock).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(["offline", "server"])(
+    "preserves tokens on %s failure",
+    async (failure) => {
+      getTokensMock.mockResolvedValueOnce({
+        accessToken: "access",
+        refreshToken: "refresh",
+      });
+      globalThis.fetch = mock(() => {
+        if (failure === "offline") {
+          throw new Error("offline");
+        }
+        return Promise.resolve(new Response(null, { status: 503 }));
+      }) as unknown as typeof fetch;
+      await expect(signOutTeak()).rejects.toThrow("try Sign Out again");
+      expect(removeTokensMock).not.toHaveBeenCalled();
+    },
+  );
+
+  test("waits for a running authorization and blocks refresh while signing out", async () => {
+    let finishAuthorization: (token: string) => void = () => {};
+    authorizeMock.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          finishAuthorization = resolve;
+        }),
+    );
+    const authorization = authorizeTeak();
+    const signOut = signOutTeak();
+    await expect(authorizeTeak()).rejects.toThrow("sign-out is in progress");
+    expect(await getStoredTeakAccessToken()).toBeNull();
+    expect(getTokensMock).not.toHaveBeenCalled();
+    getTokensMock.mockResolvedValueOnce({
+      accessToken: "fresh-access",
+      refreshToken: "fresh-refresh",
+    });
+    globalThis.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(new URLSearchParams(String(init?.body)).get("token")).toBe(
+        "fresh-refresh",
+      );
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as unknown as typeof fetch;
+    finishAuthorization("fresh-access");
+    await authorization;
+    await signOut;
+    expect(removeTokensMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("handles an already-cleared session without revoking an API key", async () => {
+    getTokensMock.mockResolvedValueOnce(undefined);
+    const fetchMock = mock();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    await signOutTeak();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(removeTokensMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/raycast/src/components/SignOutAction.tsx
+++ b/apps/raycast/src/components/SignOutAction.tsx
@@ -1,5 +1,5 @@
 import { Action, Icon, showToast, Toast } from "@raycast/api";
-import { teakOAuth } from "../lib/oauth";
+import { signOutTeak } from "../lib/oauth";
 import { getPreferences } from "../lib/preferences";
 
 interface SignOutActionProps {
@@ -17,7 +17,16 @@ export function SignOutAction({ onSignedOut }: SignOutActionProps) {
     <Action
       icon={Icon.Logout}
       onAction={async () => {
-        await teakOAuth.client.removeTokens();
+        try {
+          await signOutTeak();
+        } catch (error) {
+          await showToast({
+            style: Toast.Style.Failure,
+            title: "Could not sign out of Teak",
+            message: error instanceof Error ? error.message : "Try again.",
+          });
+          return;
+        }
         await showToast({
           style: Toast.Style.Success,
           title: "Signed out of Teak",

--- a/apps/raycast/src/lib/oauth.ts
+++ b/apps/raycast/src/lib/oauth.ts
@@ -1,6 +1,10 @@
 import { OAuth } from "@raycast/api";
 import { OAuthService } from "@raycast/utils";
-import { getAppBaseUrl, getOAuthTokenBaseUrl } from "./constants";
+import {
+  getApiBaseUrl,
+  getAppBaseUrl,
+  getOAuthTokenBaseUrl,
+} from "./constants";
 
 // Teak's authorization server (Better Auth `mcp` plugin) exposes the OAuth
 // endpoints on the web origin. `teak-raycast` is registered server-side as a
@@ -40,8 +44,15 @@ export const teakOAuth = new OAuthService({
 // first would fail Raycast's state check against the second ("OAuth state
 // mismatch"). All callers share a single in-flight authorization (one `state`).
 let inFlightAuthorize: Promise<string> | null = null;
+let inFlightStoredToken: Promise<string | null> | null = null;
+let inFlightSignOut: Promise<void> | null = null;
 
 export function authorizeTeak(): Promise<string> {
+  if (inFlightSignOut) {
+    return Promise.reject(
+      new Error("Teak sign-out is in progress. Try again."),
+    );
+  }
   if (!inFlightAuthorize) {
     inFlightAuthorize = teakOAuth.authorize().finally(() => {
       inFlightAuthorize = null;
@@ -53,9 +64,54 @@ export function authorizeTeak(): Promise<string> {
 // Force a brand-new authorization: drop stored tokens and any in-flight guard,
 // then re-authorize. Used after a 401 when the current token is rejected.
 export async function reauthorizeTeak(): Promise<string> {
+  if (inFlightSignOut) {
+    throw new Error("Teak sign-out is in progress. Try again.");
+  }
   await teakOAuth.client.removeTokens();
   inFlightAuthorize = null;
   return authorizeTeak();
+}
+
+export function signOutTeak(): Promise<void> {
+  if (!inFlightSignOut) {
+    inFlightSignOut = revokeStoredSession().finally(() => {
+      inFlightSignOut = null;
+    });
+  }
+  return inFlightSignOut;
+}
+
+async function revokeStoredSession(): Promise<void> {
+  // A refresh may rotate both credentials. Revoke its final stored result,
+  // and prevent new authorizations from restoring tokens after sign-out.
+  await Promise.allSettled([inFlightAuthorize, inFlightStoredToken]);
+  const tokenSet = await teakOAuth.client.getTokens();
+  const token = tokenSet?.refreshToken || tokenSet?.accessToken;
+  if (token) {
+    try {
+      const response = await fetch(
+        `${getApiBaseUrl().replace(/\/v1$/, "")}/api/oauth/revoke`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({
+            client_id: "teak-raycast",
+            token,
+          }).toString(),
+          redirect: "error",
+          signal: AbortSignal.timeout(10_000),
+        },
+      );
+      if (!response.ok) {
+        throw new Error("Revocation failed");
+      }
+    } catch {
+      throw new Error(
+        "Your credentials are still saved. Check your connection and try Sign Out again.",
+      );
+    }
+  }
+  await teakOAuth.client.removeTokens();
 }
 
 // Non-interactive check for an existing stored session. Unlike authorizeTeak(),
@@ -78,7 +134,19 @@ export async function hasStoredTeakSession(): Promise<boolean> {
 // with the stored refresh token. Returns null when there is no stored token or
 // the refresh fails (stale/revoked) — callers then prompt the user to sign in
 // explicitly rather than popping the browser overlay from a background command.
-export async function getStoredTeakAccessToken(): Promise<string | null> {
+export function getStoredTeakAccessToken(): Promise<string | null> {
+  if (inFlightSignOut) {
+    return Promise.resolve(null);
+  }
+  if (!inFlightStoredToken) {
+    inFlightStoredToken = resolveStoredTeakAccessToken().finally(() => {
+      inFlightStoredToken = null;
+    });
+  }
+  return inFlightStoredToken;
+}
+
+async function resolveStoredTeakAccessToken(): Promise<string | null> {
   const tokenSet = await client.getTokens();
   if (!tokenSet?.accessToken) {
     return null;
@@ -100,6 +168,7 @@ export async function getStoredTeakAccessToken(): Promise<string | null> {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: body.toString(),
+      signal: AbortSignal.timeout(10_000),
     });
     if (!response.ok) {
       return null;

--- a/packages/convex/__tests__/__tests__/getFileUrl.test.ts
+++ b/packages/convex/__tests__/__tests__/getFileUrl.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, mock, test } from "bun:test";
+import { withTestSession } from "../helpers/session.test-utils";
 
 describe("getFileUrl authorization", () => {
   test("rejects a card owned by another user", async () => {
     const { getFileUrl } = await import("../../card/getFileUrl");
     const handler = (getFileUrl as any).handler ?? getFileUrl;
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -13,7 +14,7 @@ describe("getFileUrl authorization", () => {
           fileKey: "users/u2/cards/c1/file",
         }),
       },
-    } as any;
+    } as any);
 
     await expect(
       handler(ctx, { cardId: "c1", key: "users/u2/cards/c1/file" })
@@ -23,7 +24,7 @@ describe("getFileUrl authorization", () => {
   test("rejects a key that the owned card does not reference", async () => {
     const { getFileUrl } = await import("../../card/getFileUrl");
     const handler = (getFileUrl as any).handler ?? getFileUrl;
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -32,7 +33,7 @@ describe("getFileUrl authorization", () => {
           fileKey: "users/u1/cards/c1/file",
         }),
       },
-    } as any;
+    } as any);
 
     await expect(
       handler(ctx, { cardId: "c1", key: "users/u1/cards/c2/file" })

--- a/packages/convex/__tests__/admin.test.ts
+++ b/packages/convex/__tests__/admin.test.ts
@@ -1,6 +1,8 @@
 // @ts-nocheck
+
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { r2MockModuleFactory, r2Mocks } from "./helpers/r2Mock.test-utils";
+import { withTestSession } from "./helpers/session.test-utils";
 
 mock.module("../storage/r2", r2MockModuleFactory);
 
@@ -28,29 +30,29 @@ describe("admin.ts", () => {
 
   describe("getAccess", () => {
     test("returns not allowed when unauthenticated", async () => {
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue(null) },
-      } as any;
+      } as any);
       const handler = (getAccess as any).handler ?? getAccess;
       const result = await handler(ctx, {});
       expect(result).toEqual({ allowed: false });
     });
 
     test("returns not allowed when no configured admin exists", async () => {
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         runQuery: mock().mockResolvedValue({ page: [] }),
-      } as any;
+      } as any);
       const handler = (getAccess as any).handler ?? getAccess;
       const result = await handler(ctx, {});
       expect(result).toEqual({ allowed: false });
     });
 
     test("returns allowed when user matches the configured admin", async () => {
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         runQuery: mock().mockResolvedValue({ page: [{ _id: "u1" }] }),
-      } as any;
+      } as any);
       const handler = (getAccess as any).handler ?? getAccess;
       const result = await handler(ctx, {});
       expect(result).toEqual({ allowed: true });
@@ -70,10 +72,10 @@ describe("admin.ts", () => {
     });
 
     test("returns not allowed when user is not the configured admin", async () => {
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u2" }) },
         runQuery: mock().mockResolvedValue({ page: [{ _id: "u1" }] }),
-      } as any;
+      } as any);
       const handler = (getAccess as any).handler ?? getAccess;
       const result = await handler(ctx, {});
       expect(result).toEqual({ allowed: false });
@@ -81,35 +83,36 @@ describe("admin.ts", () => {
 
     test("fails closed when the admin email is not configured", async () => {
       delete process.env.TEAK_ADMIN_EMAIL;
-      const ctx = {
+      const runQuery = mock();
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
-        runQuery: mock(),
-      } as any;
+        runQuery,
+      } as any);
       const handler = (getAccess as any).handler ?? getAccess;
       const result = await handler(ctx, {});
       expect(result).toEqual({ allowed: false });
-      expect(ctx.runQuery).not.toHaveBeenCalled();
+      expect(runQuery).not.toHaveBeenCalled();
     });
   });
 
   describe("getOverview", () => {
     test("throws when unauthorized", async () => {
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue(null) },
         runQuery: mock().mockResolvedValue({ page: [] }),
-      } as any;
+      } as any);
       const handler = (getOverview as any).handler ?? getOverview;
       await expect(handler(ctx, {})).rejects.toThrow("Unauthorized");
     });
 
     test("returns empty overview when no cards", async () => {
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         runQuery: mock().mockResolvedValue({ page: [{ _id: "u1" }] }),
         db: {
           query: mock().mockReturnValue({ take: mock().mockResolvedValue([]) }),
         },
-      } as any;
+      } as any);
       const handler = (getOverview as any).handler ?? getOverview;
       const result = await handler(ctx, {});
 
@@ -145,7 +148,7 @@ describe("admin.ts", () => {
           metadataStatus: "completed",
         },
       ];
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         runQuery: mock().mockResolvedValue({ page: [{ _id: "u1" }] }),
         db: {
@@ -153,7 +156,7 @@ describe("admin.ts", () => {
             take: mock().mockResolvedValue(cards),
           }),
         },
-      } as any;
+      } as any);
       const handler = (getOverview as any).handler ?? getOverview;
       const result = await handler(ctx, {});
 
@@ -189,7 +192,7 @@ describe("admin.ts", () => {
           createdAt: Date.now(),
         },
       ];
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         runQuery: mock().mockResolvedValue({ page: [{ _id: "u1" }] }),
         db: {
@@ -197,7 +200,7 @@ describe("admin.ts", () => {
             take: mock().mockResolvedValue(cards),
           }),
         },
-      } as any;
+      } as any);
       const handler = (getOverview as any).handler ?? getOverview;
       const result = await handler(ctx, {});
 
@@ -219,7 +222,7 @@ describe("admin.ts", () => {
           createdAt: Date.now(),
         },
       ];
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         runQuery: mock().mockResolvedValue({ page: [{ _id: "u1" }] }),
         db: {
@@ -227,7 +230,7 @@ describe("admin.ts", () => {
             take: mock().mockResolvedValue(cards),
           }),
         },
-      } as any;
+      } as any);
       const handler = (getOverview as any).handler ?? getOverview;
       const result = await handler(ctx, {});
 
@@ -243,7 +246,7 @@ describe("admin.ts", () => {
         userId: "u1",
         createdAt: Date.now(),
       }));
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         runQuery: mock().mockResolvedValue({ page: [{ _id: "u1" }] }),
         db: {
@@ -251,7 +254,7 @@ describe("admin.ts", () => {
             take: mock().mockResolvedValue(cards),
           }),
         },
-      } as any;
+      } as any);
       const handler = (getOverview as any).handler ?? getOverview;
       const result = await handler(ctx, {});
 
@@ -282,7 +285,7 @@ describe("admin.ts", () => {
           createdAt: Date.now(),
         },
       ];
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         runQuery: mock().mockResolvedValue({ page: [{ _id: "u1" }] }),
         db: {
@@ -290,7 +293,7 @@ describe("admin.ts", () => {
             take: mock().mockResolvedValue(cards),
           }),
         },
-      } as any;
+      } as any);
       const handler = (getOverview as any).handler ?? getOverview;
       const result = await handler(ctx, {});
 
@@ -387,12 +390,12 @@ describe("admin.ts", () => {
 
   describe("refreshCardProcessing", () => {
     test("throws when unauthorized", async () => {
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue(null) },
         runQuery: mock().mockResolvedValue({ page: [] }),
         runMutation: mock(),
         scheduler: { runAfter: mock() },
-      } as any;
+      } as any);
       const handler =
         (refreshCardProcessing as any).handler ?? refreshCardProcessing;
       await expect(handler(ctx, { cardId: "c1" })).rejects.toThrow(
@@ -402,7 +405,7 @@ describe("admin.ts", () => {
 
     test("returns not_found when card missing", async () => {
       let callCount = 0;
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         runQuery: mock().mockImplementation(() => {
           callCount++;
@@ -412,7 +415,7 @@ describe("admin.ts", () => {
         }),
         runMutation: mock(),
         scheduler: { runAfter: mock() },
-      } as any;
+      } as any);
       const handler =
         (refreshCardProcessing as any).handler ?? refreshCardProcessing;
       const result = await handler(ctx, { cardId: "c1" });
@@ -424,7 +427,7 @@ describe("admin.ts", () => {
     test("resets processing and schedules workflow", async () => {
       let callCount = 0;
       const card = { _id: "c1" };
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         runQuery: mock().mockImplementation(() => {
           callCount++;
@@ -434,7 +437,7 @@ describe("admin.ts", () => {
         }),
         runMutation: mock().mockResolvedValue({ clearedThumbnail: false }),
         scheduler: { runAfter: mock().mockResolvedValue(null) },
-      } as any;
+      } as any);
       const handler =
         (refreshCardProcessing as any).handler ?? refreshCardProcessing;
       const result = await handler(ctx, { cardId: "c1" });

--- a/packages/convex/__tests__/ai/actions.test.ts
+++ b/packages/convex/__tests__/ai/actions.test.ts
@@ -1,5 +1,7 @@
 // @ts-nocheck
+
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { withTestSession } from "../helpers/session.test-utils";
 
 describe("ai/actions.ts", () => {
   let manuallyGenerateAI: any;
@@ -9,9 +11,9 @@ describe("ai/actions.ts", () => {
   });
 
   test("throws when unauthenticated", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
     const handler = (manuallyGenerateAI as any).handler ?? manuallyGenerateAI;
     await expect(handler(ctx, { cardId: "c1" })).rejects.toThrow(
       "Authentication required"
@@ -19,12 +21,12 @@ describe("ai/actions.ts", () => {
   });
 
   test("schedules workflow when verified", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       runQuery: mock().mockResolvedValue({ exists: true }),
       runMutation: mock().mockResolvedValue(true),
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
     const handler = (manuallyGenerateAI as any).handler ?? manuallyGenerateAI;
     const result = await handler(ctx, { cardId: "c1" });
     expect(result).toEqual({ success: true });
@@ -32,12 +34,12 @@ describe("ai/actions.ts", () => {
   });
 
   test("rejects when the reprocessing limit is exhausted", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       runQuery: mock().mockResolvedValue({ exists: true }),
       runMutation: mock().mockResolvedValue(false),
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
     const handler = (manuallyGenerateAI as any).handler ?? manuallyGenerateAI;
 
     await expect(handler(ctx, { cardId: "c1" })).rejects.toThrow(
@@ -47,10 +49,10 @@ describe("ai/actions.ts", () => {
   });
 
   test("throws when verification fails", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       runQuery: mock().mockResolvedValue(null),
-    } as any;
+    } as any);
     const handler = (manuallyGenerateAI as any).handler ?? manuallyGenerateAI;
     await expect(handler(ctx, { cardId: "c1" })).rejects.toThrow(
       "Card not found or access denied"

--- a/packages/convex/__tests__/authNative.test.ts
+++ b/packages/convex/__tests__/authNative.test.ts
@@ -1,10 +1,12 @@
 // @ts-nocheck
+
 import { describe, expect, mock, test } from "bun:test";
 import {
   consumeNativeAuthByState,
   createNativeAuthCode,
   pollNativeAuthCode,
 } from "../authNative";
+import { withTestSession } from "./helpers/session.test-utils";
 
 const toBase64Url = (bytes: Uint8Array): string =>
   btoa(String.fromCharCode(...bytes))
@@ -25,7 +27,7 @@ const getHandler = (fn: unknown) => (fn as any).handler ?? fn;
 describe("authNative.ts", () => {
   test("creates native auth codes for authenticated users", async () => {
     const insert = mock().mockResolvedValue("native-auth-id");
-    const ctx = {
+    const ctx = withTestSession({
       auth: {
         getUserIdentity: mock().mockResolvedValue({
           subject: "user_123",
@@ -33,7 +35,7 @@ describe("authNative.ts", () => {
         }),
       },
       db: { insert },
-    };
+    });
 
     const result = await getHandler(createNativeAuthCode)(ctx, {
       deviceId: "desktop-device-123456",
@@ -58,7 +60,7 @@ describe("authNative.ts", () => {
 
   test("accepts the browser-extension surface", async () => {
     const insert = mock().mockResolvedValue("native-auth-id");
-    const ctx = {
+    const ctx = withTestSession({
       auth: {
         getUserIdentity: mock().mockResolvedValue({
           subject: "user_123",
@@ -66,7 +68,7 @@ describe("authNative.ts", () => {
         }),
       },
       db: { insert },
-    };
+    });
 
     const result = await getHandler(createNativeAuthCode)(ctx, {
       deviceId: "extension-device-123456",
@@ -83,7 +85,7 @@ describe("authNative.ts", () => {
   });
 
   test("rejects invalid native surfaces", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: {
         getUserIdentity: mock().mockResolvedValue({
           subject: "user_123",
@@ -91,7 +93,7 @@ describe("authNative.ts", () => {
         }),
       },
       db: { insert: mock() },
-    };
+    });
 
     await expect(
       getHandler(createNativeAuthCode)(ctx, {
@@ -104,7 +106,7 @@ describe("authNative.ts", () => {
   });
 
   test("rejects invalid device, state, and code challenge inputs", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: {
         getUserIdentity: mock().mockResolvedValue({
           subject: "user_123",
@@ -112,7 +114,7 @@ describe("authNative.ts", () => {
         }),
       },
       db: { insert: mock() },
-    };
+    });
 
     for (const args of [
       {

--- a/packages/convex/__tests__/card/createCard.test.ts
+++ b/packages/convex/__tests__/card/createCard.test.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { withTestSession } from "../helpers/session.test-utils";
 
 // Set environment variables BEFORE any imports that might load auth.ts
 process.env.SITE_URL = "https://teakvault.com";
@@ -90,10 +91,10 @@ describe("card/createCard.ts", () => {
   });
 
   test("throws when unauthenticated", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mock().mockResolvedValue({ ok: true }),
       auth: { getUserIdentity: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     await expect(
       ((createCard as any).handler ?? createCard)(ctx, { content: "Hello" })
@@ -101,7 +102,7 @@ describe("card/createCard.ts", () => {
   });
 
   test("creates quote card when content is quoted", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mock().mockResolvedValue({ ok: true }),
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -115,7 +116,7 @@ describe("card/createCard.ts", () => {
         insert: mock().mockResolvedValue("c1"),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const handler = (createCard as any).handler ?? createCard;
     const cardId = await handler(ctx, {
@@ -146,7 +147,7 @@ describe("card/createCard.ts", () => {
   });
 
   test("sets metadataStatus pending for link cards", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mock().mockResolvedValue({ ok: true }),
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -160,7 +161,7 @@ describe("card/createCard.ts", () => {
         insert: mock().mockResolvedValue("c2"),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const handler = (createCard as any).handler ?? createCard;
     await handler(ctx, {
@@ -184,7 +185,7 @@ describe("card/createCard.ts", () => {
     // "I read this at https://example.com") should keep a text card. The
     // backend only auto-upgrades URL content to a link when no type is
     // provided, so an explicit type is always honored.
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mock().mockResolvedValue({ ok: true }),
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -198,7 +199,7 @@ describe("card/createCard.ts", () => {
         insert: mock().mockResolvedValue("c_text_url"),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const handler = (createCard as any).handler ?? createCard;
     await handler(ctx, {
@@ -216,7 +217,7 @@ describe("card/createCard.ts", () => {
 
   test("keeps explicit text stable for URLs, quotes, colors, and Markdown", async () => {
     const insert = mock(async () => "c_explicit");
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mock().mockResolvedValue({ ok: true }),
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -229,7 +230,7 @@ describe("card/createCard.ts", () => {
         insert,
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
     const handler = (createCard as any).handler ?? createCard;
     const sources = [
       "https://example.com",
@@ -250,7 +251,7 @@ describe("card/createCard.ts", () => {
   });
 
   test("preserves explicit Markdown text source exactly and enforces UTF-8 bytes", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mock().mockResolvedValue({ ok: true }),
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -262,7 +263,7 @@ describe("card/createCard.ts", () => {
         insert: mock().mockResolvedValue("c_markdown"),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
     const source =
       "\uFEFF  # Heading\r\n- [ ] task\rBody\nhttps://example.com  ";
     const handler = (createCard as any).handler ?? createCard;
@@ -282,7 +283,7 @@ describe("card/createCard.ts", () => {
   });
 
   test("lets the backend upgrade a URL to a link card when type is omitted", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mock().mockResolvedValue({ ok: true }),
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -296,7 +297,7 @@ describe("card/createCard.ts", () => {
         insert: mock().mockResolvedValue("c_link_auto"),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const handler = (createCard as any).handler ?? createCard;
     await handler(ctx, {
@@ -314,7 +315,7 @@ describe("card/createCard.ts", () => {
   });
 
   test("keeps implicit text source exact when content has no URL", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mock().mockResolvedValue({ ok: true }),
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -328,7 +329,7 @@ describe("card/createCard.ts", () => {
         insert: mock().mockResolvedValue("c_text"),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const handler = (createCard as any).handler ?? createCard;
     const content = "\uFEFF  # regular note\r\n\rBody  ";
@@ -346,7 +347,7 @@ describe("card/createCard.ts", () => {
   });
 
   test("rejects unsafe url schemes", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mock().mockResolvedValue({ ok: true }),
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -360,7 +361,7 @@ describe("card/createCard.ts", () => {
         insert: mock().mockResolvedValue("c_unsafe"),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const handler = (createCard as any).handler ?? createCard;
     await expect(
@@ -375,7 +376,7 @@ describe("card/createCard.ts", () => {
   });
 
   test("normalizes failure classes before scheduling telemetry", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mock().mockResolvedValue({ ok: true }),
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -389,7 +390,7 @@ describe("card/createCard.ts", () => {
         insert: mock().mockRejectedValue(new Error("Request timed out")),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const handler = (createCard as any).handler ?? createCard;
     await expect(handler(ctx, { content: "Hello" })).rejects.toThrow(
@@ -406,7 +407,7 @@ describe("card/createCard.ts", () => {
   });
 
   test("builds fileMetadata when fileKey provided", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mock().mockResolvedValue({ ok: true }),
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -419,7 +420,7 @@ describe("card/createCard.ts", () => {
         insert: mock().mockResolvedValue("c3"),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const handler = (createCard as any).handler ?? createCard;
     await handler(ctx, {
@@ -445,7 +446,7 @@ describe("card/createCard.ts", () => {
   });
 
   test("preserves metadata source when provided", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mock().mockResolvedValue({ ok: true }),
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -459,7 +460,7 @@ describe("card/createCard.ts", () => {
         insert: mock().mockResolvedValue("c4"),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const handler = (createCard as any).handler ?? createCard;
     await handler(ctx, {

--- a/packages/convex/__tests__/card/deleteCard.test.ts
+++ b/packages/convex/__tests__/card/deleteCard.test.ts
@@ -1,6 +1,8 @@
 // @ts-nocheck
+
 import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import * as r2Storage from "../../storage/r2";
+import { withTestSession } from "../helpers/session.test-utils";
 
 const deleteObjectMock = spyOn(r2Storage, "deleteObject").mockResolvedValue(
   undefined
@@ -15,9 +17,9 @@ describe("card/deleteCard.ts", () => {
   });
 
   test("throws when unauthenticated", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
     const handler = (permanentDeleteCard as any).handler ?? permanentDeleteCard;
     await expect(handler(ctx, { id: "c1" })).rejects.toThrow(
       "User must be authenticated"
@@ -25,7 +27,7 @@ describe("card/deleteCard.ts", () => {
   });
 
   test("deletes files and card", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -49,7 +51,7 @@ describe("card/deleteCard.ts", () => {
         }),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const handler = (permanentDeleteCard as any).handler ?? permanentDeleteCard;
     await handler(ctx, { id: "c1" });

--- a/packages/convex/__tests__/card/findDuplicateCard.test.ts
+++ b/packages/convex/__tests__/card/findDuplicateCard.test.ts
@@ -1,6 +1,8 @@
 // @ts-nocheck
+
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { r2MockModuleFactory, r2Mocks } from "../helpers/r2Mock.test-utils";
+import { withTestSession } from "../helpers/session.test-utils";
 
 mock.module("../../storage/r2", r2MockModuleFactory);
 
@@ -15,16 +17,16 @@ describe("card/findDuplicateCard.ts", () => {
   });
 
   test("returns null when unauthenticated", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
     const handler = (findDuplicateCard as any).handler ?? findDuplicateCard;
     const result = await handler(ctx, { url: "https://example.com" });
     expect(result).toBeNull();
   });
 
   test("returns null when no duplicate found", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         query: mock().mockReturnValue({
@@ -35,7 +37,7 @@ describe("card/findDuplicateCard.ts", () => {
           }),
         }),
       },
-    } as any;
+    } as any);
 
     const handler = (findDuplicateCard as any).handler ?? findDuplicateCard;
     const result = await handler(ctx, { url: "https://example.com" });
@@ -63,7 +65,7 @@ describe("card/findDuplicateCard.ts", () => {
       key ? `file://${key}` : null
     );
 
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         query: mock().mockReturnValue({
@@ -74,7 +76,7 @@ describe("card/findDuplicateCard.ts", () => {
           }),
         }),
       },
-    } as any;
+    } as any);
 
     const handler = (findDuplicateCard as any).handler ?? findDuplicateCard;
     const result = await handler(ctx, { url: "https://example.com" });
@@ -99,7 +101,7 @@ describe("card/findDuplicateCard.ts", () => {
       url: "https://example.com",
     };
 
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         query: mock().mockReturnValue({
@@ -110,7 +112,7 @@ describe("card/findDuplicateCard.ts", () => {
           }),
         }),
       },
-    } as any;
+    } as any);
 
     const handler = (findDuplicateCard as any).handler ?? findDuplicateCard;
     const result = await handler(ctx, { url: "https://example.com" });
@@ -138,7 +140,7 @@ describe("card/findDuplicateCard.ts", () => {
 
     r2Mocks.resolveObjectUrl.mockResolvedValue("file://f1");
 
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         query: mock().mockReturnValue({
@@ -149,7 +151,7 @@ describe("card/findDuplicateCard.ts", () => {
           }),
         }),
       },
-    } as any;
+    } as any);
 
     const handler = (findDuplicateCard as any).handler ?? findDuplicateCard;
     const result = await handler(ctx, { url: "https://example.com/image.jpg" });
@@ -184,12 +186,12 @@ describe("card/findDuplicateCard.ts", () => {
       }),
     };
 
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         query: mock().mockReturnValue(queryMock),
       },
-    } as any;
+    } as any);
 
     const handler = (findDuplicateCard as any).handler ?? findDuplicateCard;
     await handler(ctx, { url: "https://example.com" });

--- a/packages/convex/__tests__/card/getCard.test.ts
+++ b/packages/convex/__tests__/card/getCard.test.ts
@@ -1,5 +1,7 @@
 // @ts-nocheck
+
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { withTestSession } from "../helpers/session.test-utils";
 
 const resolveObjectUrlMock = mock((key?: string) =>
   Promise.resolve(key ? `file://${key}` : null)
@@ -30,16 +32,16 @@ describe("card/getCard.ts", () => {
   });
 
   test("getCard returns null when unauthenticated", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
     const handler = (getCard as any).handler ?? getCard;
     const result = await handler(ctx, { id: "c1" });
     expect(result).toBeNull();
   });
 
   test("getCard attaches urls and formats quote", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -53,7 +55,7 @@ describe("card/getCard.ts", () => {
           metadata: { linkPreview: { screenshotStorageKey: "s1" } },
         }),
       },
-    } as any;
+    } as any);
 
     const handler = (getCard as any).handler ?? getCard;
     const result = await handler(ctx, { id: "c1" });
@@ -64,7 +66,7 @@ describe("card/getCard.ts", () => {
   });
 
   test("getCardByUrlId returns null for malformed ids", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockImplementation(() => {
@@ -72,7 +74,7 @@ describe("card/getCard.ts", () => {
         }),
       },
       storage: { getUrl: mock() },
-    } as any;
+    } as any);
 
     const handler = (getCardByUrlId as any).handler ?? getCardByUrlId;
     const result = await handler(ctx, { id: "12345" });
@@ -81,7 +83,7 @@ describe("card/getCard.ts", () => {
   });
 
   test("getCard hydrates stored link media and falls back preview image to first attachment", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -111,7 +113,7 @@ describe("card/getCard.ts", () => {
           },
         }),
       },
-    } as any;
+    } as any);
 
     const handler = (getCard as any).handler ?? getCard;
     const result = await handler(ctx, { id: "c1" });
@@ -153,10 +155,10 @@ describe("card/getCard.ts", () => {
         content: "Hi",
       },
     ];
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: { query: mock().mockReturnValue(buildQuery(cards)) },
-    } as any;
+    } as any);
 
     const handler = (getDeletedCards as any).handler ?? getDeletedCards;
     const result = await handler(ctx, { limit: 1 });

--- a/packages/convex/__tests__/card/getCards.test.ts
+++ b/packages/convex/__tests__/card/getCards.test.ts
@@ -1,5 +1,7 @@
 // @ts-nocheck
+
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { withTestSession } from "../helpers/session.test-utils";
 
 const resolveObjectUrlMock = mock((key?: string) =>
   Promise.resolve(key ? `file://${key}` : null)
@@ -50,9 +52,9 @@ describe("card/getCards.ts", () => {
 
   describe("getCards", () => {
     test("returns empty when unauthenticated", async () => {
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue(null) },
-      } as any;
+      } as any);
       const handler = (getCards as any).handler ?? getCards;
       const result = await handler(ctx, {});
       expect(result).toEqual([]);
@@ -71,10 +73,10 @@ describe("card/getCards.ts", () => {
           metadata: { linkPreview: { screenshotStorageKey: "s1" } },
         },
       ];
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(buildQuery(cards)) },
-      } as any;
+      } as any);
 
       const handler = (getCards as any).handler ?? getCards;
       const result = await handler(ctx, { limit: 1 });
@@ -87,11 +89,11 @@ describe("card/getCards.ts", () => {
     test("uses favorites index when favoritesOnly", async () => {
       const cards: any[] = [];
       const query = buildQuery(cards);
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (getCards as any).handler ?? getCards;
       await handler(ctx, { favoritesOnly: true });
@@ -102,11 +104,11 @@ describe("card/getCards.ts", () => {
     test("uses by_user_type_deleted index when type is specified", async () => {
       const cards: any[] = [];
       const query = buildQuery(cards);
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (getCards as any).handler ?? getCards;
       await handler(ctx, { type: "image" });
@@ -128,11 +130,11 @@ describe("card/getCards.ts", () => {
         }),
       } as any;
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (getCards as any).handler ?? getCards;
       await handler(ctx, {});
@@ -149,11 +151,11 @@ describe("card/getCards.ts", () => {
         withIndex: mock().mockReturnValue({ order: orderMock }),
       } as any;
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (getCards as any).handler ?? getCards;
       await handler(ctx, { limit: 100_000 });
@@ -170,11 +172,11 @@ describe("card/getCards.ts", () => {
         withIndex: mock().mockReturnValue({ order: orderMock }),
       } as any;
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (getCards as any).handler ?? getCards;
       await handler(ctx, { limit: -10 });
@@ -192,10 +194,10 @@ describe("card/getCards.ts", () => {
           metadata: { linkPreview: { imageStorageKey: "img1" } },
         },
       ];
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(buildQuery(cards)) },
-      } as any;
+      } as any);
 
       const handler = (getCards as any).handler ?? getCards;
       const result = await handler(ctx, {});
@@ -229,10 +231,10 @@ describe("card/getCards.ts", () => {
           },
         },
       ];
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(buildQuery(cards)) },
-      } as any;
+      } as any);
 
       const handler = (getCards as any).handler ?? getCards;
       const result = await handler(ctx, {});
@@ -274,11 +276,11 @@ describe("card/getCards.ts", () => {
           fileId: "f1",
         },
       ];
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(buildQuery(cards)) },
         storage: { getUrl: mock().mockResolvedValue(null) },
-      } as any;
+      } as any);
 
       const handler = (getCards as any).handler ?? getCards;
       const result = await handler(ctx, {});
@@ -288,9 +290,9 @@ describe("card/getCards.ts", () => {
 
   describe("searchCards", () => {
     test("returns empty when unauthenticated", async () => {
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue(null) },
-      } as any;
+      } as any);
       const handler = (searchCards as any).handler ?? searchCards;
       const result = await handler(ctx, {});
       expect(result).toEqual([]);
@@ -308,11 +310,11 @@ describe("card/getCards.ts", () => {
       ];
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (searchCards as any).handler ?? searchCards;
       const result = await handler(ctx, { searchQuery: "fav" });
@@ -329,11 +331,11 @@ describe("card/getCards.ts", () => {
       ];
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (searchCards as any).handler ?? searchCards;
       const result = await handler(ctx, { searchQuery: "trash" });
@@ -346,11 +348,11 @@ describe("card/getCards.ts", () => {
       ];
       const query = buildQuery([cards[0], cards[0]]); // Same card twice
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: buildSearchDb(cards, query),
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (searchCards as any).handler ?? searchCards;
       const result = await handler(ctx, { searchQuery: "test" });
@@ -376,11 +378,11 @@ describe("card/getCards.ts", () => {
       ];
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: buildSearchDb(cards, query),
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (searchCards as any).handler ?? searchCards;
       const result = await handler(ctx, {
@@ -410,11 +412,11 @@ describe("card/getCards.ts", () => {
       ];
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: buildSearchDb(cards, query),
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (searchCards as any).handler ?? searchCards;
       const result = await handler(ctx, {
@@ -444,11 +446,11 @@ describe("card/getCards.ts", () => {
       ];
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: buildSearchDb(cards, query),
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (searchCards as any).handler ?? searchCards;
       const result = await handler(ctx, {
@@ -469,11 +471,11 @@ describe("card/getCards.ts", () => {
       }));
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: buildSearchDb(cards, query),
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (searchCards as any).handler ?? searchCards;
       const result = await handler(ctx, { searchQuery: "test", limit: 10 });
@@ -484,11 +486,11 @@ describe("card/getCards.ts", () => {
       const cards: any[] = [];
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (searchCards as any).handler ?? searchCards;
       await handler(ctx, { types: ["image"] });
@@ -504,11 +506,11 @@ describe("card/getCards.ts", () => {
       ];
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (searchCards as any).handler ?? searchCards;
       const result = await handler(ctx, { types: ["image"] });
@@ -519,11 +521,11 @@ describe("card/getCards.ts", () => {
       const cards: any[] = [];
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (searchCards as any).handler ?? searchCards;
       await handler(ctx, {
@@ -560,11 +562,11 @@ describe("card/getCards.ts", () => {
         },
       ];
       const query = buildQuery(cards);
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (searchCards as any).handler ?? searchCards;
       const result = await handler(ctx, {
@@ -580,11 +582,11 @@ describe("card/getCards.ts", () => {
 
     test("throws for invalid hex filters", async () => {
       const query = buildQuery([]);
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler = (searchCards as any).handler ?? searchCards;
       await expect(
@@ -597,9 +599,9 @@ describe("card/getCards.ts", () => {
 
   describe("searchCardsPaginated", () => {
     test("returns empty pagination when unauthenticated", async () => {
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue(null) },
-      } as any;
+      } as any);
       const handler =
         (searchCardsPaginated as any).handler ?? searchCardsPaginated;
       const result = await handler(ctx, {
@@ -620,11 +622,11 @@ describe("card/getCards.ts", () => {
       ];
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler =
         (searchCardsPaginated as any).handler ?? searchCardsPaginated;
@@ -641,11 +643,11 @@ describe("card/getCards.ts", () => {
       ];
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler =
         (searchCardsPaginated as any).handler ?? searchCardsPaginated;
@@ -666,11 +668,11 @@ describe("card/getCards.ts", () => {
       }));
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: buildSearchDb(cards, query),
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler =
         (searchCardsPaginated as any).handler ?? searchCardsPaginated;
@@ -693,11 +695,11 @@ describe("card/getCards.ts", () => {
       ];
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: buildSearchDb(cards, query),
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler =
         (searchCardsPaginated as any).handler ?? searchCardsPaginated;
@@ -721,11 +723,11 @@ describe("card/getCards.ts", () => {
       ];
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: buildSearchDb(cards, query),
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler =
         (searchCardsPaginated as any).handler ?? searchCardsPaginated;
@@ -756,11 +758,11 @@ describe("card/getCards.ts", () => {
       ];
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: buildSearchDb(cards, query),
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler =
         (searchCardsPaginated as any).handler ?? searchCardsPaginated;
@@ -779,11 +781,11 @@ describe("card/getCards.ts", () => {
       ];
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler =
         (searchCardsPaginated as any).handler ?? searchCardsPaginated;
@@ -808,11 +810,11 @@ describe("card/getCards.ts", () => {
         paginate: paginateMock,
       } as any;
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler =
         (searchCardsPaginated as any).handler ?? searchCardsPaginated;
@@ -836,11 +838,11 @@ describe("card/getCards.ts", () => {
       }));
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: buildSearchDb(cards, query),
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler =
         (searchCardsPaginated as any).handler ?? searchCardsPaginated;
@@ -856,11 +858,11 @@ describe("card/getCards.ts", () => {
       const cards: any[] = [];
       const query = buildQuery(cards);
 
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler =
         (searchCardsPaginated as any).handler ?? searchCardsPaginated;
@@ -896,11 +898,11 @@ describe("card/getCards.ts", () => {
         },
       ];
       const query = buildQuery(cards);
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler =
         (searchCardsPaginated as any).handler ?? searchCardsPaginated;
@@ -916,11 +918,11 @@ describe("card/getCards.ts", () => {
 
     test("throws for invalid hex filters in paginated mode", async () => {
       const query = buildQuery([]);
-      const ctx = {
+      const ctx = withTestSession({
         auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
         db: { query: mock().mockReturnValue(query) },
         storage: { getUrl: mock() },
-      } as any;
+      } as any);
 
       const handler =
         (searchCardsPaginated as any).handler ?? searchCardsPaginated;

--- a/packages/convex/__tests__/card/getFileUrl.test.ts
+++ b/packages/convex/__tests__/card/getFileUrl.test.ts
@@ -1,5 +1,7 @@
 // @ts-nocheck
+
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { withTestSession } from "../helpers/session.test-utils";
 
 const resolveObjectUrlMock = mock((key?: string) =>
   Promise.resolve(key ? "https://file" : null)
@@ -22,9 +24,9 @@ describe("card/getFileUrl.ts", () => {
   });
 
   test("throws when unauthenticated", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
     const handler = (getFileUrl as any).handler ?? getFileUrl;
     await expect(handler(ctx, { key: "f1", cardId: "c1" })).rejects.toThrow(
       "Unauthenticated call to getFileUrl"
@@ -32,7 +34,7 @@ describe("card/getFileUrl.ts", () => {
   });
 
   test("returns file url for matching fileKey", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -42,7 +44,7 @@ describe("card/getFileUrl.ts", () => {
           fileMetadata: { fileName: "payload.html" },
         }),
       },
-    } as any;
+    } as any);
 
     const handler = (getFileUrl as any).handler ?? getFileUrl;
     const result = await handler(ctx, { key: "f1", cardId: "c1" });

--- a/packages/convex/__tests__/card/updateCard.test.ts
+++ b/packages/convex/__tests__/card/updateCard.test.ts
@@ -1,6 +1,8 @@
 // @ts-nocheck
+
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { CARD_USAGE_SHARD_VERSION } from "../../card/cardUsage";
+import { withTestSession } from "../helpers/session.test-utils";
 
 const mockReprocessLimit = mock().mockResolvedValue({ ok: true });
 
@@ -68,9 +70,9 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCard throws when unauthenticated", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
     await expect(
       ((updateCard as any).handler ?? updateCard)(ctx, {
         id: "c1",
@@ -80,7 +82,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCard normalizes quote content and schedules pipeline", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mockReprocessLimit,
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -94,7 +96,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const updateHandler = (updateCard as any).handler ?? updateCard;
     await updateHandler(ctx, { id: "c1", content: "'New quote'" });
@@ -116,7 +118,7 @@ describe("card/updateCard.ts", () => {
 
   test("updateCard rejects rapid reprocessing before changing the card", async () => {
     mockReprocessLimit.mockResolvedValueOnce({ ok: false });
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mockReprocessLimit,
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -129,7 +131,7 @@ describe("card/updateCard.ts", () => {
         patch: mock(),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCard as any).handler ?? updateCard;
     await expect(handler(ctx, { id: "c1", content: "New" })).rejects.toThrow(
@@ -140,14 +142,14 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCard throws when card not found", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue(null),
         patch: mock(),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const updateHandler = (updateCard as any).handler ?? updateCard;
     await expect(
@@ -156,7 +158,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCard throws when not authorized", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u2" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -168,7 +170,7 @@ describe("card/updateCard.ts", () => {
         patch: mock(),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const updateHandler = (updateCard as any).handler ?? updateCard;
     await expect(
@@ -177,7 +179,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCard does not normalize content for non-quote types", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mockReprocessLimit,
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -190,7 +192,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const updateHandler = (updateCard as any).handler ?? updateCard;
     await updateHandler(ctx, { id: "c1", content: "'quoted text'" });
@@ -210,7 +212,7 @@ describe("card/updateCard.ts", () => {
       content: "Old",
       processingStatus: { classify: { status: "completed" } },
     };
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mockReprocessLimit,
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -218,7 +220,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
     const handler = (updateCard as any).handler ?? updateCard;
     const source = "\uFEFF  # Heading\r\n\rBody  ";
     await handler(ctx, { id: "c1", content: source });
@@ -232,7 +234,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCard updates link type with categorize stage", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mockReprocessLimit,
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -245,7 +247,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const updateHandler = (updateCard as any).handler ?? updateCard;
     await updateHandler(ctx, { id: "c1", content: "New content" });
@@ -256,9 +258,9 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField throws when unauthenticated", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
     const handler = (updateCardField as any).handler ?? updateCardField;
     await expect(
       handler(ctx, { cardId: "c1", field: "content", value: "Hi" })
@@ -266,10 +268,10 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField throws when card not found", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: { get: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await expect(
@@ -278,12 +280,12 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField throws when not authorized", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u2" }) },
       db: {
         get: mock().mockResolvedValue({ _id: "c1", userId: "u1" }),
       },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await expect(
@@ -292,7 +294,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField updates url and clears link preview", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       runMutation: mockReprocessLimit,
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
@@ -310,7 +312,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const updateFieldHandler =
       (updateCardField as any).handler ?? updateCardField;
@@ -334,7 +336,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField captures favorite state changes", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -346,7 +348,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock().mockResolvedValue(null) },
-    } as any;
+    } as any);
 
     const updateFieldHandler =
       (updateCardField as any).handler ?? updateCardField;
@@ -358,7 +360,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField updates notes field", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -370,7 +372,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await handler(ctx, { cardId: "c1", field: "notes", value: " New notes " });
@@ -383,7 +385,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField clears notes with empty string", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -395,7 +397,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await handler(ctx, { cardId: "c1", field: "notes", value: "   " });
@@ -408,7 +410,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField updates tags field", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -419,7 +421,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await handler(ctx, {
@@ -436,7 +438,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField clears tags with empty array", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -448,7 +450,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await handler(ctx, { cardId: "c1", field: "tags", value: [] });
@@ -461,7 +463,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField updates aiSummary field", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -472,7 +474,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await handler(ctx, {
@@ -489,7 +491,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField toggles isFavorited", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -501,7 +503,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await handler(ctx, { cardId: "c1", field: "isFavorited" });
@@ -514,7 +516,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField removes AI tag", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -526,7 +528,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await handler(ctx, {
@@ -543,7 +545,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField clears aiTags when last tag removed", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -555,7 +557,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await handler(ctx, {
@@ -573,14 +575,14 @@ describe("card/updateCard.ts", () => {
 
   test("updateCardField returns card early when no tag to remove", async () => {
     const card = { _id: "c1", userId: "u1", type: "text" };
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue(card),
         patch: mock(),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     const result = await handler(ctx, { cardId: "c1", field: "removeAiTag" });
@@ -590,7 +592,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField clears notes when value is null", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -602,7 +604,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await handler(ctx, { cardId: "c1", field: "notes", value: null });
@@ -615,7 +617,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField supports explicit favorite state", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -627,7 +629,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await handler(ctx, {
@@ -645,7 +647,7 @@ describe("card/updateCard.ts", () => {
 
   test("updateCardField marks card as deleted", async () => {
     const _now = Date.now();
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -656,7 +658,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await handler(ctx, { cardId: "c1", field: "delete" });
@@ -672,7 +674,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField soft-deletes while processing is still pending", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -688,7 +690,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await expect(
@@ -707,7 +709,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField restores deleted card", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -720,7 +722,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await handler(ctx, { cardId: "c1", field: "restore" });
@@ -736,7 +738,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField throws when restoring non-deleted card", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -748,7 +750,7 @@ describe("card/updateCard.ts", () => {
         patch: mock(),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await expect(
@@ -757,7 +759,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField throws for unsupported field", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -768,7 +770,7 @@ describe("card/updateCard.ts", () => {
         patch: mock(),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await expect(
@@ -777,7 +779,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField does not schedule pipeline when content unchanged", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -789,7 +791,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await handler(ctx, {
@@ -802,7 +804,7 @@ describe("card/updateCard.ts", () => {
   });
 
   test("updateCardField does not schedule pipeline when url unchanged", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue({ subject: "u1" }) },
       db: {
         get: mock().mockResolvedValue({
@@ -815,7 +817,7 @@ describe("card/updateCard.ts", () => {
         patch: mock().mockResolvedValue(null),
       },
       scheduler: { runAfter: mock() },
-    } as any;
+    } as any);
 
     const handler = (updateCardField as any).handler ?? updateCardField;
     await handler(ctx, {

--- a/packages/convex/__tests__/helpers/session.test-utils.ts
+++ b/packages/convex/__tests__/helpers/session.test-utils.ts
@@ -1,0 +1,51 @@
+import { mock } from "bun:test";
+
+interface Identity {
+  sessionId?: string;
+  subject: string;
+}
+interface TestContext {
+  auth?: { getUserIdentity: () => Promise<Identity | null> };
+  runQuery?: (...args: any[]) => any;
+}
+
+// Business-logic unit tests supply an authenticated identity and its matching
+// live session. Revoked, expired, and forged sessions are covered with the real
+// Better Auth component in securitySessions.test.ts, without this fixture.
+export function withTestSession<T extends TestContext>(ctx: T): T {
+  const auth = ctx.auth;
+  if (!auth) {
+    return ctx;
+  }
+  const identity = async () => {
+    const user = await auth.getUserIdentity();
+    return user
+      ? { ...user, sessionId: user.sessionId ?? "test-session" }
+      : null;
+  };
+  const sourceRunQuery = ctx.runQuery;
+  const runQuery = mock(async (...args: any[]) => {
+    const queryArgs = args[1] as { model?: string } | undefined;
+    if (queryArgs?.model === "session") {
+      const originalUser = await auth.getUserIdentity();
+      if (originalUser?.sessionId && sourceRunQuery) {
+        return sourceRunQuery(...args);
+      }
+      const user = await identity();
+      return user
+        ? {
+            _id: user.sessionId,
+            userId: user.subject,
+            createdAt: Date.now(),
+            expiresAt: Date.now() + 60_000,
+          }
+        : null;
+    }
+    return sourceRunQuery?.(...args);
+  });
+  return {
+    ...ctx,
+    auth: { ...auth, getUserIdentity: identity },
+    runQuery,
+  };
+}

--- a/packages/convex/__tests__/mcp.test.ts
+++ b/packages/convex/__tests__/mcp.test.ts
@@ -256,7 +256,7 @@ describe("Convex MCP endpoint", () => {
     expect(names).toEqual(EXPECTED_TOOL_NAMES);
   });
 
-  test("caches successful MCP bearer validation briefly", async () => {
+  test("checks live credentials on consecutive MCP requests", async () => {
     const authorization = `Bearer teakapi_secret_live_b1c2d3e4_${"a".repeat(64)}`;
     const runMutation = mock().mockResolvedValue({
       keyId: "key_2",
@@ -294,8 +294,68 @@ describe("Convex MCP endpoint", () => {
 
     expect(firstResponse.status).toBe(200);
     expect(secondResponse.status).toBe(200);
-    expect(runMutation).toHaveBeenCalledTimes(1);
+    expect(runMutation).toHaveBeenCalledTimes(2);
   });
+
+  for (const [kind, authorization] of [
+    ["API key", `Bearer teakapi_secret_live_c1d2e3f4_${"b".repeat(64)}`],
+    ["OAuth token", `Bearer ${"r".repeat(32)}`],
+  ] as const) {
+    test(`immediately rejects a revoked ${kind} after initialize`, async () => {
+      let revoked = false;
+      const runMutation = mock(
+        (_reference: unknown, args: { token?: string }) => {
+          if (!args.token) {
+            return Promise.resolve({ ok: true });
+          }
+          return Promise.resolve(
+            revoked
+              ? null
+              : {
+                  keyId: "connection",
+                  userId: "owner",
+                  access: "full_access",
+                  source: "oauth",
+                  rateLimitKey: "oauth:client:owner",
+                }
+          );
+        }
+      );
+      const ctx = { runMutation, runQuery: mock() };
+      const initialize = await handleMcpV1Request(
+        ctx,
+        mcpRequest(
+          {
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: { protocolVersion: "2025-06-18" },
+          },
+          authorization
+        )
+      );
+      expect(initialize.status).toBe(200);
+      revoked = true;
+      for (const method of ["tools/list", "ping", "tools/call"]) {
+        const response = await handleMcpV1Request(
+          ctx,
+          mcpRequest(
+            {
+              jsonrpc: "2.0",
+              id: 2,
+              method,
+              params: { name: "teak_v1_list_cards", arguments: {} },
+            },
+            authorization
+          )
+        );
+        expect(response.status).toBe(401);
+        expect(response.headers.get("WWW-Authenticate")).toContain(
+          "resource_metadata="
+        );
+      }
+    });
+  }
 
   test("forwards MCP tools to the injected v1 executor", async () => {
     const captured: Array<{

--- a/packages/convex/__tests__/oauthClients.test.ts
+++ b/packages/convex/__tests__/oauthClients.test.ts
@@ -16,8 +16,11 @@ describe("ensureOAuthClients", () => {
       {}
     );
 
-    expect(result).toMatchObject({ created: 4, updated: 0 });
-    expect(runMutation).toHaveBeenCalledTimes(4);
+    expect(result).toMatchObject({
+      created: FIRST_PARTY_OAUTH_CLIENTS.length,
+      updated: 0,
+    });
+    expect(runMutation).toHaveBeenCalledTimes(FIRST_PARTY_OAUTH_CLIENTS.length);
 
     const first = runMutation.mock.calls[0][1];
     expect(first.input.model).toBe("oauthApplication");
@@ -38,7 +41,10 @@ describe("ensureOAuthClients", () => {
       {}
     );
 
-    expect(result).toMatchObject({ created: 0, updated: 4 });
+    expect(result).toMatchObject({
+      created: 0,
+      updated: FIRST_PARTY_OAUTH_CLIENTS.length,
+    });
     expect(runMutation.mock.calls[0][1].input.update.type).toBe("public");
     expect(runMutation.mock.calls[0][1].input.update).not.toHaveProperty(
       "skipConsent"

--- a/packages/convex/__tests__/oauthTokens.test.ts
+++ b/packages/convex/__tests__/oauthTokens.test.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+
 import { describe, expect, mock, test } from "bun:test";
 import {
   getOAuthConsentRequest,
@@ -8,6 +9,7 @@ import {
   revokeOAuthConnection,
   validateOAuthAccessToken,
 } from "../oauthTokens";
+import { withTestSession } from "./helpers/session.test-utils";
 
 const runHandler = (fn: any, ctx: any, args: any) =>
   (fn.handler ?? fn)(ctx, args);
@@ -210,10 +212,10 @@ describe("getOAuthUserInfo", () => {
 
 describe("OAuth connection management", () => {
   test("hides consent details while authentication is hydrating", async () => {
-    const ctx = {
+    const ctx = withTestSession({
       auth: { getUserIdentity: mock().mockResolvedValue(null) },
       runQuery: mock(),
-    };
+    });
 
     expect(
       await runHandler(getOAuthConsentRequest, ctx, {
@@ -235,12 +237,12 @@ describe("OAuth connection management", () => {
         }),
       })
       .mockResolvedValueOnce({ name: "Trusted Notes" });
-    const ctx = {
+    const ctx = withTestSession({
       auth: {
         getUserIdentity: mock().mockResolvedValue({ subject: "user_1" }),
       },
       runQuery,
-    };
+    });
 
     expect(
       await runHandler(getOAuthConsentRequest, ctx, {
@@ -263,12 +265,12 @@ describe("OAuth connection management", () => {
         userId: "user_2",
       }),
     });
-    const ctx = {
+    const ctx = withTestSession({
       auth: {
         getUserIdentity: mock().mockResolvedValue({ subject: "user_1" }),
       },
       runQuery,
-    };
+    });
 
     expect(
       await runHandler(getOAuthConsentRequest, ctx, {
@@ -300,7 +302,7 @@ describe("OAuth connection management", () => {
         ],
       })
       .mockResolvedValueOnce({ name: "Teak CLI" });
-    const ctx = {
+    const ctx = withTestSession({
       auth: {
         getUserIdentity: mock().mockResolvedValue({
           subject: "user_1",
@@ -308,7 +310,7 @@ describe("OAuth connection management", () => {
         }),
       },
       runQuery,
-    };
+    });
 
     expect(await runHandler(listOAuthConnections, ctx, {})).toEqual([
       {
@@ -325,12 +327,12 @@ describe("OAuth connection management", () => {
 
   test("returns no connections while settings authentication hydrates", async () => {
     const runQuery = mock();
-    const ctx = {
+    const ctx = withTestSession({
       auth: {
         getUserIdentity: mock().mockResolvedValue(null),
       },
       runQuery,
-    };
+    });
 
     expect(await runHandler(listOAuthConnections, ctx, {})).toEqual([]);
     expect(runQuery).not.toHaveBeenCalled();
@@ -346,7 +348,7 @@ describe("OAuth connection management", () => {
       .mockResolvedValueOnce({ page: [{ _id: "token_1" }] })
       .mockResolvedValueOnce({ page: [{ _id: "consent_1" }] });
     const runMutation = mock().mockResolvedValue(undefined);
-    const ctx = {
+    const ctx = withTestSession({
       auth: {
         getUserIdentity: mock().mockResolvedValue({
           subject: "user_1",
@@ -355,7 +357,7 @@ describe("OAuth connection management", () => {
       },
       runMutation,
       runQuery,
-    };
+    });
 
     expect(
       await runHandler(revokeOAuthConnection, ctx, {

--- a/packages/convex/admin.ts
+++ b/packages/convex/admin.ts
@@ -16,6 +16,7 @@ import type {
 } from "./card/processingStatus";
 import { stagePending } from "./card/processingStatus";
 import { patchCardWithSearchSync } from "./card/searchDocumentHelpers";
+import { getSessionIdentity } from "./securitySessions";
 import { deleteObject, resolveObjectUrl } from "./storage/r2";
 
 interface StageSummary {
@@ -78,7 +79,7 @@ const getAdminUserId = async (ctx: AdminCtx) => {
 };
 
 const ensureAdmin = async (ctx: AdminCtx) => {
-  const identity = await ctx.auth.getUserIdentity();
+  const identity = await getSessionIdentity(ctx);
   if (!identity) {
     throw new Error("Unauthorized");
   }
@@ -157,7 +158,7 @@ const getActiveCardCountForUser = async (
 export const getAccess = query({
   args: {},
   handler: async (ctx) => {
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getSessionIdentity(ctx);
     if (!identity) {
       return { allowed: false } as const;
     }

--- a/packages/convex/ai/actions.ts
+++ b/packages/convex/ai/actions.ts
@@ -1,12 +1,13 @@
 import { ConvexError, v } from "convex/values";
 import { internal } from "../_generated/api";
 import { action } from "../_generated/server";
+import { getSessionIdentity } from "../securitySessions";
 import { CARD_ERROR_CODES, CARD_ERROR_MESSAGES } from "../shared/constants";
 
 export const manuallyGenerateAI = action({
   args: { cardId: v.id("cards") },
   handler: async (ctx, { cardId }) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       throw new Error("Authentication required");
     }

--- a/packages/convex/auth.ts
+++ b/packages/convex/auth.ts
@@ -400,6 +400,18 @@ export const createAuth = (ctx: GenericCtx<DataModel>) => {
               ],
             },
             {
+              clientId: "teak-firefox",
+              clientSecret: "",
+              type: "public",
+              name: "Teak Firefox",
+              disabled: false,
+              skipConsent: false,
+              metadata: null,
+              redirectUrls: [
+                "https://810ad09f1a9233882b69a56ac05bd31b93aad88b.extensions.allizom.org/oauth/callback",
+              ],
+            },
+            {
               clientId: "teak-safari",
               clientSecret: "",
               type: "public",

--- a/packages/convex/authNative.ts
+++ b/packages/convex/authNative.ts
@@ -8,6 +8,7 @@ import {
   mutation,
 } from "./_generated/server";
 import { resolveTeakDevAppUrl } from "./devUrls";
+import { getSessionIdentity } from "./securitySessions";
 import { mintDedicatedSession } from "./shared/dedicatedSessions";
 import { rateLimiter } from "./shared/rateLimits";
 
@@ -304,7 +305,7 @@ export const createNativeAuthCode = mutation({
   },
   returns: createNativeAuthCodeResultValidator,
   handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     const sessionId =
       user && typeof user.sessionId === "string" ? user.sessionId : null;
     if (!(user?.subject && sessionId)) {

--- a/packages/convex/billing.ts
+++ b/packages/convex/billing.ts
@@ -4,13 +4,14 @@ import { ConvexError, v } from "convex/values";
 import { api, components } from "./_generated/api";
 import { action, query } from "./_generated/server";
 import { resolveTeakDevAppUrl } from "./devUrls";
+import { getSessionIdentity } from "./securitySessions";
 import { isApprovedPolarProductId } from "./shared/polarPlans";
 import { normalizeErrorClass } from "./shared/telemetry";
 import { scheduleBillingOutcome } from "./telemetry/schedule";
 
 // User query to use in the Polar component
 export const getUserInfoHandler = async (ctx: any) => {
-  const user = await ctx.auth.getUserIdentity();
+  const user = await getSessionIdentity(ctx);
   if (!user) {
     throw new ConvexError("User not found");
   }

--- a/packages/convex/card/createCard.ts
+++ b/packages/convex/card/createCard.ts
@@ -11,6 +11,7 @@ import {
   mutation,
 } from "../_generated/server";
 import { cardTypeValidator, colorValidator } from "../schema";
+import { getSessionIdentity } from "../securitySessions";
 import type { CardCreationSource } from "../shared/metrics";
 import { normalizeErrorClass } from "../shared/telemetry";
 import { assertSafeExternalUrl } from "../shared/utils/safeUrl";
@@ -232,7 +233,7 @@ export const createCard = mutation({
   args: createCardArgs,
   returns: v.id("cards"),
   handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       throw new Error("User must be authenticated");
     }

--- a/packages/convex/card/deleteCard.ts
+++ b/packages/convex/card/deleteCard.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { mutation } from "../_generated/server";
+import { getSessionIdentity } from "../securitySessions";
 import { cardStorageObjectKeys, deleteObject } from "../storage/r2";
 import {
   ensureCardUsageShardsForRemoval,
@@ -13,7 +14,7 @@ export const permanentDeleteCard = mutation({
   },
   returns: v.null(),
   handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       throw new Error("User must be authenticated");
     }

--- a/packages/convex/card/findDuplicateCard.ts
+++ b/packages/convex/card/findDuplicateCard.ts
@@ -1,5 +1,6 @@
 import { v } from "convex/values";
 import { internalQuery, query } from "../_generated/server";
+import { getSessionIdentity } from "../securitySessions";
 import { cardReturnValidator } from "./getCards";
 import { attachFileUrls } from "./queryUtils";
 
@@ -31,7 +32,7 @@ export const findDuplicateCard = query({
   },
   returns: v.union(cardReturnValidator, v.null()),
   handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       return null;
     }

--- a/packages/convex/card/getCard.ts
+++ b/packages/convex/card/getCard.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import type { Id } from "../_generated/dataModel";
 import { internalQuery, query } from "../_generated/server";
+import { getSessionIdentity } from "../securitySessions";
 import { cardReturnValidator } from "./getCards";
 import { attachFileUrls } from "./queryUtils";
 import {
@@ -27,7 +28,7 @@ export const getCard = query({
   },
   returns: v.union(v.null(), cardReturnValidator),
   handler: async (ctx, { id }) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       return null;
     }
@@ -42,7 +43,7 @@ export const getCardByUrlId = query({
   },
   returns: v.union(v.null(), cardReturnValidator),
   handler: async (ctx, { id }) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       return null;
     }
@@ -70,7 +71,7 @@ export const getDeletedCards = query({
   },
   returns: v.array(cardReturnValidator),
   handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       return [];
     }

--- a/packages/convex/card/getCards.ts
+++ b/packages/convex/card/getCards.ts
@@ -3,6 +3,7 @@ import { type Infer, v } from "convex/values";
 import type { Doc } from "../_generated/dataModel";
 import { type QueryCtx, query } from "../_generated/server";
 import { cardTypeValidator, cardValidator } from "../schema";
+import { getSessionIdentity } from "../securitySessions";
 import {
   clampPageSize,
   clampSearchLimit,
@@ -82,7 +83,7 @@ export const getCards = query({
   },
   returns: v.array(cardReturnValidator),
   handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       return [];
     }
@@ -140,7 +141,7 @@ export const searchCards = query({
   },
   returns: v.array(cardReturnValidator),
   handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       return [];
     }
@@ -358,7 +359,7 @@ export const searchCardsPaginatedHandler = async (
   } else if (options.gridOnly) {
     attachListUrls = attachGridFileUrls;
   }
-  const user = await ctx.auth.getUserIdentity();
+  const user = await getSessionIdentity(ctx);
   if (!user) {
     return { page: [], isDone: true, continueCursor: null };
   }

--- a/packages/convex/card/getFileUrl.ts
+++ b/packages/convex/card/getFileUrl.ts
@@ -2,6 +2,7 @@ import type { FilesImageRendition } from "@teak/files-protocol";
 import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import { action, internalQuery, query } from "../_generated/server";
+import { getSessionIdentity } from "../securitySessions";
 import { resolveImageUrl, resolveObjectUrl } from "../storage/r2";
 
 const mediaRenditionValidator = v.union(
@@ -42,7 +43,7 @@ export const getFileUrl = query({
   },
   returns: v.union(v.string(), v.null()),
   handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       throw new Error("Unauthenticated call to getFileUrl");
     }
@@ -76,7 +77,7 @@ export const getAuthorizedMedia = internalQuery({
     v.null()
   ),
   handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       throw new Error("Unauthenticated media refresh");
     }

--- a/packages/convex/card/updateCard.ts
+++ b/packages/convex/card/updateCard.ts
@@ -6,6 +6,7 @@ import {
   type MutationCtx,
   mutation,
 } from "../_generated/server";
+import { getSessionIdentity } from "../securitySessions";
 import { CARD_ERROR_CODES, CARD_ERROR_MESSAGES } from "../shared/constants";
 import { rateLimiter } from "../shared/rateLimits";
 import { assertSafeExternalUrl } from "../shared/utils/safeUrl";
@@ -107,7 +108,7 @@ export const updateCard = mutation({
   },
   returns: v.null(), // db.patch returns void/null
   handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       throw new Error("User must be authenticated");
     }
@@ -382,7 +383,7 @@ export const updateCardField = mutation({
   },
   returns: v.null(),
   handler: async (ctx, { cardId, field, value, tagToRemove }) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       throw new Error("User must be authenticated");
     }

--- a/packages/convex/card/uploadCard.ts
+++ b/packages/convex/card/uploadCard.ts
@@ -3,6 +3,7 @@ import { internal } from "../_generated/api";
 import { type MutationCtx, mutation } from "../_generated/server";
 import { ensureCardCreationAllowed } from "../auth";
 import { type CardType, cardTypeValidator } from "../schema";
+import { getSessionIdentity } from "../securitySessions";
 import {
   type FileFormat,
   FileFormatValidationError,
@@ -83,7 +84,7 @@ export const uploadAndCreateCard = mutation({
     errorCode: v.optional(v.string()),
   }),
   handler: async (ctx, _args) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       return { success: false, error: "User must be authenticated" };
     }

--- a/packages/convex/card/uploadCardAction.ts
+++ b/packages/convex/card/uploadCardAction.ts
@@ -5,6 +5,7 @@ import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import { type ActionCtx, action, internalAction } from "../_generated/server";
 import { cardTypeValidator } from "../schema";
+import { getSessionIdentity } from "../securitySessions";
 import {
   FileFormatValidationError,
   fileUploadErrorCode,
@@ -295,7 +296,7 @@ export const finalizeUploadedCard = action({
   args: finalizeArgs,
   returns: finalizeResult,
   handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       return { success: false, error: "User must be authenticated" };
     }

--- a/packages/convex/dataExport.ts
+++ b/packages/convex/dataExport.ts
@@ -1,3 +1,4 @@
+import { getSessionIdentity } from "./securitySessions";
 /**
  * Export feature Convex functions.
  *
@@ -88,7 +89,7 @@ const startResultValidator = v.object({
 // ---------------------------------------------------------------------------
 
 async function requireUserId(ctx: QueryCtx | MutationCtx): Promise<string> {
-  const user = await ctx.auth.getUserIdentity();
+  const user = await getSessionIdentity(ctx);
   if (!user) {
     throw new Error("User must be authenticated");
   }
@@ -294,7 +295,7 @@ export const getExportDownloadUrl = action({
     ctx,
     { jobId }
   ): Promise<{ url: string; expiresInSeconds: number } | null> => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       throw new Error("User must be authenticated");
     }

--- a/packages/convex/dataImport.ts
+++ b/packages/convex/dataImport.ts
@@ -5,6 +5,7 @@ import {
   internalMutation,
   internalQuery,
   type MutationCtx,
+  type QueryCtx,
   query,
 } from "./_generated/server";
 import { assertAccountNotDeleting } from "./accountDeletion";
@@ -18,6 +19,7 @@ import {
   colorValidator,
   importModeValidator,
 } from "./schema";
+import { getSessionIdentity } from "./securitySessions";
 
 const internalAny = internal as Record<string, any>;
 const activeStatuses = new Set<string>(ACTIVE_IMPORT_STATUSES);
@@ -76,10 +78,8 @@ const itemInputValidator = v.object({
   failureReason: v.optional(v.string()),
 });
 
-async function requireUserId(ctx: {
-  auth: { getUserIdentity: () => Promise<any> };
-}) {
-  const identity = await ctx.auth.getUserIdentity();
+async function requireUserId(ctx: MutationCtx | QueryCtx) {
+  const identity = await getSessionIdentity(ctx);
   if (!identity) {
     throw new Error("User must be authenticated");
   }

--- a/packages/convex/fileUploads.ts
+++ b/packages/convex/fileUploads.ts
@@ -11,6 +11,7 @@ import {
 } from "./_generated/server";
 import { ensureCardCreationAllowed } from "./auth";
 import { validateDirectUploadRequest } from "./card/uploadCard";
+import { getSessionIdentity } from "./securitySessions";
 import { MULTIPART_UPLOAD_THRESHOLD } from "./shared/constants";
 import {
   buildSignedMultipartPartUrl,
@@ -40,8 +41,8 @@ interface SessionResponse {
   uploadKey: string;
 }
 
-const requireIdentity = async (ctx: Pick<ActionCtx, "auth">) => {
-  const identity = await ctx.auth.getUserIdentity();
+const requireIdentity = async (ctx: Pick<ActionCtx, "auth" | "runQuery">) => {
+  const identity = await getSessionIdentity(ctx);
   if (!identity) {
     throw new ConvexError({
       code: "UNAUTHENTICATED",

--- a/packages/convex/importUpload.ts
+++ b/packages/convex/importUpload.ts
@@ -13,7 +13,7 @@ import {
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { ConvexError, v } from "convex/values";
 import { internal } from "./_generated/api";
-import { action } from "./_generated/server";
+import { type ActionCtx, action } from "./_generated/server";
 import {
   IMPORT_PART_BYTES,
   IMPORT_UPLOAD_TTL_MS,
@@ -23,6 +23,7 @@ import {
 } from "./import/constants";
 import { createImportS3Client, getImportR2Config } from "./import/r2Client";
 import { importModeValidator } from "./schema";
+import { getSessionIdentity } from "./securitySessions";
 import { buildR2ObjectKey } from "./storage/r2";
 
 const internalAny = internal as Record<string, any>;
@@ -36,10 +37,8 @@ const uploadResultValidator = v.object({
   parts: v.array(partValidator),
 });
 
-async function requireUserId(ctx: {
-  auth: { getUserIdentity: () => Promise<any> };
-}) {
-  const identity = await ctx.auth.getUserIdentity();
+async function requireUserId(ctx: ActionCtx) {
+  const identity = await getSessionIdentity(ctx);
   if (!identity) {
     throw new Error("User must be authenticated");
   }

--- a/packages/convex/mcp/httpServer.ts
+++ b/packages/convex/mcp/httpServer.ts
@@ -23,52 +23,8 @@ const MCP_CORS_HEADERS: Record<string, string> = {
   "Access-Control-Max-Age": "86400",
 };
 
-const TOKEN_VALIDATION_TTL_MS = 30_000;
-const MAX_VALIDATED_TOKENS = 10_000;
 export const MAX_MCP_JSON_RPC_BATCH = 100;
 const JSON_RPC_RATE_LIMITED_CODE = -32_000;
-const validatedTokenCache = new Map<string, number>();
-
-const getAuthorizationHeader = (request: Request): string | null =>
-  request.headers.get("authorization");
-
-const hasFreshValidation = (authorization: string, now: number): boolean => {
-  const expiresAt = validatedTokenCache.get(authorization);
-  if (!expiresAt) {
-    return false;
-  }
-
-  if (expiresAt <= now) {
-    validatedTokenCache.delete(authorization);
-    return false;
-  }
-
-  return true;
-};
-
-const rememberValidation = (authorization: string, now: number): void => {
-  validatedTokenCache.set(authorization, now + TOKEN_VALIDATION_TTL_MS);
-
-  for (const [cachedAuthorization, expiresAt] of validatedTokenCache) {
-    if (expiresAt <= now) {
-      validatedTokenCache.delete(cachedAuthorization);
-    }
-  }
-
-  if (validatedTokenCache.size <= MAX_VALIDATED_TOKENS) {
-    return;
-  }
-
-  const overflow = validatedTokenCache.size - MAX_VALIDATED_TOKENS;
-  let removed = 0;
-  for (const cachedAuthorization of validatedTokenCache.keys()) {
-    validatedTokenCache.delete(cachedAuthorization);
-    removed += 1;
-    if (removed >= overflow) {
-      return;
-    }
-  }
-};
 
 const withMcpCors = (response: Response): Response => {
   const withGatewayHeaders = withPublicApiGatewayHeaders(response);
@@ -316,21 +272,13 @@ const validateMcpBearer = async (
   ctx: any,
   request: Request
 ): Promise<Response | null> => {
-  const authorization = getAuthorizationHeader(request);
-  const now = Date.now();
-  if (authorization && hasFreshValidation(authorization, now)) {
-    return null;
-  }
-
+  // Validate even protocol-only requests against live credentials. A previous
+  // successful request must not keep a disconnected app or revoked key usable.
   const authError = await validatePublicApiBearer(ctx, request);
   if (authError) {
     return authError.status === 401
       ? withAuthChallenge(authError, request.url)
       : withMcpCors(authError);
-  }
-
-  if (authorization) {
-    rememberValidation(authorization, now);
   }
 
   return null;

--- a/packages/convex/mcpRevocation.test.ts
+++ b/packages/convex/mcpRevocation.test.ts
@@ -1,0 +1,97 @@
+/// <reference types="vite/client" />
+
+import betterAuthTest from "@convex-dev/better-auth/test";
+import rateLimiterTest from "@convex-dev/rate-limiter/test";
+import { convexTest } from "convex-test";
+import { beforeEach, expect, test, vi } from "vitest";
+import { TEST_APPLE_PRIVATE_KEY } from "./__tests__/helpers/appleAuth.test-utils";
+import { api, components, internal } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+
+beforeEach(() => {
+  vi.stubEnv("SITE_URL", "http://localhost:3000");
+  vi.stubEnv("GOOGLE_CLIENT_ID", "test");
+  vi.stubEnv("GOOGLE_CLIENT_SECRET", "test");
+  vi.stubEnv("APPLE_CLIENT_ID", "test-client");
+  vi.stubEnv("APPLE_KEY_ID", "test-key");
+  vi.stubEnv("APPLE_TEAM_ID", "test-team");
+  vi.stubEnv("APPLE_PRIVATE_KEY", TEST_APPLE_PRIVATE_KEY);
+});
+
+test("disconnect blocks an already initialized MCP client without waiting for a cache to expire", async () => {
+  const t = convexTest(schema, modules);
+  betterAuthTest.register(t);
+  rateLimiterTest.register(t, "rateLimiterV2");
+  await t.mutation(internal.oauthClients.ensureOAuthClients, {});
+  const now = Date.now();
+  const user = await t.mutation(components.betterAuth.adapter.create, {
+    input: {
+      model: "user",
+      data: {
+        name: "MCP connection test",
+        email: "mcp-connection@example.com",
+        emailVerified: true,
+        createdAt: now,
+        updatedAt: now,
+      },
+    },
+  });
+  const session = await t.mutation(components.betterAuth.adapter.create, {
+    input: {
+      model: "session",
+      data: {
+        userId: user._id,
+        token: crypto.randomUUID(),
+        createdAt: now,
+        updatedAt: now,
+        expiresAt: now + 3_600_000,
+      },
+    },
+  });
+  const accessToken = "m".repeat(32);
+  await t.mutation(components.betterAuth.adapter.create, {
+    input: {
+      model: "oauthAccessToken",
+      data: {
+        clientId: "teak-cli",
+        userId: user._id,
+        accessToken,
+        refreshToken: "n".repeat(32),
+        accessTokenExpiresAt: now + 3_600_000,
+        refreshTokenExpiresAt: now + 86_400_000,
+        createdAt: now,
+        updatedAt: now,
+        scopes: "profile email offline_access",
+      },
+    },
+  });
+  const request = (method: string) =>
+    t.fetch("/mcp", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method,
+        params: { protocolVersion: "2025-06-18" },
+      }),
+    });
+  expect((await request("initialize")).status).toBe(200);
+  expect((await request("tools/list")).status).toBe(200);
+  await t
+    .withIdentity({ subject: user._id, sessionId: session._id })
+    .action(api.oauthTokens.revokeOAuthConnection, { clientId: "teak-cli" });
+  for (const method of ["tools/list", "ping", "tools/call", "initialize"]) {
+    const response = await request(method);
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toContain(
+      "resource_metadata="
+    );
+  }
+});

--- a/packages/convex/oauthClients.ts
+++ b/packages/convex/oauthClients.ts
@@ -50,6 +50,13 @@ export const FIRST_PARTY_OAUTH_CLIENTS: OAuthClientSeed[] = [
     ],
   },
   {
+    clientId: "teak-firefox",
+    name: "Teak Firefox",
+    redirectUrls: [
+      "https://810ad09f1a9233882b69a56ac05bd31b93aad88b.extensions.allizom.org/oauth/callback",
+    ],
+  },
+  {
     clientId: "teak-safari",
     name: "Teak Safari",
     redirectUrls: ["teak-safari://oauth/callback"],

--- a/packages/convex/oauthTokens.ts
+++ b/packages/convex/oauthTokens.ts
@@ -9,7 +9,7 @@ import {
   query,
 } from "./_generated/server";
 import { isFirstPartyOAuthClientId } from "./oauthClients";
-import { currentSession } from "./securitySessions";
+import { currentSession, getSessionIdentity } from "./securitySessions";
 
 // Better Auth's `mcp`/oidc authorization server mints opaque access and refresh
 // tokens with `generateRandomString(32, ...)`. Today the mcp plugin uses the
@@ -271,7 +271,7 @@ export const getOAuthConsentRequest = query({
     // The client can subscribe before its session token finishes hydrating.
     // Treat that transient state as no visible request instead of surfacing a
     // production query error; the subscription reruns when auth becomes ready.
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getSessionIdentity(ctx);
     if (!identity?.subject) {
       return null;
     }

--- a/packages/convex/securitySessions.test.ts
+++ b/packages/convex/securitySessions.test.ts
@@ -49,6 +49,41 @@ async function setup() {
 }
 
 describe("Security sessions", () => {
+  test("revoking a device blocks cached-token card reads and writes", async () => {
+    const { t, authenticated, current, other } = await setup();
+    const id = await t.run((ctx) =>
+      ctx.db.insert("cards", {
+        userId: "owner",
+        type: "text",
+        content: "Private card",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      })
+    );
+    const otherDevice = t.withIdentity({
+      subject: "owner",
+      sessionId: other._id,
+    });
+    expect(await authenticated.query(api.cards.getCard, { id })).toMatchObject({
+      content: "Private card",
+    });
+    await otherDevice.mutation(api.securitySessions.revokeSession, {
+      sessionId: current._id,
+    });
+    expect(await authenticated.query(api.cards.getCard, { id })).toBeNull();
+    expect(await authenticated.query(api.cards.getCards, { limit: 2 })).toEqual(
+      []
+    );
+    await expect(
+      authenticated.mutation(api.cards.createCard, {
+        type: "text",
+        content: "Revocation bypass",
+      })
+    ).rejects.toThrow("authenticated");
+    expect(await otherDevice.query(api.cards.getCard, { id })).toMatchObject({
+      content: "Private card",
+    });
+  });
   test("lists only owned live sessions with safe fields and this device first", async () => {
     const { authenticated, current, other } = await setup();
     const result = await authenticated.query(

--- a/packages/convex/securitySessions.ts
+++ b/packages/convex/securitySessions.ts
@@ -1,13 +1,7 @@
 import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 import { components } from "./_generated/api";
-import {
-  type ActionCtx,
-  type MutationCtx,
-  mutation,
-  type QueryCtx,
-  query,
-} from "./_generated/server";
+import { type ActionCtx, mutation, query } from "./_generated/server";
 
 interface SessionRecord {
   _id: string;
@@ -52,7 +46,9 @@ export function sessionDisplayName(agent: string | null | undefined): string {
 
 // Check the live session as well as the signed JWT. A revoked session must not
 // use a cached JWT to inspect or revoke other credentials.
-export async function currentSession(ctx: ActionCtx | MutationCtx | QueryCtx) {
+export async function currentSession(
+  ctx: Pick<ActionCtx, "auth" | "runQuery">
+) {
   const identity = await ctx.auth.getUserIdentity();
   if (!identity || typeof identity.sessionId !== "string") {
     return null;
@@ -65,6 +61,18 @@ export async function currentSession(ctx: ActionCtx | MutationCtx | QueryCtx) {
     ],
   })) as SessionRecord | null;
   return session && session.expiresAt > Date.now() ? session : null;
+}
+
+// Reuse the same live-session check for all device-authenticated data APIs.
+// Query callers also subscribe to the session row, so revocation invalidates
+// their existing subscriptions without waiting for the signed JWT to expire.
+export async function getSessionIdentity(
+  ctx: Pick<ActionCtx, "auth" | "runQuery">
+) {
+  if (!(await currentSession(ctx))) {
+    return null;
+  }
+  return ctx.auth.getUserIdentity();
 }
 
 const displayValidator = v.object({

--- a/packages/convex/storage/r2.ts
+++ b/packages/convex/storage/r2.ts
@@ -7,6 +7,7 @@ import { v } from "convex/values";
 import { internal } from "../_generated/api";
 import type { ActionCtx, MutationCtx } from "../_generated/server";
 import { mutation, query } from "../_generated/server";
+import { getSessionIdentity } from "../securitySessions";
 import { inferFileFormat } from "../shared/fileFormats";
 import {
   buildSignedWorkerUploadUrl,
@@ -380,7 +381,7 @@ export const generateUploadUrl = mutation({
     url: v.string(),
   }),
   handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       throw new Error("User must be authenticated");
     }
@@ -407,7 +408,7 @@ export const getFileUrl = query({
   },
   returns: v.union(v.string(), v.null()),
   handler: async (ctx, args) => {
-    const user = await ctx.auth.getUserIdentity();
+    const user = await getSessionIdentity(ctx);
     if (!user) {
       throw new Error("Unauthenticated call to getFileUrl");
     }

--- a/packages/convex/vitest.config.ts
+++ b/packages/convex/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       "./occContention.test.ts",
       "./safariOAuth.test.ts",
       "./securitySessions.test.ts",
+      "./mcpRevocation.test.ts",
     ],
   },
 });

--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -258,16 +258,24 @@ export const signUp = async (page: Page, email = uniqueEmail()) => {
   return email;
 };
 
-export const generateApiKey = async (page: Page) => {
+export const openSecurity = async (
+  page: Page,
+  tab: "Connections" | "API keys" = "Connections"
+) => {
   await page.goto(appPath("/settings"));
-  await page.getByText("API Keys").waitFor();
-  await settingsRow(page, "API Keys")
+  await settingsRow(page, "Security")
     .getByRole("button", { name: "Manage" })
     .click();
-  const dialog = page.getByRole("dialog", { name: "Manage API Keys" });
+  const dialog = page.getByRole("dialog", { name: "Security", exact: true });
   await expect(dialog).toBeVisible();
+  await dialog.getByRole("tab", { name: tab, exact: true }).click();
+  return dialog;
+};
+
+export const generateApiKey = async (page: Page) => {
+  const dialog = await openSecurity(page, "API keys");
   await clickVisibleControl(
-    dialog.getByRole("button", { name: "Generate Key" })
+    dialog.getByRole("button", { name: "Create key", exact: true })
   );
   // React updates the input's live value property, not necessarily its HTML
   // value attribute, so do not use an attribute-prefix CSS selector here.
@@ -359,12 +367,8 @@ export const deleteAccountViaUi = async (page: Page, account: AccountState) => {
 
 export const revokeVisibleKey = async (page: Page, rawKey: string) => {
   const visiblePrefix = rawKey.split("_").slice(0, 4).join("_");
-  await page.goto(appPath("/settings"));
-  await settingsRow(page, "API Keys")
-    .getByRole("button", { name: "Manage" })
-    .click();
-  const dialog = page.getByRole("dialog", { name: "Manage API Keys" });
-  const row = dialog.getByRole("row").filter({ hasText: visiblePrefix });
+  const dialog = await openSecurity(page, "API keys");
+  const row = dialog.getByRole("listitem").filter({ hasText: visiblePrefix });
   await expect(row).toBeVisible();
   await row.getByRole("button", { name: /^Revoke / }).click();
   await expect(

--- a/packages/tests/src/journey/06-security.e2e.ts
+++ b/packages/tests/src/journey/06-security.e2e.ts
@@ -3,11 +3,13 @@ import { expect, request as playwrightRequest, test } from "@playwright/test";
 import { apiFetch } from "../helpers/api";
 import { cleanupE2EAccounts } from "../helpers/e2e-cleanup";
 import { env } from "../helpers/env";
+import { connectMcp } from "../helpers/mcp";
 import {
   clientFor,
   createAccount,
   generateApiKey,
   newAnonymousContext,
+  openSecurity,
   revokeVisibleKey,
 } from "../helpers/prod";
 import { readState } from "../helpers/run-state";
@@ -122,19 +124,22 @@ test("external OAuth requires explicit full-vault consent and can be revoked", a
   }
   expect((await apiFetch("/v1/tags", tokens.access_token)).status).toBe(200);
 
-  await page.goto("/settings");
-  await page
-    .getByText("Connected apps")
-    .locator("xpath=ancestor::div[.//button][1]")
-    .getByRole("button", { name: "Manage" })
-    .click();
-  const dialog = page.getByRole("dialog", { name: "Connected apps" });
-  await expect(dialog.getByText(clientName)).toBeVisible();
-  await dialog.getByRole("button", { name: "Disconnect" }).click();
-  await expect(dialog.getByText(clientName)).not.toBeVisible();
-  await expect
-    .poll(async () => (await apiFetch("/v1/tags", tokens.access_token)).status)
-    .toBe(401);
+  const mcp = await connectMcp(tokens.access_token);
+  try {
+    expect((await mcp.listTools()).tools.length).toBeGreaterThan(0);
+    const dialog = await openSecurity(page);
+    await expect(dialog.getByText(clientName, { exact: true })).toBeVisible();
+    await dialog
+      .getByRole("button", { name: `Disconnect ${clientName}`, exact: true })
+      .click();
+    await expect(
+      dialog.getByText(clientName, { exact: true })
+    ).not.toBeVisible();
+    expect((await apiFetch("/v1/tags", tokens.access_token)).status).toBe(401);
+    await expect(mcp.listTools()).rejects.toThrow(/401|unauthorized/i);
+  } finally {
+    await mcp.close();
+  }
 });
 
 test("cross-tenant, revoked-key, hostile input, headers, and cookie security", async ({

--- a/packages/ui/src/components/settings/SecuritySection.tsx
+++ b/packages/ui/src/components/settings/SecuritySection.tsx
@@ -124,6 +124,10 @@ function ConnectionsPanel(props: SecurityConnectionsProps) {
   ].sort((a, b) => Number(b.current) - Number(a.current) || b.date - a.date);
   return (
     <div>
+      <p className="py-2 text-muted-foreground text-sm">
+        Sign out a single device, or disconnect an app across all its
+        installations.
+      </p>
       {error ? (
         <p className="py-2 text-destructive text-sm" role="alert">
           {error}


### PR DESCRIPTION
Revoked devices and apps lose access immediately.

- Device-authenticated data APIs check the live session via getSessionIdentity, so Security sign-out stops card/data access without waiting for JWT expiry.
- MCP bearer validation runs on every request; removed token validation cache so disconnected apps and revoked keys stop immediately, including existing connections.
- CLI, desktop, Raycast, and extension sign-out revokes the installation's access with retry-safe credential clearing.
- Regression tests for revocation, plus docs and changelog updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Firefox browser extension support, including browser-specific sign-in and credential storage.
  - Sign-out now revokes the installation’s access before clearing local credentials across CLI, desktop, and Raycast.
  - Security connections and app disconnections now take effect immediately, including existing MCP connections.
  - Added clearer Security settings guidance for device sign-out, app disconnection, and API key management.

- **Bug Fixes**
  - Failed sign-out attempts preserve credentials so users can retry.
  - MCP requests now re-check access immediately after credentials are revoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->