### PR TITLE
fix(convex): break storage/r2 import cycle via leaf r2Keys module

### DIFF
--- a/packages/convex/__tests__/helpers/r2Mock.test-utils.ts
+++ b/packages/convex/__tests__/helpers/r2Mock.test-utils.ts
@@ -14,6 +14,13 @@
  */
 
 import { mock } from "bun:test";
+import { PENDING_UPLOAD_CARD_ID } from "../../storage/r2";
+import {
+  assertR2KeyInNamespace,
+  buildR2ListPrefix,
+  getR2KeyPrefix,
+  isR2KeyInNamespace,
+} from "../../storage/r2Keys";
 
 const hashUserId = (userId: string) =>
   Array.from(new TextEncoder().encode(userId))
@@ -62,6 +69,13 @@ export const r2Mocks = {
 };
 
 export const r2MockModuleFactory = () => ({
+  // Pure key-namespace helpers pass through from the dependency-free leaf
+  // module so mocked importers never hit a named-export link error.
+  assertR2KeyInNamespace,
+  buildR2ListPrefix,
+  getR2KeyPrefix,
+  isR2KeyInNamespace,
+  PENDING_UPLOAD_CARD_ID,
   // Faithful port of the real cardStorageObjectKeys so tests that receive the
   // mocked module still observe identical key collection semantics.
   cardStorageObjectKeys: (card: {

--- a/packages/convex/storage/filesWorkerClient.ts
+++ b/packages/convex/storage/filesWorkerClient.ts
@@ -17,7 +17,7 @@ import {
   type FilesOp,
   type FilesOpRequest,
 } from "@teak/files-protocol";
-import { assertR2KeyInNamespace, hmacSha256Hex } from "./r2";
+import { assertR2KeyInNamespace, hmacSha256Hex } from "./r2Keys";
 
 // Op URLs are minted per action invocation; a short TTL bounds the replay
 // window (the worker additionally rejects exps further than 15 min out).

--- a/packages/convex/storage/pendingUploadCleanup.ts
+++ b/packages/convex/storage/pendingUploadCleanup.ts
@@ -7,7 +7,8 @@ import {
   type FilesWorkerListObjectsResult,
   isFilesWorkerConfigured,
 } from "./filesWorkerClient";
-import { buildR2ListPrefix, PENDING_UPLOAD_CARD_ID } from "./r2";
+import { PENDING_UPLOAD_CARD_ID } from "./r2";
+import { buildR2ListPrefix } from "./r2Keys";
 
 const STALE_AFTER_MS = 24 * 60 * 60 * 1000;
 const PENDING_UPLOAD_SEGMENT = `/cards/${PENDING_UPLOAD_CARD_ID}/`;

--- a/packages/convex/storage/r2.ts
+++ b/packages/convex/storage/r2.ts
@@ -13,6 +13,24 @@ import {
   buildSignedWorkerUploadUrl,
   putObjectViaFilesWorker,
 } from "./filesWorkerClient";
+import {
+  assertR2KeyInNamespace,
+  getR2KeyPrefix,
+  hmacSha256Hex,
+  isR2KeyInNamespace,
+} from "./r2Keys";
+
+// Re-exported for backward compatibility: existing importers keep importing
+// these names from `storage/r2`. New code should import them from
+// `storage/r2Keys` directly so it never depends on the mocked `storage/r2`
+// surface (see r2Keys.ts).
+export {
+  assertR2KeyInNamespace,
+  buildR2ListPrefix,
+  getR2KeyPrefix,
+  hmacSha256Hex,
+  isR2KeyInNamespace,
+} from "./r2Keys";
 
 // Object keys are content-immutable (every upload writes a fresh UUID key), so
 // signed URLs can live far longer than a single session. Long-lived,
@@ -43,33 +61,6 @@ export const PRIVATE_FILE_CACHE_CONTROL = "private, max-age=518400, immutable"; 
 
 export type R2ObjectKey = string;
 export const PENDING_UPLOAD_CARD_ID = "upload-pending-v2";
-
-/**
- * Internal R2 key prefix for environment isolation.
- * - Production: unset -> "users/..."
- * - Development: "dev/" -> "dev/users/..."
- * This is protection against routine mistakes; shared credentials retain bucket-wide authority.
- */
-export const getR2KeyPrefix = (): string => {
-  const raw = process.env.R2_KEY_PREFIX ?? "";
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return "";
-  }
-  const normalized = trimmed.replace(/^\/+/, "");
-  return normalized.endsWith("/") ? normalized : `${normalized}/`;
-};
-
-export const buildR2ListPrefix = (): string => `${getR2KeyPrefix()}users/`;
-
-export const isR2KeyInNamespace = (key: string): boolean =>
-  key.startsWith(`${getR2KeyPrefix()}users/`);
-
-export const assertR2KeyInNamespace = (key: string): void => {
-  if (!isR2KeyInNamespace(key)) {
-    throw new Error("invalid_storage_key_namespace");
-  }
-};
 
 export const getR2ReadBase = (key: string): string => {
   const filesBase = process.env.FILES_BASE;
@@ -161,30 +152,6 @@ export const getR2Url = async (
     key,
     response,
     bucketedSignatureExpiry()
-  );
-};
-
-const hexEncode = (buffer: ArrayBuffer): string =>
-  Array.from(new Uint8Array(buffer), (byte) =>
-    byte.toString(16).padStart(2, "0")
-  ).join("");
-
-// Must stay in lockstep with apps/files-worker/src/lib.ts — the shared test
-// vectors prove both runtimes produce identical HMAC output.
-export const hmacSha256Hex = async (
-  secret: string,
-  message: string
-): Promise<string> => {
-  const encoder = new TextEncoder();
-  const cryptoKey = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"]
-  );
-  return hexEncode(
-    await crypto.subtle.sign("HMAC", cryptoKey, encoder.encode(message))
   );
 };
 

--- a/packages/convex/storage/r2Keys.ts
+++ b/packages/convex/storage/r2Keys.ts
@@ -1,0 +1,62 @@
+/**
+ * Leaf storage primitives: R2 key-namespace helpers and HMAC signing.
+ *
+ * This module must not import from any other `storage/*` module.
+ * `storage/r2` is heavily mocked in tests (see
+ * `__tests__/helpers/r2Mock.test-utils.ts`) while `storage/filesWorkerClient`
+ * is imported for real alongside those mocks, so anything imported from the
+ * mocked surface risks a named-export link error depending on test execution
+ * order. Keep every export here pure and dependency-free; `storage/r2`
+ * re-exports them for backward compatibility.
+ */
+
+/**
+ * Internal R2 key prefix for environment isolation.
+ * - Production: unset -> "users/..."
+ * - Development: "dev/" -> "dev/users/..."
+ * This is protection against routine mistakes; shared credentials retain bucket-wide authority.
+ */
+export const getR2KeyPrefix = (): string => {
+  const raw = process.env.R2_KEY_PREFIX ?? "";
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const normalized = trimmed.replace(/^\/+/, "");
+  return normalized.endsWith("/") ? normalized : `${normalized}/`;
+};
+
+export const buildR2ListPrefix = (): string => `${getR2KeyPrefix()}users/`;
+
+export const isR2KeyInNamespace = (key: string): boolean =>
+  key.startsWith(`${getR2KeyPrefix()}users/`);
+
+export const assertR2KeyInNamespace = (key: string): void => {
+  if (!isR2KeyInNamespace(key)) {
+    throw new Error("invalid_storage_key_namespace");
+  }
+};
+
+const hexEncode = (buffer: ArrayBuffer): string =>
+  Array.from(new Uint8Array(buffer), (byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("");
+
+// Must stay in lockstep with apps/files-worker/src/lib.ts — the shared test
+// vectors prove both runtimes produce identical HMAC output.
+export const hmacSha256Hex = async (
+  secret: string,
+  message: string
+): Promise<string> => {
+  const encoder = new TextEncoder();
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  return hexEncode(
+    await crypto.subtle.sign("HMAC", cryptoKey, encoder.encode(message))
+  );
+};

--- a/packages/convex/workflows/objectCleanup.ts
+++ b/packages/convex/workflows/objectCleanup.ts
@@ -16,7 +16,7 @@ import {
   callFilesWorkerJson,
   isFilesWorkerConfigured,
 } from "../storage/filesWorkerClient";
-import { isR2KeyInNamespace } from "../storage/r2";
+import { isR2KeyInNamespace } from "../storage/r2Keys";
 import { startWorkflow, workflow } from "./manager";
 
 const internalAny = internal as any;

--- a/packages/convex/workflows/orphanSweep.ts
+++ b/packages/convex/workflows/orphanSweep.ts
@@ -23,7 +23,8 @@ import {
   type FilesWorkerListObjectsResult,
   isFilesWorkerConfigured,
 } from "../storage/filesWorkerClient";
-import { buildR2ListPrefix, cardStorageObjectKeys } from "../storage/r2";
+import { cardStorageObjectKeys } from "../storage/r2";
+import { buildR2ListPrefix } from "../storage/r2Keys";
 import { recordBackendLog } from "../telemetry/sentry";
 
 // Orphans younger than this are ignored: pending-upload sessions, in-flight


### PR DESCRIPTION
Fixes the deterministic CLI Release failure on v1.0.66 (Bun 1.4.0, Linux CI): `SyntaxError: Export named 'assertR2KeyInNamespace' not found in module 'storage/r2.ts'`.

Root cause: `storage/r2.ts` <-> `storage/filesWorkerClient.ts` circular import combined with partial `mock.module('storage/r2')` registrations (e.g. generatePdfThumbnail mock provides no key-namespace helpers). Depending on test-file execution order, real importers of those helpers resolve against the partial mock and the whole file fails to link. Local Bun 1.4.1/macOS ordering masked it; CI ordering exposes it. Rerun of the failed CLI job failed identically, so not transient.

Change (pure code motion, no behavior change):
- New leaf module `storage/r2Keys.ts` with the dependency-free primitives (`getR2KeyPrefix`, `buildR2ListPrefix`, `isR2KeyInNamespace`, `assertR2KeyInNamespace`, `hmacSha256Hex`). Zero imports by construction.
- `storage/r2.ts` imports them for internal use and re-exports for backward compatibility.
- `filesWorkerClient.ts`, `objectCleanup.ts`, `orphanSweep.ts`, `pendingUploadCleanup.ts` import the helpers from `r2Keys` directly.
- `r2Mock.test-utils.ts` factory passes the pure helpers (plus `PENDING_UPLOAD_CARD_ID`) through so a partial r2 mock can never cause a named-export link error again. Verified every name imported from `storage/r2` in non-test code is now provided by the factory.

Verified: convex typecheck clean, biome clean, 1520/1520 unit + 36/36 edge tests pass locally.

Intended follow-up: ship as 1.0.67 patch release (keeps v1.0.66 tag immutable per runbook).