### PR TITLE
Move import parsing and audio transcription into files worker

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - ".github/workflows/backend-deploy.yml"
       - "packages/convex/**"
+      - "packages/files-protocol/**"
+      - "apps/files-worker/**"
+      - "scripts/check-files-readiness.ts"
       - "bun.lock"
   workflow_dispatch:
 
@@ -37,6 +40,8 @@ jobs:
           test -n "$CONVEX_DEPLOY_KEY"
           test -n "$SENTRY_AUTH_TOKEN"
           test -n "$SENTRY_BACKEND_DSN"
+      - name: Wait for compatible files worker
+        run: bun run scripts/check-files-readiness.ts --prod --wait
       - name: Configure backend release context
         working-directory: packages/convex
         run: |

--- a/apps/docs/content/changelog/2026-09-12.mdx
+++ b/apps/docs/content/changelog/2026-09-12.mdx
@@ -1,0 +1,12 @@
+---
+title: "More reliable imports"
+description: Imports handle cancellation and changed uploads more reliably.
+type: changelog
+date: "2026-09-12"
+changelog:
+  category: Improvements
+---
+
+- Canceling an import now stops parsing between batches.
+- Archive imports detect changes to the uploaded file during processing.
+- Import error reports show short excerpts of failed items to keep large reports manageable.

--- a/apps/files-worker/README.md
+++ b/apps/files-worker/README.md
@@ -26,14 +26,16 @@ worker. Eligible sources (≤20 MB) are transformed directly from R2 through
 the binding, cached per source ETag + rendition + format; larger sources keep
 the URL-based transformation path. The Convex backend remains the control plane — it authenticates
 users, owns card state, validates uploads, and orchestrates workflows —
-while every byte-processing operation (uploads, deletes, analysis, AI,
-generated media) flows through this worker.
+while stored-file processing and storage transfers flow through this worker.
+Remote preview fetching retains its DNS-pinned Convex implementation (see below);
+PDF/video rendering and screenshots remain in Kernel.
 
 ## Internal ops
 
 Besides downloads, the worker accepts body-bound, short-lived signed `POST`
 requests at `/__ops/v1`. Contracts and typed success/error envelopes live in
 `@teak/files-protocol`; `HEAD` and `GET` can never execute an operation.
+Operation request bodies are limited to 1 MiB before signature verification.
 
 - `op=analyze-image` / `analyze-image-content` — reads intrinsic dimensions
   and a bounded color sample through Cloudflare transformations; SVG input is
@@ -70,6 +72,98 @@ requests at `/__ops/v1`. Contracts and typed success/error envelopes live in
   Workers AI (Gemma multimodal) with the same system prompt, JSON output
   shape, and bounded validation retries as the pipeline it replaced; image
   bytes never leave the worker (`src/imageMetadata.ts`).
+
+## Import and audio processing
+
+- `transcribe-audio` accepts an authorized R2 source key and optional MIME hint.
+  The AI binding streams the R2 body to `@cf/openai/whisper-large-v3-turbo`.
+  Audio is limited to the existing 100 MiB upload limit; returned UTF-8 text
+  is limited to 512 KiB. Results contain text, byte count, MIME type, and source
+  ETag, never segments or audio bytes. Convex retains AI telemetry and optional
+  enrichment failure semantics; card processing status and retries stay there.
+- `index-import-source` accepts archive/bookmarks/raindrop, expected source size,
+  and an offset cursor. It returns at most 100 items and 4 MiB of item JSON;
+  continuation requests bind the original ETag. The import action binds
+  that ETag to the job before storing rows and uses it during extraction. Convex owns card
+  validation, deduplication across pages, cancellation, and database writes.
+- `read-import-markdown` returns one UTF-8 Markdown entry (512 KiB maximum),
+  or a typed per-item decoding/size failure. Convex decides whether a legacy
+  document becomes a text card. Import writes are batched by both item count
+  and encoded size after Markdown expansion.
+- ZIP inspection, indexing, and `extract-import-files` share `src/zip.ts`.
+  Ranged reads support classic ZIP and ZIP64 offsets within the existing 5 GiB
+  archive/expanded-byte limits. Central directories are capped at 32 MiB and
+  20,002 entries (10,000 cards plus files and metadata). Multi-disk, encrypted,
+  duplicate, traversal, and unsupported-compression entries are rejected.
+  Every read checks source ETag; local headers and actual decompressed sizes
+  are checked before extracted files are stored under the same user namespace.
+- Import JSON retains its 64 MiB byte limit and is parsed incrementally with
+  completed siblings discarded. Only the requested page is retained. Defensive
+  limits also bound JSON nesting (64), string tokens (1 MiB), and individual
+  in-progress values (4 MiB). Extraction/preview entries retain the 100:1
+  compression-ratio guard; JSON and Markdown use actual streamed byte limits
+  so highly compressible valid text remains importable.
+- The canonical pure bookmark/CSV parsers remain in `packages/convex/import`
+  and are imported directly by the worker. They execute in the worker for
+  imports; no second parser or S3 fallback exists. Sources remain capped at
+  20 MiB and 10,000 bookmarks. HTML is parsed without building a DOM, with a
+  nesting limit of 128; CSV is limited to 256 columns and assembles quoted
+  fields in bounded chunks.
+- Convex generates bounded error-report excerpts and uploads them through the
+  existing signed PUT endpoint. Source/report cleanup is handed to the durable
+  object-deletion workflow before import rows are removed. Multipart abort is
+  idempotent only for R2 `NoSuchUpload` (10024); other errors propagate.
+
+### Remote preview ingestion: retained security boundary
+
+`workflows/steps/linkMetadata/fetchMetadata.ts` still downloads remote preview
+assets using the existing DNS validation, pinned address set, redirect checks,
+byte/type limits, and dimensions checks, then uploads through the worker.
+Moving this fetch without equivalent connection pinning would permit DNS
+rebinding between validation and connection.
+
+The [Workers HTTP API](https://developers.cloudflare.com/workers/runtime-apis/nodejs/http/)
+does not implement `lookup` or `createConnection`.
+[`resolveOverride`](https://developers.cloudflare.com/workers/runtime-apis/request/#requestinitcfproperties)
+is restricted to hosts in the zone and cannot pin arbitrary external preview
+hosts. A local workerd probe using the existing Undici Agent with a custom
+lookup failed before calling lookup with
+`ERR_OPTION_NOT_IMPLEMENTED: The options.ALPNProtocols option is not implemented`.
+This was reproduced on 2026-09-12 with both repository Wrangler 4.125.0 and
+latest Wrangler 4.131.1. Replacing the transport with custom TLS/HTTP shims
+is outside this consolidation. The protected Convex path remains canonical.
+
+### Verification and deployment boundary
+
+Deterministic tests cover signed routes, pagination, source replacement, ZIP64
+reads beyond 4 GiB, unsafe entries, actual decompression limits, Markdown
+outcomes, and binding input/output limits. `packages/convex/importConsolidation.test.ts`
+checks real Convex mutation state for deduplication, action replay, cancellation,
+and rejected source changes using the edge test runtime.
+
+Local workerd verification used a separate config with a local-only R2 bucket
+and test signing secret. It exercised upload, 103-card indexing over two pages,
+Markdown, file extraction, HTML/CSV, and cleanup. The real AI binding was tested
+with synthetic speech streamed from local R2; no production objects were written.
+The streaming binding contract is also documented in the
+[Cloudflare binding implementation](https://github.com/cloudflare/workerd/blob/main/src/cloudflare/internal/ai-api.ts).
+
+Deploy the worker operations before their Convex callers. The backend deployment
+runs `bun run scripts/check-files-readiness.ts --prod --wait`: an authenticated,
+read-only capability probe must confirm the required operations and AI/Images
+bindings before Convex deploys. It waits at most ten minutes for Cloudflare Builds.
+
+The first index step retains its original function reference and arguments.
+Old journal results have no continuation cursor and follow their existing step
+sequence. New imports checkpoint one page per action and deduplicate across
+pages using the job/URL index. Markdown reads run eight at a time. The optional `importJobs.sourceEtag` is bound atomically
+inside indexing/extraction, so existing journals can resume without a restart
+or backfill. A local backend plus real R2 run indexed 10,000 items (about
+55 MiB of JSON, including 256 Markdown files) across 100 pages in 391 seconds.
+The longest Markdown-heavy page took 44 seconds; all fixtures were cleaned up. Before rollback, retain this optional schema field while reverting
+callers; reverting to a schema that rejects stored ETags requires a separate,
+explicitly approved data migration. Keep the compatible worker deployed while
+rolling back backend callers.
 
 ## Single-file signed uploads
 

--- a/apps/files-worker/package.json
+++ b/apps/files-worker/package.json
@@ -15,6 +15,8 @@
     "@cf-wasm/photon": "^0.4.0",
     "@resvg/resvg-wasm": "^2.6.2",
     "@sentry/cloudflare": "10.69.0",
+    "@streamparser/json": "^0.0.26",
+    "@teak/convex": "workspace:*",
     "@teak/files-protocol": "workspace:*",
     "client-zip": "^2.4.5",
     "fflate": "^0.8.2"

--- a/apps/files-worker/src/consolidation.test.ts
+++ b/apps/files-worker/src/consolidation.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  buildFilesOpSigningPayload,
+  FILES_AUDIO_MAX_BYTES,
+  FILES_TRANSCRIPT_MAX_BYTES,
+  FILES_TRANSCRIPTION_MODEL,
+  type FilesOp,
+} from "@teak/files-protocol";
+import { strToU8, zipSync } from "fflate";
+import { hmacSha256Hex, sha256Hex } from "./lib";
+import { type FilesOpsEnv, handleInternalOp } from "./ops";
+import { FakeBucket } from "./testsupport";
+import { transcribeAudio } from "./transcript";
+
+async function request(op: FilesOp, params: Record<string, unknown>) {
+  const body = JSON.stringify({ version: 1, op, params });
+  const expiresAt = String(Math.floor(Date.now() / 1000) + 600),
+    requestId = "test";
+  return new Request("http://localhost/__ops/v1", {
+    method: "POST",
+    body,
+    headers: {
+      "x-teak-request-id": requestId,
+      "x-teak-expires-at": expiresAt,
+      "x-teak-signature": await hmacSha256Hex(
+        "test-secret",
+        buildFilesOpSigningPayload({
+          bodySha256: await sha256Hex(body),
+          expiresAt,
+          requestId,
+        })
+      ),
+    },
+  });
+}
+const envFor = (bucket: FakeBucket): FilesOpsEnv => ({
+  BUCKET: bucket as unknown as R2Bucket,
+  FILES_SIGNING_SECRET: "test-secret",
+});
+
+describe("signed file operations", () => {
+  test("malformed archive JSON is a non-retryable input failure", async () => {
+    const bucket = new FakeBucket();
+    const key = "users/u/imports/job/source.zip";
+    const bytes = zipSync({
+      "manifest.json": strToU8('{"version":1,"cards":[}'),
+    });
+    bucket.objects.set(key, { bytes });
+    const response = await handleInternalOp(
+      await request("index-import-source", {
+        sourceKey: key,
+        mode: "archive",
+        expectedSize: bytes.length,
+      }),
+      envFor(bucket)
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { code: "INVALID_INPUT", retryable: false },
+    });
+  });
+  test("streams R2 audio through the binding, returning only bounded transcript facts", async () => {
+    const bucket = new FakeBucket();
+    bucket.objects.set("users/u/audio.wav", {
+      bytes: new Uint8Array([1, 2, 3]),
+      httpMetadata: { contentType: "audio/wav" },
+    });
+    const run = mock(
+      async (_model: string, inputs: Record<string, unknown>) => {
+        const audio = inputs.audio as {
+          body: ReadableStream;
+          contentType: string;
+        };
+        expect(audio.contentType).toBe("audio/wav");
+        expect(
+          new Uint8Array(await new Response(audio.body).arrayBuffer())
+        ).toEqual(new Uint8Array([1, 2, 3]));
+        return {
+          text: "Hello world",
+          segments: [{ text: "Do not return segments" }],
+        };
+      }
+    );
+    const response = await handleInternalOp(
+      await request("transcribe-audio", { sourceKey: "users/u/audio.wav" }),
+      { ...envFor(bucket), AI: { run } }
+    );
+    expect(response.status).toBe(200);
+    const result = (await response.json()) as { data: Record<string, unknown> };
+    expect(result.data).toMatchObject({
+      text: "Hello world",
+      byteLength: 3,
+      mimeType: "audio/wav",
+    });
+    expect(result.data).not.toHaveProperty("segments");
+    expect(run.mock.calls[0][0]).toBe(FILES_TRANSCRIPTION_MODEL);
+  });
+  test("rejects oversized audio before inference and bounds model output", async () => {
+    const run = mock(async () => ({
+      text: "x".repeat(FILES_TRANSCRIPT_MAX_BYTES + 1),
+    }));
+    const bucket = new FakeBucket();
+    bucket.objects.set("users/u/audio", { bytes: new Uint8Array([1]) });
+    const env = { ...envFor(bucket), AI: { run } };
+    await expect(
+      transcribeAudio(env, { sourceKey: "users/u/audio" })
+    ).rejects.toThrow("source_too_large");
+    const get = bucket.get.bind(bucket);
+    bucket.get = (key, options) => {
+      const object = get(key, options);
+      return object ? { ...object, size: FILES_AUDIO_MAX_BYTES + 1 } : object;
+    };
+    run.mockClear();
+    await expect(
+      transcribeAudio(env, { sourceKey: "users/u/audio" })
+    ).rejects.toThrow("source_too_large");
+    expect(run).not.toHaveBeenCalled();
+  });
+  test("returns retryable failures for unavailable AI, and input errors for malformed requests", async () => {
+    const bucket = new FakeBucket();
+    bucket.objects.set("users/u/audio", { bytes: new Uint8Array([1]) });
+    for (const params of [
+      { sourceKey: 3 },
+      { sourceKey: "users/u/../bad" },
+      { sourceKey: "users/u/audio", mimeType: 5 },
+    ]) {
+      const response = await handleInternalOp(
+        await request("transcribe-audio", params),
+        envFor(bucket)
+      );
+      expect(response.status).toBe(400);
+    }
+    const response = await handleInternalOp(
+      await request("transcribe-audio", { sourceKey: "users/u/audio" }),
+      envFor(bucket)
+    );
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      error: { retryable: true },
+    });
+  });
+  test("indexes and extracts through signed routes with source-version and user isolation", async () => {
+    const bucket = new FakeBucket(),
+      key = "users/u/imports/job/source.zip";
+    const bytes = zipSync(
+      {
+        "manifest.json": strToU8(
+          '{"version":1,"cards":[{"type":"document","file":{"path":"files/a.txt"}}]}'
+        ),
+        "files/a.txt": strToU8("Hello"),
+      },
+      { level: 0 }
+    );
+    bucket.objects.set(key, { bytes });
+    const indexed = await handleInternalOp(
+      await request("index-import-source", {
+        sourceKey: key,
+        mode: "archive",
+        expectedSize: bytes.length,
+      }),
+      envFor(bucket)
+    );
+    expect(indexed.status).toBe(200);
+    const page = (await indexed.json()) as {
+      data: { sourceEtag: string; items: unknown[] };
+    };
+    expect(page.data.items).toEqual([
+      {
+        sourceIndex: 0,
+        card: { type: "document", file: { path: "files/a.txt" } },
+        file: { path: "files/a.txt", uncompressedSize: 5 },
+      },
+    ]);
+    const extracted = await handleInternalOp(
+      await request("extract-import-files", {
+        archiveKey: key,
+        sourceEtag: page.data.sourceEtag,
+        entries: [
+          {
+            path: "files/a.txt",
+            destinationKey: "users/u/import-job/item/file/a.txt",
+          },
+        ],
+      }),
+      envFor(bucket)
+    );
+    expect(extracted.status).toBe(200);
+    expect(bucket.storedBytes("users/u/import-job/item/file/a.txt")).toEqual(
+      strToU8("Hello")
+    );
+    const changed = await handleInternalOp(
+      await request("read-import-markdown", {
+        sourceKey: key,
+        sourceEtag: '"old"',
+        path: "files/a.txt",
+      }),
+      envFor(bucket)
+    );
+    expect(changed.status).toBe(409);
+    const unsigned = await handleInternalOp(
+      new Request("http://localhost/__ops/v1", {
+        method: "POST",
+        body: JSON.stringify({
+          op: "index-import-source",
+          version: 1,
+          params: { sourceKey: key },
+        }),
+      }),
+      envFor(bucket)
+    );
+    expect(unsigned.status).toBe(401);
+  });
+  test("only suppresses a confirmed missing multipart upload", async () => {
+    const bucket = new FakeBucket();
+    bucket.resumeMultipartUpload = () => {
+      throw new Error("R2: NoSuchUpload (10024)");
+    };
+    expect(
+      (
+        await handleInternalOp(
+          await request("abort-multipart", {
+            key: "users/u/imports/job/source",
+            uploadId: "gone",
+          }),
+          envFor(bucket)
+        )
+      ).status
+    ).toBe(200);
+    bucket.resumeMultipartUpload = () => {
+      throw new Error("R2: ServiceUnavailable (10043)");
+    };
+    expect(
+      (
+        await handleInternalOp(
+          await request("abort-multipart", {
+            key: "users/u/imports/job/source",
+            uploadId: "gone",
+          }),
+          envFor(bucket)
+        )
+      ).status
+    ).toBe(500);
+  });
+});

--- a/apps/files-worker/src/importJson.ts
+++ b/apps/files-worker/src/importJson.ts
@@ -1,0 +1,163 @@
+import { JSONParser, TokenType } from "@streamparser/json";
+import {
+  FILES_IMPORT_PAGE_BYTES,
+  FILES_IMPORT_PAGE_ITEMS,
+  type FilesImportIndexItem,
+} from "@teak/files-protocol";
+import {
+  consumeZipEntry,
+  type ZipCentralEntry,
+  type ZipDirectory,
+} from "./zip";
+
+/** Discard completed siblings; retain only this page, never the 64 MiB JSON document. */
+export async function readImportJson(
+  bucket: R2Bucket,
+  key: string,
+  directory: ZipDirectory,
+  entry: ZipCentralEntry,
+  cursor: number
+) {
+  const items: FilesImportIndexItem[] = [];
+  let total = 0,
+    pageBytes = 0,
+    full = false,
+    hasCards = false;
+  let cardsArrays = 0;
+  let version: unknown, exportVersion: unknown;
+  let parser: JSONParser | undefined;
+  let rootArray = false,
+    depth = 0,
+    lastRootKey = "",
+    valueBytes = 0;
+  const entries = new Map(
+    directory.entries.map((value) => [value.name, value])
+  );
+  const initialize = (chunk: Uint8Array) => {
+    const first = new TextDecoder().decode(chunk).trimStart()[0];
+    if (!first) {
+      return;
+    }
+    rootArray = first === "[";
+    hasCards = rootArray;
+    parser = new JSONParser({
+      paths: rootArray
+        ? ["$.*"]
+        : ["$.cards.*", "$.version", "$.exportVersion"],
+      keepStack: false,
+      stringBufferSize: 65_536,
+      emitPartialTokens: true,
+    });
+    parser.onError = (error) => {
+      if (error.message.startsWith("invalid_archive")) {
+        throw error;
+      }
+      throw new Error("archive_parse_failed", { cause: error });
+    };
+    parser.onToken = ({ token, value, partial }) => {
+      if (typeof value === "string" && value.length > 1024 * 1024) {
+        throw new Error("invalid_archive_json_value_size");
+      }
+      if (partial) {
+        return;
+      }
+      if (token === TokenType.LEFT_BRACE || token === TokenType.LEFT_BRACKET) {
+        if (
+          depth === 1 &&
+          lastRootKey === "cards" &&
+          token === TokenType.LEFT_BRACKET
+        ) {
+          cardsArrays += 1;
+          if (cardsArrays > 1) {
+            throw new Error("invalid_archive_duplicate_cards");
+          }
+          hasCards = true;
+        }
+        depth++;
+        if (depth > 64) {
+          throw new Error("invalid_archive_json_depth");
+        }
+      } else if (
+        token === TokenType.RIGHT_BRACE ||
+        token === TokenType.RIGHT_BRACKET
+      ) {
+        depth--;
+      } else if (depth === 1 && token === TokenType.STRING) {
+        lastRootKey = String(value);
+      }
+      valueBytes += typeof value === "string" ? value.length : 8;
+      if (valueBytes > FILES_IMPORT_PAGE_BYTES) {
+        throw new Error("invalid_archive_json_value_size");
+      }
+    };
+    parser.onValue = ({ key: field, value, stack }) => {
+      if (!rootArray && stack.length === 1) {
+        if (field === "version") {
+          version = value;
+        }
+        if (field === "exportVersion") {
+          exportVersion = value;
+        }
+        valueBytes = 0;
+        return;
+      }
+      const sourceIndex = total++;
+      valueBytes = 0;
+      if (total > 10_000) {
+        throw new Error("invalid_archive_card_count");
+      }
+      if (sourceIndex < cursor || full) {
+        return;
+      }
+      const item: FilesImportIndexItem = { sourceIndex, card: value };
+      const raw = value as { file?: { path?: unknown } } | null;
+      if (typeof raw?.file?.path === "string") {
+        const file = entries.get(raw.file.path);
+        if (file && !file.name.endsWith("/")) {
+          item.file = {
+            path: file.name,
+            uncompressedSize: file.uncompressedSize,
+          };
+        }
+      }
+      const size = new TextEncoder().encode(JSON.stringify(item)).length;
+      if (size > FILES_IMPORT_PAGE_BYTES) {
+        item.card = undefined;
+        item.error = "Import item is too large";
+        item.label = `Item ${sourceIndex + 1}`;
+      }
+      const boundedSize = new TextEncoder().encode(JSON.stringify(item)).length;
+      if (
+        items.length &&
+        (pageBytes + boundedSize > FILES_IMPORT_PAGE_BYTES ||
+          items.length >= FILES_IMPORT_PAGE_ITEMS)
+      ) {
+        full = true;
+        return;
+      }
+      items.push(item);
+      pageBytes += boundedSize;
+    };
+  };
+  await consumeZipEntry(
+    bucket,
+    key,
+    directory,
+    entry,
+    64 * 1024 * 1024,
+    (chunk) => {
+      if (!parser) {
+        initialize(chunk);
+      }
+      parser?.write(chunk);
+    },
+    Number.POSITIVE_INFINITY
+  );
+  if (!parser) {
+    throw new Error("archive_parse_failed");
+  }
+  if (!parser.isEnded) {
+    parser.end();
+  }
+  return { items, total, hasCards, version: version ?? exportVersion };
+}

--- a/apps/files-worker/src/importSource.test.ts
+++ b/apps/files-worker/src/importSource.test.ts
@@ -23,6 +23,32 @@ function archive(files: Record<string, Uint8Array>) {
 const asBucket = (bucket: FakeBucket) => bucket as unknown as R2Bucket;
 
 describe("worker import source", () => {
+  test("matches CP437 filenames in both ZIP headers to Unicode manifest paths", async () => {
+    const { bucket, params, bytes } = archive({
+      "manifest.json": strToU8(
+        JSON.stringify({
+          version: 1,
+          cards: [{ type: "document", file: { path: "files/café.md" } }],
+        })
+      ),
+      "files/cafX.md": strToU8("# Café"),
+    });
+    const name = strToU8("files/cafX.md");
+    for (let i = 0; i <= bytes.length - name.length; i++) {
+      if (name.every((byte, j) => bytes[i + j] === byte)) {
+        bytes[i + 9] = 130;
+      }
+    }
+    const page = await indexImportSource(asBucket(bucket), params);
+    expect(page.items[0].file?.path).toBe("files/café.md");
+    expect(
+      await readImportMarkdown(asBucket(bucket), {
+        sourceKey,
+        sourceEtag: page.sourceEtag,
+        path: "files/café.md",
+      })
+    ).toEqual({ content: "# Café", type: "text" });
+  });
   test("pages inline manifest cards and returns only referenced file facts", async () => {
     const cards = Array.from({ length: 103 }, (_, i) => ({
       type: "text",

--- a/apps/files-worker/src/importSource.test.ts
+++ b/apps/files-worker/src/importSource.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import { strToU8, zipSync } from "fflate";
+import { indexImportSource, readImportMarkdown } from "./importSource";
+import { FakeBucket, fakeHttpEtag } from "./testsupport";
+import {
+  ArchiveEntryTooLargeError,
+  extractZipEntries,
+  readZipDirectory,
+  readZipEntry,
+} from "./zip";
+
+const sourceKey = "users/u/imports/job/source.zip";
+function archive(files: Record<string, Uint8Array>) {
+  const bucket = new FakeBucket();
+  const bytes = zipSync(files, { level: 0 });
+  bucket.objects.set(sourceKey, { bytes });
+  return {
+    bucket,
+    params: { sourceKey, mode: "archive" as const, expectedSize: bytes.length },
+    bytes,
+  };
+}
+const asBucket = (bucket: FakeBucket) => bucket as unknown as R2Bucket;
+
+describe("worker import source", () => {
+  test("pages inline manifest cards and returns only referenced file facts", async () => {
+    const cards = Array.from({ length: 103 }, (_, i) => ({
+      type: "text",
+      content: `Card ${i}`,
+    }));
+    const { bucket, params } = archive({
+      "manifest.json": strToU8(JSON.stringify({ version: 1, cards })),
+    });
+    const first = await indexImportSource(asBucket(bucket), params);
+    expect(first.total).toBe(103);
+    expect(first.items).toHaveLength(100);
+    expect(first.nextCursor).toBe(100);
+    expect(first.items[0]).toEqual({ sourceIndex: 0, card: cards[0] });
+    const last = await indexImportSource(asBucket(bucket), {
+      ...params,
+      cursor: first.nextCursor!,
+      sourceEtag: first.sourceEtag,
+    });
+    expect(last.items.map((item) => item.sourceIndex)).toEqual([100, 101, 102]);
+    expect(last.nextCursor).toBeNull();
+  });
+  test("supports separate array and object cards.json, legacy version, and empty archives", async () => {
+    for (const cards of [[], [{ type: "text", content: "hello" }]]) {
+      for (const json of [cards, { cards }]) {
+        const { bucket, params } = archive({
+          "manifest.json": strToU8('{"exportVersion":1}'),
+          "cards.json": strToU8(JSON.stringify(json)),
+        });
+        const result = await indexImportSource(asBucket(bucket), params);
+        expect(result.total).toBe(cards.length);
+        expect(result.nextCursor).toBeNull();
+      }
+    }
+  });
+  test("rejects unsupported versions, missing cards, unsafe paths, and encrypted entries", async () => {
+    for (const manifest of [{ version: 2, cards: [] }, { version: 1 }]) {
+      const { bucket, params } = archive({
+        "manifest.json": strToU8(JSON.stringify(manifest)),
+      });
+      await expect(indexImportSource(asBucket(bucket), params)).rejects.toThrow(
+        "invalid_archive"
+      );
+    }
+    const { bucket, params } = archive({
+      "../bad": strToU8("bad"),
+      "manifest.json": strToU8('{"version":1,"cards":[]}'),
+    });
+    await expect(indexImportSource(asBucket(bucket), params)).rejects.toThrow(
+      "invalid_archive_entry"
+    );
+  });
+  test("rejects a changed source even when its byte length is unchanged", async () => {
+    const { bucket, params, bytes } = archive({
+      "manifest.json": strToU8('{"version":1,"cards":[]}'),
+    });
+    await expect(
+      indexImportSource(asBucket(bucket), { ...params, sourceEtag: '"old"' })
+    ).rejects.toThrow("source_changed");
+    await expect(
+      indexImportSource(asBucket(bucket), { ...params, cursor: 1 })
+    ).rejects.toThrow("invalid_import_params");
+    expect(fakeHttpEtag(bytes)).toBe(
+      (await indexImportSource(asBucket(bucket), params)).sourceEtag
+    );
+  });
+  test("returns Markdown content and typed UTF-8/size failures", async () => {
+    const { bucket, bytes } = archive({
+      "files/note.md": strToU8("# Notes"),
+      "files/bad.md": new Uint8Array([0xff]),
+      "files/large.md": new Uint8Array(512 * 1024 + 1),
+    });
+    const params = { sourceKey, sourceEtag: fakeHttpEtag(bytes) };
+    expect(
+      await readImportMarkdown(asBucket(bucket), {
+        ...params,
+        path: "files/note.md",
+      })
+    ).toEqual({ content: "# Notes", type: "text" });
+    expect(
+      await readImportMarkdown(asBucket(bucket), {
+        ...params,
+        path: "files/bad.md",
+      })
+    ).toMatchObject({ status: "failed", failureCode: "INVALID_UTF8" });
+    expect(
+      await readImportMarkdown(asBucket(bucket), {
+        ...params,
+        path: "files/large.md",
+      })
+    ).toMatchObject({ status: "failed", failureCode: "CONTENT_TOO_LARGE" });
+  });
+  test("enforces actual inflated size and never writes an oversized entry", async () => {
+    const { bucket } = archive({ "files/a": strToU8("abc") });
+    const directory = await readZipDirectory(asBucket(bucket), sourceKey);
+    const entry = { ...directory.entries[0], uncompressedSize: 2 };
+    await expect(
+      readZipEntry(asBucket(bucket), sourceKey, directory, entry, 2)
+    ).rejects.toBeInstanceOf(ArchiveEntryTooLargeError);
+    await expect(
+      extractZipEntries(asBucket(bucket), sourceKey, [
+        { path: "files/a", destinationKey: "users/other/card/file/a" },
+      ])
+    ).rejects.toThrow("invalid_extract_entry");
+    expect(bucket.puts).toHaveLength(0);
+  });
+  test("parses bookmark HTML and Raindrop CSV and retains per-item failures", async () => {
+    for (const mode of ["bookmarks", "raindrop"] as const) {
+      const text =
+        mode === "bookmarks"
+          ? '<DL><DT><A HREF="javascript:bad">Bad</A><DT><A HREF="https://example.com">Good</A></DL>'
+          : 'url,title,note\njavascript:bad,Bad,\nhttps://example.com,Good,"A, note"';
+      const bytes = strToU8(text),
+        bucket = new FakeBucket();
+      bucket.objects.set(sourceKey, { bytes });
+      const result = await indexImportSource(asBucket(bucket), {
+        sourceKey,
+        mode,
+        expectedSize: bytes.length,
+      });
+      expect(result.total).toBe(2);
+      expect(result.items[0].error).toContain("unsafe");
+      expect(result.items[1].card).toMatchObject({
+        type: "link",
+        content: "Good",
+        url: "https://example.com",
+      });
+    }
+  });
+});

--- a/apps/files-worker/src/importSource.ts
+++ b/apps/files-worker/src/importSource.ts
@@ -1,0 +1,225 @@
+import { parseBookmarksHtml } from "@teak/convex/import/bookmarks";
+import { parseRaindropCsv } from "@teak/convex/import/raindrop";
+import {
+  decodeMarkdownUtf8,
+  MARKDOWN_CONTENT_MAX_BYTES,
+  MarkdownContentError,
+} from "@teak/convex/shared/markdown";
+import {
+  FILES_IMPORT_PAGE_BYTES,
+  FILES_IMPORT_PAGE_ITEMS,
+  type FilesImportIndexParams,
+  type FilesImportIndexResult,
+  type FilesImportMarkdownParams,
+  type FilesImportMarkdownResult,
+} from "@teak/files-protocol";
+import { readImportJson } from "./importJson";
+import { isValidUploadKey } from "./upload";
+import {
+  ArchiveEntryTooLargeError,
+  readZipDirectory,
+  readZipEntry,
+} from "./zip";
+
+export async function indexImportSource(
+  bucket: R2Bucket,
+  input: unknown
+): Promise<FilesImportIndexResult> {
+  if (!input || typeof input !== "object") {
+    throw new Error("invalid_import_params");
+  }
+  const params = input as FilesImportIndexParams;
+  const { sourceKey, mode, expectedSize, sourceEtag } = params;
+  const cursor = params.cursor ?? 0;
+  if (
+    !(
+      typeof sourceKey === "string" &&
+      isValidUploadKey(sourceKey) &&
+      ["archive", "bookmarks", "raindrop"].includes(mode) &&
+      Number.isSafeInteger(expectedSize)
+    ) ||
+    expectedSize < 0 ||
+    !Number.isSafeInteger(cursor) ||
+    cursor < 0 ||
+    cursor > 10_000 ||
+    (cursor > 0 && !sourceEtag) ||
+    (sourceEtag !== undefined &&
+      (typeof sourceEtag !== "string" || sourceEtag.length > 255))
+  ) {
+    throw new Error("invalid_import_params");
+  }
+  const meta = await bucket.head(sourceKey);
+  if (!meta) {
+    throw new Error("source_not_found");
+  }
+  if (
+    meta.size !== expectedSize ||
+    (sourceEtag && sourceEtag !== meta.httpEtag)
+  ) {
+    throw new Error("source_changed");
+  }
+  if (mode === "archive") {
+    const directory = await readZipDirectory(bucket, sourceKey, meta.httpEtag);
+    const manifestEntry = directory.entries.find(
+      (entry) => entry.name === "manifest.json"
+    );
+    if (!manifestEntry) {
+      throw new Error("invalid_archive_missing_manifest");
+    }
+    let page = await readImportJson(
+      bucket,
+      sourceKey,
+      directory,
+      manifestEntry,
+      cursor
+    );
+    if (page.version !== 1) {
+      throw new Error("invalid_archive_version");
+    }
+    if (!page.hasCards) {
+      const cardsEntry = directory.entries.find(
+        (entry) => entry.name === "cards.json"
+      );
+      if (!cardsEntry) {
+        throw new Error("invalid_archive_missing_cards");
+      }
+      page = await readImportJson(
+        bucket,
+        sourceKey,
+        directory,
+        cardsEntry,
+        cursor
+      );
+      if (!page.hasCards) {
+        throw new Error("invalid_archive_missing_cards");
+      }
+    }
+    return {
+      items: page.items,
+      total: page.total,
+      nextCursor:
+        cursor + page.items.length < page.total
+          ? cursor + page.items.length
+          : null,
+      sourceEtag: meta.httpEtag,
+    };
+  }
+  if (meta.size > 20 * 1024 * 1024) {
+    throw new Error("source_too_large");
+  }
+  const object = await bucket.get(sourceKey);
+  if (!object) {
+    throw new Error("source_not_found");
+  }
+  if (object.httpEtag !== meta.httpEtag) {
+    await object.body.cancel();
+    throw new Error("source_changed");
+  }
+  const text = await object.text();
+  let parsed: ReturnType<typeof parseBookmarksHtml>;
+  try {
+    parsed =
+      mode === "raindrop" ? parseRaindropCsv(text) : parseBookmarksHtml(text);
+  } catch (error) {
+    throw new Error("invalid_bookmark_source", { cause: error });
+  }
+  if (parsed.length > 10_000) {
+    throw new Error("invalid_bookmark_count");
+  }
+  const items: FilesImportIndexResult["items"] = [];
+  let bytes = 0;
+  for (
+    let i = cursor;
+    i < parsed.length && items.length < FILES_IMPORT_PAGE_ITEMS;
+    i++
+  ) {
+    let item = { ...parsed[i], sourceIndex: i };
+    let size = new TextEncoder().encode(JSON.stringify(item)).length;
+    if (size > FILES_IMPORT_PAGE_BYTES) {
+      item = {
+        label: item.label.slice(0, 100_000),
+        error: "Import item is too large",
+        sourceIndex: i,
+      };
+      size = new TextEncoder().encode(JSON.stringify(item)).length;
+    }
+    if (items.length && bytes + size > FILES_IMPORT_PAGE_BYTES) {
+      break;
+    }
+    items.push(item);
+    bytes += size;
+  }
+  return {
+    items,
+    total: parsed.length,
+    nextCursor:
+      cursor + items.length < parsed.length ? cursor + items.length : null,
+    sourceEtag: meta.httpEtag,
+  };
+}
+export async function readImportMarkdown(
+  bucket: R2Bucket,
+  input: unknown
+): Promise<FilesImportMarkdownResult> {
+  if (!input || typeof input !== "object") {
+    throw new Error("invalid_markdown_params");
+  }
+  const params = input as FilesImportMarkdownParams;
+  if (
+    typeof params.sourceKey !== "string" ||
+    !isValidUploadKey(params.sourceKey) ||
+    typeof params.path !== "string" ||
+    typeof params.sourceEtag !== "string" ||
+    !params.sourceEtag ||
+    params.sourceEtag.length > 255
+  ) {
+    throw new Error("invalid_markdown_params");
+  }
+  const directory = await readZipDirectory(
+    bucket,
+    params.sourceKey,
+    params.sourceEtag
+  );
+  const entry = directory.entries.find((item) => item.name === params.path);
+  if (!entry) {
+    throw new Error("invalid_archive_entry");
+  }
+  try {
+    const bytes = await readZipEntry(
+      bucket,
+      params.sourceKey,
+      directory,
+      entry,
+      MARKDOWN_CONTENT_MAX_BYTES,
+      Number.POSITIVE_INFINITY
+    );
+    return { content: decodeMarkdownUtf8(bytes), type: "text" };
+  } catch (error) {
+    if (error instanceof MarkdownContentError) {
+      return {
+        status: "failed",
+        failureCode: error.code,
+        failureReason: error.message,
+      };
+    }
+    if (error instanceof ArchiveEntryTooLargeError) {
+      return {
+        status: "failed",
+        failureCode: "CONTENT_TOO_LARGE",
+        failureReason: error.message,
+      };
+    }
+    if (
+      error instanceof Error &&
+      (error.message.startsWith("invalid_archive") ||
+        error.message === "archive_parse_failed")
+    ) {
+      return {
+        status: "failed",
+        failureCode: "INVALID_ITEM",
+        failureReason: error.message,
+      };
+    }
+    throw error;
+  }
+}

--- a/apps/files-worker/src/inspect.test.ts
+++ b/apps/files-worker/src/inspect.test.ts
@@ -124,13 +124,19 @@ describe("import archive extraction", () => {
       files[`files/${index}.txt`] = new Uint8Array([index % 255]);
     }
     const bucket = new FakeBucket();
-    bucket.objects.set("large-import.zip", { bytes: zipSync(files) });
-    const result = await extractZipEntries(bucket, "large-import.zip", [
-      {
-        destinationKey: "users/u/imports/10001.txt",
-        path: "files/10001.txt",
-      },
-    ]);
+    bucket.objects.set("users/u/imports/job/large-import.zip", {
+      bytes: zipSync(files),
+    });
+    const result = await extractZipEntries(
+      bucket,
+      "users/u/imports/job/large-import.zip",
+      [
+        {
+          destinationKey: "users/u/imports/10001.txt",
+          path: "files/10001.txt",
+        },
+      ]
+    );
     expect(result).toHaveLength(1);
     expect(bucket.storedBytes("users/u/imports/10001.txt")).toEqual(
       new Uint8Array([10_001 % 255])
@@ -139,19 +145,23 @@ describe("import archive extraction", () => {
 
   test("extracts only requested entries directly into destination keys", async () => {
     const bucket = new FakeBucket();
-    bucket.objects.set("import.zip", {
+    bucket.objects.set("users/u/imports/job/import.zip", {
       bytes: zipSync({
         "files/a.txt": new TextEncoder().encode("Alpha"),
         "files/b.txt": new TextEncoder().encode("Beta"),
       }),
     });
-    const result = await extractZipEntries(bucket, "import.zip", [
-      {
-        contentType: "text/plain",
-        destinationKey: "users/u/imports/a.txt",
-        path: "files/a.txt",
-      },
-    ]);
+    const result = await extractZipEntries(
+      bucket,
+      "users/u/imports/job/import.zip",
+      [
+        {
+          contentType: "text/plain",
+          destinationKey: "users/u/imports/a.txt",
+          path: "files/a.txt",
+        },
+      ]
+    );
     expect(result).toEqual([
       {
         bytes: 5,

--- a/apps/files-worker/src/inspect.ts
+++ b/apps/files-worker/src/inspect.ts
@@ -9,20 +9,24 @@
 //   - mode "css"  → count of color variable declarations
 //   - mode "text" → decoded (optionally RTF-stripped) text for AI analysis
 
-import { inflateSync } from "fflate";
+import {
+  InspectSourceMissing,
+  rangeRead,
+  readZipDirectory,
+  readZipEntry,
+} from "./zip";
+
+export {
+  extractZipEntries,
+  findEocd,
+  InspectSourceMissing,
+  parseCentralDirectory,
+  rangeRead,
+} from "./zip";
 
 const MAX_AI_TEXT_BYTES = 512 * 1024;
 export const MAX_ARCHIVE_ENTRIES = 10_000;
 const MAX_ARCHIVE_ENTRY_BYTES = 512 * 1024;
-const MAX_COMPRESSION_RATIO = 100;
-
-/** Never read more than this for any single central directory. */
-const MAX_CENTRAL_DIRECTORY_BYTES = 32 * 1024 * 1024;
-/** EOCD is at most 22 bytes + up to 64KiB of archive comment. */
-const EOCD_SEARCH_WINDOW = 22 + 65_536;
-/** Local file header: fixed part only. */
-const LOCAL_HEADER_FIXED_BYTES = 30;
-
 const PPTX_SLIDE_REGEX = /^ppt\/slides\/slide\d+\.xml$/iu;
 const DOCX_TEXT_PATH = "word/document.xml";
 const XML_ENTITY_REGEX = /&(amp|apos|gt|lt|quot|#39);/gu;
@@ -52,12 +56,6 @@ const textFacts = (text: string): Record<string, number> => ({
     .length,
 });
 
-export class InspectSourceMissing extends Error {
-  constructor() {
-    super("source_not_found");
-  }
-}
-
 const decodeXmlText = (value: string): string =>
   value
     .replace(/<[^>]+>/gu, " ")
@@ -72,22 +70,6 @@ export const extractRtfText = (value: string): string =>
     .replace(/[{}]/gu, " ")
     .replace(/\s+/gu, " ")
     .trim();
-
-/**
- * Read exactly [offset, offset+length) from an object via ranged get().
- */
-export const rangeRead = async (
-  bucket: R2Bucket,
-  key: string,
-  offset: number,
-  length: number
-): Promise<Uint8Array> => {
-  const object = await bucket.get(key, { range: { offset, length } });
-  if (!object) {
-    throw new InspectSourceMissing();
-  }
-  return new Uint8Array(await object.arrayBuffer());
-};
 
 /**
  * Read at most maxBytes bytes of an object; null when missing, and objects
@@ -113,213 +95,6 @@ const boundedRead = async (
   return partial;
 };
 
-/* ------------------------------------------------------------------ *
- * ZIP central-directory walking over ranged reads.
- *
- * ZIP integers are little-endian; DataView keeps the bit-twiddling honest.
- * Archives inspected here are capped well below zip64 territory, so the
- * classic 32-bit structure is sufficient.
- * ------------------------------------------------------------------ */
-
-export interface ZipCentralEntry {
-  compressedSize: number;
-  compressionMethod: number;
-  localHeaderOffset: number;
-  name: string;
-  uncompressedSize: number;
-}
-
-interface EocdRecord {
-  cdOffset: number;
-  cdSize: number;
-  entryCount: number;
-}
-
-const EOCD_SIGNATURE = 0x06_05_4b_50;
-const CD_ENTRY_SIGNATURE = 0x02_01_4b_50;
-const LOCAL_HEADER_SIGNATURE = 0x04_03_4b_50;
-
-const u16 = (bytes: Uint8Array, offset: number): number =>
-  new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint16(
-    offset,
-    true
-  );
-const u32 = (bytes: Uint8Array, offset: number): number =>
-  new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(
-    offset,
-    true
-  );
-
-/** Locate and parse the End of Central Directory record inside a tail slice. */
-export const findEocd = (tail: Uint8Array): EocdRecord | null => {
-  if (tail.length < 22) {
-    return null;
-  }
-  let eocd = -1;
-  for (
-    let i = tail.length - 22;
-    i >= Math.max(0, tail.length - EOCD_SEARCH_WINDOW);
-    i -= 1
-  ) {
-    if (u32(tail, i) === EOCD_SIGNATURE) {
-      eocd = i;
-      break;
-    }
-  }
-  if (eocd < 0) {
-    return null;
-  }
-  return {
-    entryCount: u16(tail, eocd + 10),
-    cdSize: u32(tail, eocd + 12),
-    cdOffset: u32(tail, eocd + 16),
-  };
-};
-
-/** Parse central directory entries from a CD byte slice. */
-export const parseCentralDirectory = (
-  cdBytes: Uint8Array,
-  entryCount: number
-): ZipCentralEntry[] => {
-  const entries: ZipCentralEntry[] = [];
-  let offset = 0;
-  const decoder = new TextDecoder();
-  for (let index = 0; index < entryCount; index += 1) {
-    if (
-      offset + 46 > cdBytes.length ||
-      u32(cdBytes, offset) !== CD_ENTRY_SIGNATURE
-    ) {
-      break;
-    }
-    const nameLength = u16(cdBytes, offset + 28);
-    const extraLength = u16(cdBytes, offset + 30);
-    const commentLength = u16(cdBytes, offset + 32);
-    entries.push({
-      name: decoder.decode(
-        cdBytes.subarray(offset + 46, offset + 46 + nameLength)
-      ),
-      compressionMethod: u16(cdBytes, offset + 10),
-      compressedSize: u32(cdBytes, offset + 20),
-      uncompressedSize: u32(cdBytes, offset + 24),
-      localHeaderOffset: u32(cdBytes, offset + 42),
-    });
-    offset += 46 + nameLength + extraLength + commentLength;
-  }
-  return entries;
-};
-
-/** Decompress one entry's payload given its raw local data slice. */
-export const inflateEntryData = (
-  raw: Uint8Array,
-  compressionMethod: number
-): Uint8Array | null => {
-  try {
-    if (compressionMethod === 0) {
-      return raw.slice();
-    }
-    if (compressionMethod === 8) {
-      return inflateSync(raw);
-    }
-    return null;
-  } catch {
-    return null;
-  }
-};
-
-const canReadArchiveEntry = (entry: ZipCentralEntry): boolean => {
-  if (entry.uncompressedSize > MAX_ARCHIVE_ENTRY_BYTES) {
-    return false;
-  }
-  if (entry.compressedSize === 0) {
-    return entry.uncompressedSize === 0;
-  }
-  return entry.uncompressedSize / entry.compressedSize <= MAX_COMPRESSION_RATIO;
-};
-
-export interface ExtractZipEntryRequest {
-  contentType?: string;
-  destinationKey: string;
-  path: string;
-}
-
-export const extractZipEntries = async (
-  bucket: R2Bucket,
-  archiveKey: string,
-  requested: ExtractZipEntryRequest[]
-): Promise<Array<{ bytes: number; destinationKey: string; path: string }>> => {
-  if (requested.length === 0 || requested.length > 50) {
-    throw new Error("invalid_extract_batch");
-  }
-  const meta = await bucket.head(archiveKey);
-  if (!meta || meta.size < 22) {
-    throw new InspectSourceMissing();
-  }
-  const tailLength = Math.min(meta.size, EOCD_SEARCH_WINDOW);
-  const tail = await rangeRead(
-    bucket,
-    archiveKey,
-    meta.size - tailLength,
-    tailLength
-  );
-  const eocd = findEocd(tail);
-  if (!eocd || eocd.cdSize > MAX_CENTRAL_DIRECTORY_BYTES) {
-    throw new Error("archive_parse_failed");
-  }
-  const entries = parseCentralDirectory(
-    await rangeRead(bucket, archiveKey, eocd.cdOffset, eocd.cdSize),
-    eocd.entryCount
-  );
-  const byName = new Map(entries.map((entry) => [entry.name, entry]));
-  const results: Array<{
-    bytes: number;
-    destinationKey: string;
-    path: string;
-  }> = [];
-  for (const item of requested) {
-    const entry = byName.get(item.path);
-    if (
-      !entry ||
-      entry.uncompressedSize > 20 * 1024 * 1024 ||
-      (entry.compressedSize > 0 &&
-        entry.uncompressedSize / entry.compressedSize > MAX_COMPRESSION_RATIO)
-    ) {
-      throw new Error("archive_entry_invalid");
-    }
-    const header = await rangeRead(
-      bucket,
-      archiveKey,
-      entry.localHeaderOffset,
-      LOCAL_HEADER_FIXED_BYTES
-    );
-    if (u32(header, 0) !== LOCAL_HEADER_SIGNATURE) {
-      throw new Error("archive_parse_failed");
-    }
-    const dataStart =
-      entry.localHeaderOffset +
-      LOCAL_HEADER_FIXED_BYTES +
-      u16(header, 26) +
-      u16(header, 28);
-    const bytes = inflateEntryData(
-      await rangeRead(bucket, archiveKey, dataStart, entry.compressedSize),
-      entry.compressionMethod
-    );
-    if (!bytes || bytes.byteLength !== entry.uncompressedSize) {
-      throw new Error("archive_entry_invalid");
-    }
-    await bucket.put(item.destinationKey, bytes, {
-      httpMetadata: {
-        contentType: item.contentType ?? "application/octet-stream",
-      },
-    });
-    results.push({
-      bytes: bytes.byteLength,
-      destinationKey: item.destinationKey,
-      path: item.path,
-    });
-  }
-  return results;
-};
-
 export interface ZipInspection {
   facts: {
     archiveDirectoryCount: number;
@@ -343,28 +118,8 @@ export const inspectZipRanged = async (
   key: string,
   formatId: string
 ): Promise<ZipInspection> => {
-  const meta = await bucket.head(key);
-  if (!meta || meta.size < 22) {
-    throw new Error("archive_parse_failed");
-  }
-
-  const tailLength = Math.min(meta.size, EOCD_SEARCH_WINDOW);
-  const tail = await rangeRead(bucket, key, meta.size - tailLength, tailLength);
-  const eocd = findEocd(tail);
-  if (!eocd) {
-    throw new Error("archive_parse_failed");
-  }
-  if (
-    eocd.cdOffset >= meta.size ||
-    eocd.cdSize > MAX_CENTRAL_DIRECTORY_BYTES ||
-    eocd.cdOffset + eocd.cdSize > meta.size ||
-    eocd.entryCount === 0
-  ) {
-    throw new Error("archive_parse_failed");
-  }
-
-  const cdBytes = await rangeRead(bucket, key, eocd.cdOffset, eocd.cdSize);
-  const entries = parseCentralDirectory(cdBytes, eocd.entryCount);
+  const directory = await readZipDirectory(bucket, key);
+  const entries = directory.entries;
 
   let archiveDirectoryCount = 0;
   let archiveFileCount = 0;
@@ -396,35 +151,18 @@ export const inspectZipRanged = async (
     if (
       !shouldReadText ||
       textBytes >= MAX_AI_TEXT_BYTES ||
-      !canReadArchiveEntry(entry)
+      entry.uncompressedSize > MAX_ARCHIVE_ENTRY_BYTES
     ) {
       continue;
     }
 
-    // Local headers carry their own name/extra lengths which may differ from
-    // the central directory's, so read the fixed header first.
-    if (entry.localHeaderOffset + LOCAL_HEADER_FIXED_BYTES > meta.size) {
-      continue;
-    }
-    const localHeader = await rangeRead(
+    const entryBytes = await readZipEntry(
       bucket,
       key,
-      entry.localHeaderOffset,
-      LOCAL_HEADER_FIXED_BYTES
-    );
-    if (u32(localHeader, 0) !== LOCAL_HEADER_SIGNATURE) {
-      continue;
-    }
-    const dataStart =
-      entry.localHeaderOffset +
-      LOCAL_HEADER_FIXED_BYTES +
-      u16(localHeader, 26) +
-      u16(localHeader, 28);
-    if (dataStart + entry.compressedSize > meta.size) {
-      continue;
-    }
-    const raw = await rangeRead(bucket, key, dataStart, entry.compressedSize);
-    const entryBytes = inflateEntryData(raw, entry.compressionMethod);
+      directory,
+      entry,
+      MAX_ARCHIVE_ENTRY_BYTES
+    ).catch(() => null);
     if (!entryBytes) {
       continue;
     }

--- a/apps/files-worker/src/ops.ts
+++ b/apps/files-worker/src/ops.ts
@@ -1,5 +1,7 @@
+import { readResponseTextWithinLimit } from "@teak/convex/shared/bounded-response";
 import {
   buildFilesOpSigningPayload,
+  FILES_OPS,
   FILES_PROCESSOR_VERSION,
   FILES_PROTOCOL_VERSION,
   type FilesErrorCode,
@@ -15,6 +17,7 @@ import {
 import { finalizeImageUpload } from "./finalizeImage";
 import { analyzeImage } from "./imageAnalysis";
 import { generateImageMetadataForOp } from "./imageMetadata";
+import { indexImportSource, readImportMarkdown } from "./importSource";
 import {
   extractZipEntries,
   type InspectMode,
@@ -23,9 +26,14 @@ import {
 } from "./inspect";
 import { sha256Hex, verifyBodySignature } from "./lib";
 import { reportFilesOpFailure } from "./sentry";
+import { transcribeAudio } from "./transcript";
 import { isValidUploadKey } from "./upload";
+import { ArchiveEntryTooLargeError } from "./zip";
 
 export interface FilesOpsEnv {
+  AI?: {
+    run: (model: string, args: Record<string, unknown>) => Promise<unknown>;
+  };
   BUCKET: R2Bucket;
   FILES_SIGNING_SECRET: string;
   /** Images binding; used by finalize-image-upload for decode verification. */
@@ -162,6 +170,18 @@ const dispatch = async (
 ): Promise<Response> => {
   const params = (body.params ?? {}) as Record<string, unknown>;
   switch (body.op) {
+    case "capabilities":
+      return success(requestId, {
+        operations: FILES_OPS,
+        ai: Boolean(env.AI),
+        images: Boolean(env.IMAGES),
+      });
+    case "index-import-source":
+      return success(requestId, await indexImportSource(env.BUCKET, params));
+    case "read-import-markdown":
+      return success(requestId, await readImportMarkdown(env.BUCKET, params));
+    case "transcribe-audio":
+      return success(requestId, await transcribeAudio(env, params));
     case "analyze-image":
     case "analyze-image-content":
       return success(
@@ -261,12 +281,30 @@ const dispatch = async (
         size: object.size,
       });
     }
-    case "abort-multipart":
-      await env.BUCKET.resumeMultipartUpload(
-        requiredString(params, "key"),
-        requiredString(params, "uploadId")
-      ).abort();
+    case "abort-multipart": {
+      const key = requiredString(params, "key");
+      if (!isValidUploadKey(key)) {
+        throw new Error("invalid_storage_key");
+      }
+      try {
+        await env.BUCKET.resumeMultipartUpload(
+          key,
+          requiredString(params, "uploadId")
+        ).abort();
+      } catch (error) {
+        // R2 NoSuchUpload means this idempotent cleanup has already completed.
+        // All other errors must propagate to durable workflow/cron retries.
+        if (
+          !(
+            error instanceof Error &&
+            /\b10024\b|NoSuchUpload/u.test(error.message)
+          )
+        ) {
+          throw error;
+        }
+      }
       return success(requestId, { aborted: true });
+    }
     case "finalize-upload":
       return success(requestId, await finalizeUpload(env.BUCKET, params));
     case "finalize-image-upload": {
@@ -371,7 +409,8 @@ const dispatch = async (
         await extractZipEntries(
           env.BUCKET,
           requiredString(params, "archiveKey"),
-          params.entries as never
+          params.entries,
+          optionalString(params, "sourceEtag") ?? undefined
         )
       );
     }
@@ -385,7 +424,18 @@ export const handleInternalOp = async (
   env: FilesOpsEnv
 ): Promise<Response> => {
   const requestId = request.headers.get("x-teak-request-id") ?? "unknown";
-  const rawBody = await request.text();
+  const rawBody = await readResponseTextWithinLimit(
+    new Response(request.body),
+    1024 * 1024
+  );
+  if (rawBody === null) {
+    return fail(
+      requestId,
+      "PAYLOAD_TOO_LARGE",
+      "Operation request exceeds 1 MiB",
+      413
+    );
+  }
   const bodySha256 = await sha256Hex(rawBody);
   const verification = await verifyBodySignature(
     env.FILES_SIGNING_SECRET,
@@ -411,8 +461,25 @@ export const handleInternalOp = async (
   } catch {
     return fail(requestId, "INVALID_INPUT", "Invalid JSON body", 400);
   }
-  if (body.version !== FILES_PROTOCOL_VERSION || !isFilesOp(body.op)) {
+  if (
+    !body ||
+    typeof body !== "object" ||
+    body.version !== FILES_PROTOCOL_VERSION ||
+    !isFilesOp(body.op)
+  ) {
     return fail(requestId, "UNSUPPORTED", "Unsupported operation", 400);
+  }
+  if (
+    !body.params ||
+    typeof body.params !== "object" ||
+    Array.isArray(body.params)
+  ) {
+    return fail(
+      requestId,
+      "INVALID_INPUT",
+      "Invalid operation parameters",
+      400
+    );
   }
   try {
     return await dispatch(env, requestId, body, new URL(request.url).origin);
@@ -425,7 +492,8 @@ export const handleInternalOp = async (
     }
     if (
       (error instanceof Error && error.message === "source_too_large") ||
-      error instanceof ExportTooLarge
+      error instanceof ExportTooLarge ||
+      error instanceof ArchiveEntryTooLargeError
     ) {
       return fail(requestId, "PAYLOAD_TOO_LARGE", error.message, 413);
     }

--- a/apps/files-worker/src/transcript.ts
+++ b/apps/files-worker/src/transcript.ts
@@ -1,0 +1,66 @@
+import {
+  FILES_AUDIO_MAX_BYTES,
+  FILES_TRANSCRIPT_MAX_BYTES,
+  FILES_TRANSCRIPTION_MODEL,
+  type FilesTranscriptParams,
+  type FilesTranscriptResult,
+} from "@teak/files-protocol";
+import { isValidUploadKey } from "./upload";
+
+export async function transcribeAudio(
+  env: {
+    BUCKET: R2Bucket;
+    AI?: {
+      run: (model: string, args: Record<string, unknown>) => Promise<unknown>;
+    };
+  },
+  input: unknown
+): Promise<FilesTranscriptResult> {
+  if (!input || typeof input !== "object") {
+    throw new Error("invalid_transcript_params");
+  }
+  const params = input as FilesTranscriptParams;
+  if (
+    typeof params.sourceKey !== "string" ||
+    !isValidUploadKey(params.sourceKey) ||
+    (params.mimeType !== undefined &&
+      (typeof params.mimeType !== "string" || params.mimeType.length > 255))
+  ) {
+    throw new Error("invalid_transcript_params");
+  }
+  const source = await env.BUCKET.get(params.sourceKey);
+  if (!source) {
+    throw new Error("source_not_found");
+  }
+  if (source.size > FILES_AUDIO_MAX_BYTES) {
+    await source.body.cancel();
+    throw new Error("source_too_large");
+  }
+  const mimeType =
+    params.mimeType || source.httpMetadata?.contentType || "audio/webm";
+  if (!mimeType.startsWith("audio/")) {
+    console.warn("ai.transcript.unexpected_mime_type", { mimeType });
+  }
+  if (!env.AI) {
+    await source.body.cancel();
+    throw new Error("ai_binding_missing");
+  }
+  // The first-class AI binding streams the R2 body with its content type.
+  // This preserves the 100 MiB upload limit without a base64 copy in memory.
+  const result = (await env.AI.run(FILES_TRANSCRIPTION_MODEL, {
+    audio: { body: source.body, contentType: mimeType },
+  })) as { text?: unknown };
+  const text = result?.text ?? "";
+  if (typeof text !== "string") {
+    throw new Error("transcription_invalid_response");
+  }
+  if (new TextEncoder().encode(text).byteLength > FILES_TRANSCRIPT_MAX_BYTES) {
+    throw new Error("source_too_large");
+  }
+  return {
+    text,
+    byteLength: source.size,
+    mimeType,
+    sourceEtag: source.httpEtag,
+  };
+}

--- a/apps/files-worker/src/zip.test.ts
+++ b/apps/files-worker/src/zip.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { strToU8, zipSync } from "fflate";
+import { FakeBucket } from "./testsupport";
+import { findEocd, readZipDirectory, readZipEntry } from "./zip";
+
+const key = "users/u/imports/job/source.zip";
+const bucketFor = (bytes: Uint8Array) => {
+  const bucket = new FakeBucket();
+  bucket.objects.set(key, { bytes });
+  return bucket as unknown as R2Bucket;
+};
+const view = (bytes: Uint8Array) =>
+  new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+describe("shared ranged ZIP reader", () => {
+  test("reads a ZIP64 directory and local header beyond 4 GiB without buffering the archive", async () => {
+    const original = zipSync(
+      { "manifest.json": strToU8('{"version":1,"cards":[]}') },
+      { level: 0 }
+    );
+    const eocd = findEocd(original)!;
+    const local = original.subarray(0, eocd.cdOffset);
+    const central = new Uint8Array(eocd.cdSize + 12);
+    central.set(original.subarray(eocd.cdOffset, eocd.cdOffset + eocd.cdSize));
+    const centralView = view(central);
+    expect(centralView.getUint16(30, true)).toBe(0);
+    centralView.setUint16(30, 12, true);
+    centralView.setUint32(42, 0xff_ff_ff_ff, true);
+    centralView.setUint16(eocd.cdSize, 1, true);
+    centralView.setUint16(eocd.cdSize + 2, 8, true);
+    const localOffset = 2 ** 32 + 4096;
+    centralView.setBigUint64(eocd.cdSize + 4, BigInt(localOffset), true);
+    const centralOffset = localOffset + local.length;
+    const zip64Offset = centralOffset + central.length;
+    const tail = new Uint8Array(56 + 20 + 22),
+      tailView = view(tail);
+    tailView.setUint32(0, 0x06_06_4b_50, true);
+    tailView.setBigUint64(4, 44n, true);
+    tailView.setBigUint64(24, 1n, true);
+    tailView.setBigUint64(32, 1n, true);
+    tailView.setBigUint64(40, BigInt(central.length), true);
+    tailView.setBigUint64(48, BigInt(centralOffset), true);
+    tailView.setUint32(56, 0x07_06_4b_50, true);
+    tailView.setBigUint64(64, BigInt(zip64Offset), true);
+    tailView.setUint32(72, 1, true);
+    tailView.setUint32(76, 0x06_05_4b_50, true);
+    tailView.setUint16(84, 0xff_ff, true);
+    tailView.setUint16(86, 0xff_ff, true);
+    tailView.setUint32(88, 0xff_ff_ff_ff, true);
+    tailView.setUint32(92, 0xff_ff_ff_ff, true);
+    const size = zip64Offset + tail.length;
+    let bytesRead = 0;
+    const bucket = {
+      head: () => ({ size, httpEtag: '"zip64"' }),
+      get: (
+        _key: string,
+        options: { range: { offset: number; length: number } }
+      ) => {
+        const { offset, length } = options.range;
+        bytesRead += length;
+        const bytes = new Uint8Array(length);
+        for (const [start, data] of [
+          [localOffset, local],
+          [centralOffset, central],
+          [zip64Offset, tail],
+        ] as const) {
+          const from = Math.max(offset, start),
+            to = Math.min(offset + length, start + data.length);
+          if (to > from) {
+            bytes.set(data.subarray(from - start, to - start), from - offset);
+          }
+        }
+        return {
+          size,
+          httpEtag: '"zip64"',
+          arrayBuffer: async () => bytes.buffer,
+          body: new Response(bytes).body,
+        };
+      },
+    } as unknown as R2Bucket;
+    const directory = await readZipDirectory(bucket, key);
+    expect(directory.entries[0].localHeaderOffset).toBe(localOffset);
+    expect(
+      new TextDecoder().decode(
+        await readZipEntry(bucket, key, directory, directory.entries[0], 1024)
+      )
+    ).toBe('{"version":1,"cards":[]}');
+    expect(bytesRead).toBeLessThan(70_000);
+  });
+  test("rejects encrypted, duplicate, truncated, and multidisk directories", async () => {
+    const source = zipSync(
+      { "files/a": strToU8("one"), "files/b": strToU8("two") },
+      { level: 0 }
+    );
+    const eocd = findEocd(source)!;
+    const encrypted = source.slice();
+    view(encrypted).setUint16(eocd.cdOffset + 8, 1, true);
+    await expect(readZipDirectory(bucketFor(encrypted), key)).rejects.toThrow(
+      "invalid_archive_entry"
+    );
+    const duplicate = source.slice();
+    const second = eocd.cdOffset + 46 + "files/a".length;
+    duplicate.set(strToU8("files/a"), second + 46);
+    await expect(readZipDirectory(bucketFor(duplicate), key)).rejects.toThrow(
+      "invalid_archive_entry"
+    );
+    const truncated = source.slice();
+    view(truncated).setUint32(eocd.offset + 12, eocd.cdSize - 1, true);
+    await expect(readZipDirectory(bucketFor(truncated), key)).rejects.toThrow(
+      "archive_parse_failed"
+    );
+    const multidisk = source.slice();
+    view(multidisk).setUint16(eocd.offset + 4, 1, true);
+    await expect(readZipDirectory(bucketFor(multidisk), key)).rejects.toThrow(
+      "archive_parse_failed"
+    );
+  });
+  test("rejects source replacement between directory and entry reads", async () => {
+    const bytes = zipSync({ "files/a": strToU8("hello") });
+    const bucket = new FakeBucket();
+    bucket.objects.set(key, { bytes });
+    const directory = await readZipDirectory(
+      bucket as unknown as R2Bucket,
+      key
+    );
+    const changed = bytes.slice();
+    changed[32] = (changed[32] + 1) % 256;
+    bucket.objects.set(key, { bytes: changed });
+    await expect(
+      readZipEntry(
+        bucket as unknown as R2Bucket,
+        key,
+        directory,
+        directory.entries[0],
+        1024
+      )
+    ).rejects.toThrow("source_changed");
+  });
+});

--- a/apps/files-worker/src/zip.ts
+++ b/apps/files-worker/src/zip.ts
@@ -2,6 +2,24 @@ import { isSafeArchivePath } from "@teak/convex/import/validate";
 import { Inflate } from "fflate";
 import { isValidUploadKey } from "./upload";
 
+// ZIP names without the UTF-8 flag use the standard DOS code page.
+const CP437_HIGH =
+  "ÇüéâäàåçêëèïîìÄÅÉæÆôöòûùÿÖÜ¢£¥₧ƒáíóúñÑªº¿⌐¬½¼¡«»░▒▓│┤╡╢╖╕╣║╗╝╜╛┐└┴┬├─┼╞╟╚╔╩╦╠═╬╧╨╤╥╙╘╒╓╫╪┘┌█▄▌▐▀αßΓπΣσµτΦΘΩδ∞φε∩≡±≥≤⌠⌡÷≈°∙·√ⁿ²■\xa0";
+const decodeZipName = (bytes: Uint8Array, flags: number) => {
+  if (Math.floor(flags / 2048) % 2 === 1) {
+    try {
+      return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
+        bytes
+      );
+    } catch {
+      throw new Error("invalid_archive_filename");
+    }
+  }
+  return Array.from(bytes, (byte) =>
+    byte < 128 ? String.fromCharCode(byte) : CP437_HIGH[byte - 128]
+  ).join("");
+};
+
 export class InspectSourceMissing extends Error {
   constructor() {
     super("source_not_found");
@@ -126,9 +144,7 @@ export function parseCentralDirectory(
     }
     const flags = u16(bytes, offset + 8);
     const entry: ZipCentralEntry = {
-      name: new TextDecoder().decode(
-        bytes.subarray(offset + 46, offset + 46 + nl)
-      ),
+      name: decodeZipName(bytes.subarray(offset + 46, offset + 46 + nl), flags),
       compressionMethod: u16(bytes, offset + 10),
       compressedSize: u32(bytes, offset + 20),
       uncompressedSize: u32(bytes, offset + 24),
@@ -332,14 +348,15 @@ export async function consumeZipEntry(
   if (start + entry.compressedSize > directory.cdOffset) {
     throw new Error("archive_parse_failed");
   }
-  const name = new TextDecoder().decode(
+  const name = decodeZipName(
     await rangeRead(
       bucket,
       key,
       entry.localHeaderOffset + 30,
       nl,
       directory.sourceEtag
-    )
+    ),
+    entry.flags ?? 0
   );
   if (name !== entry.name) {
     throw new Error("archive_parse_failed");

--- a/apps/files-worker/src/zip.ts
+++ b/apps/files-worker/src/zip.ts
@@ -1,0 +1,520 @@
+import { isSafeArchivePath } from "@teak/convex/import/validate";
+import { Inflate } from "fflate";
+import { isValidUploadKey } from "./upload";
+
+export class InspectSourceMissing extends Error {
+  constructor() {
+    super("source_not_found");
+  }
+}
+export class ArchiveEntryTooLargeError extends Error {
+  constructor() {
+    super("Expanded ZIP entry exceeds its limit");
+  }
+}
+export interface ZipCentralEntry {
+  compressedSize: number;
+  compressionMethod: number;
+  flags?: number;
+  localHeaderOffset: number;
+  name: string;
+  uncompressedSize: number;
+}
+interface EocdRecord {
+  cdOffset: number;
+  cdSize: number;
+  entryCount: number;
+  offset: number;
+}
+const EOCD_WINDOW = 22 + 65_535;
+const MAX_DIRECTORY = 32 * 1024 * 1024;
+const MAX_ARCHIVE_BYTES = 5 * 1024 ** 3;
+const MAX_ENTRIES = 20_002;
+const MAX_RATIO = 100;
+const u16 = (b: Uint8Array, i: number) =>
+  new DataView(b.buffer, b.byteOffset, b.byteLength).getUint16(i, true);
+const u32 = (b: Uint8Array, i: number) =>
+  new DataView(b.buffer, b.byteOffset, b.byteLength).getUint32(i, true);
+const u64 = (b: Uint8Array, i: number) => {
+  const n = Number(
+    new DataView(b.buffer, b.byteOffset, b.byteLength).getBigUint64(i, true)
+  );
+  if (!Number.isSafeInteger(n)) {
+    throw new Error("archive_parse_failed");
+  }
+  return n;
+};
+export async function rangeRead(
+  bucket: R2Bucket,
+  key: string,
+  offset: number,
+  length: number,
+  etag?: string
+): Promise<Uint8Array> {
+  if (
+    !(Number.isSafeInteger(offset) && Number.isSafeInteger(length)) ||
+    offset < 0 ||
+    length < 0 ||
+    length > MAX_DIRECTORY
+  ) {
+    throw new Error("archive_parse_failed");
+  }
+  if (!length) {
+    return new Uint8Array();
+  }
+  const object = await bucket.get(key, { range: { offset, length } });
+  if (!object) {
+    throw new InspectSourceMissing();
+  }
+  if (etag && etag !== object.httpEtag) {
+    await object.body.cancel();
+    throw new Error("source_changed");
+  }
+  const bytes = new Uint8Array(await object.arrayBuffer());
+  if (bytes.length !== length) {
+    throw new Error("archive_parse_failed");
+  }
+  return bytes;
+}
+export function findEocd(tail: Uint8Array): EocdRecord | null {
+  for (
+    let i = tail.length - 22;
+    i >= Math.max(0, tail.length - EOCD_WINDOW);
+    i--
+  ) {
+    if (
+      u32(tail, i) !== 0x06_05_4b_50 ||
+      i + 22 + u16(tail, i + 20) !== tail.length
+    ) {
+      continue;
+    }
+    if (
+      u16(tail, i + 4) !== 0 ||
+      u16(tail, i + 6) !== 0 ||
+      u16(tail, i + 8) !== u16(tail, i + 10)
+    ) {
+      throw new Error("archive_parse_failed");
+    }
+    return {
+      entryCount: u16(tail, i + 10),
+      cdSize: u32(tail, i + 12),
+      cdOffset: u32(tail, i + 16),
+      offset: i,
+    };
+  }
+  return null;
+}
+export function parseCentralDirectory(
+  bytes: Uint8Array,
+  count: number
+): ZipCentralEntry[] {
+  if (count > MAX_ENTRIES) {
+    throw new Error("invalid_archive_entry_count");
+  }
+  const entries: ZipCentralEntry[] = [];
+  let offset = 0;
+  for (let i = 0; i < count; i++) {
+    if (offset + 46 > bytes.length || u32(bytes, offset) !== 0x02_01_4b_50) {
+      throw new Error("archive_parse_failed");
+    }
+    const nl = u16(bytes, offset + 28),
+      el = u16(bytes, offset + 30),
+      cl = u16(bytes, offset + 32);
+    const end = offset + 46 + nl + el + cl;
+    if (end > bytes.length) {
+      throw new Error("archive_parse_failed");
+    }
+    const flags = u16(bytes, offset + 8);
+    const entry: ZipCentralEntry = {
+      name: new TextDecoder().decode(
+        bytes.subarray(offset + 46, offset + 46 + nl)
+      ),
+      compressionMethod: u16(bytes, offset + 10),
+      compressedSize: u32(bytes, offset + 20),
+      uncompressedSize: u32(bytes, offset + 24),
+      localHeaderOffset: u32(bytes, offset + 42),
+      flags,
+    };
+    let disk = u16(bytes, offset + 34);
+    for (let x = offset + 46 + nl; x < offset + 46 + nl + el; ) {
+      if (x + 4 > offset + 46 + nl + el) {
+        throw new Error("archive_parse_failed");
+      }
+      const tag = u16(bytes, x),
+        len = u16(bytes, x + 2),
+        next = x + 4 + len;
+      if (next > offset + 46 + nl + el) {
+        throw new Error("archive_parse_failed");
+      }
+      if (tag === 1) {
+        let z = x + 4;
+        for (const field of [
+          "uncompressedSize",
+          "compressedSize",
+          "localHeaderOffset",
+        ] as const) {
+          if (entry[field] === 0xff_ff_ff_ff) {
+            if (z + 8 > next) {
+              throw new Error("archive_parse_failed");
+            }
+            entry[field] = u64(bytes, z);
+            z += 8;
+          }
+        }
+        if (disk === 0xff_ff) {
+          if (z + 4 > next) {
+            throw new Error("archive_parse_failed");
+          }
+          disk = u32(bytes, z);
+        }
+      }
+      x = next;
+    }
+    if (
+      disk !== 0 ||
+      [
+        entry.compressedSize,
+        entry.uncompressedSize,
+        entry.localHeaderOffset,
+      ].includes(0xff_ff_ff_ff)
+    ) {
+      throw new Error("archive_parse_failed");
+    }
+    entries.push(entry);
+    offset = end;
+  }
+  if (offset !== bytes.length) {
+    throw new Error("archive_parse_failed");
+  }
+  return entries;
+}
+export interface ZipDirectory {
+  cdOffset: number;
+  entries: ZipCentralEntry[];
+  size: number;
+  sourceEtag: string;
+}
+export async function readZipDirectory(
+  bucket: R2Bucket,
+  key: string,
+  expectedEtag?: string
+): Promise<ZipDirectory> {
+  const meta = await bucket.head(key);
+  if (!meta) {
+    throw new InspectSourceMissing();
+  }
+  if (expectedEtag && meta.httpEtag !== expectedEtag) {
+    throw new Error("source_changed");
+  }
+  if (meta.size < 22 || meta.size > MAX_ARCHIVE_BYTES) {
+    throw new Error("archive_parse_failed");
+  }
+  const len = Math.min(meta.size, EOCD_WINDOW),
+    start = meta.size - len;
+  const tail = await rangeRead(bucket, key, start, len, meta.httpEtag);
+  const eocd = findEocd(tail);
+  if (!eocd) {
+    throw new Error("archive_parse_failed");
+  }
+  let { cdOffset, cdSize, entryCount } = eocd;
+  if (
+    cdOffset === 0xff_ff_ff_ff ||
+    cdSize === 0xff_ff_ff_ff ||
+    entryCount === 0xff_ff
+  ) {
+    const locator = await rangeRead(
+      bucket,
+      key,
+      start + eocd.offset - 20,
+      20,
+      meta.httpEtag
+    );
+    if (
+      u32(locator, 0) !== 0x07_06_4b_50 ||
+      u32(locator, 4) !== 0 ||
+      u32(locator, 16) !== 1
+    ) {
+      throw new Error("archive_parse_failed");
+    }
+    const zip64 = await rangeRead(
+      bucket,
+      key,
+      u64(locator, 8),
+      56,
+      meta.httpEtag
+    );
+    if (
+      u32(zip64, 0) !== 0x06_06_4b_50 ||
+      u64(zip64, 4) < 44 ||
+      u32(zip64, 16) !== 0 ||
+      u32(zip64, 20) !== 0 ||
+      u64(zip64, 24) !== u64(zip64, 32)
+    ) {
+      throw new Error("archive_parse_failed");
+    }
+    entryCount = u64(zip64, 32);
+    cdSize = u64(zip64, 40);
+    cdOffset = u64(zip64, 48);
+  }
+  if (
+    cdSize > MAX_DIRECTORY ||
+    cdOffset + cdSize > start + eocd.offset ||
+    entryCount > MAX_ENTRIES
+  ) {
+    throw new Error("archive_parse_failed");
+  }
+  const entries = parseCentralDirectory(
+    await rangeRead(bucket, key, cdOffset, cdSize, meta.httpEtag),
+    entryCount
+  );
+  const names = new Set<string>();
+  let expanded = 0;
+  for (const entry of entries) {
+    if (
+      !isSafeArchivePath(entry.name) ||
+      /^[a-z]:/iu.test(entry.name) ||
+      entry.name.split("/").includes(".") ||
+      (entry.flags ?? 0) % 2 !== 0 ||
+      names.has(entry.name) ||
+      ![0, 8].includes(entry.compressionMethod)
+    ) {
+      throw new Error("invalid_archive_entry");
+    }
+    names.add(entry.name);
+    expanded += entry.uncompressedSize;
+    if (
+      expanded > MAX_ARCHIVE_BYTES ||
+      entry.localHeaderOffset + 30 > cdOffset
+    ) {
+      throw new Error("invalid_archive_expanded_size");
+    }
+  }
+  return { entries, sourceEtag: meta.httpEtag, size: meta.size, cdOffset };
+}
+/** Every consumer uses the same bounded inflater, including JSON streaming. */
+export async function consumeZipEntry(
+  bucket: R2Bucket,
+  key: string,
+  directory: ZipDirectory,
+  entry: ZipCentralEntry,
+  limit: number,
+  consume: (chunk: Uint8Array) => void,
+  maxRatio = MAX_RATIO
+): Promise<void> {
+  if (entry.uncompressedSize > limit) {
+    throw new ArchiveEntryTooLargeError();
+  }
+  if (
+    entry.compressedSize > limit + 65_536 ||
+    (entry.compressedSize === 0
+      ? entry.uncompressedSize !== 0
+      : entry.uncompressedSize / entry.compressedSize > maxRatio)
+  ) {
+    throw new Error("invalid_archive_compression_ratio");
+  }
+  const header = await rangeRead(
+    bucket,
+    key,
+    entry.localHeaderOffset,
+    30,
+    directory.sourceEtag
+  );
+  if (
+    u32(header, 0) !== 0x04_03_4b_50 ||
+    u16(header, 8) !== entry.compressionMethod ||
+    u16(header, 6) !== entry.flags
+  ) {
+    throw new Error("archive_parse_failed");
+  }
+  const nl = u16(header, 26),
+    extra = u16(header, 28),
+    start = entry.localHeaderOffset + 30 + nl + extra;
+  if (start + entry.compressedSize > directory.cdOffset) {
+    throw new Error("archive_parse_failed");
+  }
+  const name = new TextDecoder().decode(
+    await rangeRead(
+      bucket,
+      key,
+      entry.localHeaderOffset + 30,
+      nl,
+      directory.sourceEtag
+    )
+  );
+  if (name !== entry.name) {
+    throw new Error("archive_parse_failed");
+  }
+  let total = 0;
+  const accept = (chunk: Uint8Array) => {
+    total += chunk.length;
+    if (total > limit || total > entry.uncompressedSize) {
+      throw new ArchiveEntryTooLargeError();
+    }
+    consume(chunk);
+  };
+  const inflater = entry.compressionMethod === 8 ? new Inflate(accept) : null;
+  const inflate = (chunk: Uint8Array, final: boolean) => {
+    try {
+      inflater?.push(chunk, final);
+    } catch (error) {
+      // fflate's malformed-stream errors carry a numeric code. Preserve
+      // consumer size/JSON errors and normalize invalid compressed input.
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        typeof error.code === "number"
+      ) {
+        throw new Error("archive_parse_failed", { cause: error });
+      }
+      throw error;
+    }
+  };
+  // Small compressed chunks bound even a malicious DEFLATE expansion before
+  // the size check runs. Never trust the central directory's declared size.
+  const object = entry.compressedSize
+    ? await bucket.get(key, {
+        range: { offset: start, length: entry.compressedSize },
+      })
+    : null;
+  if (entry.compressedSize && !object) {
+    throw new InspectSourceMissing();
+  }
+  if (object && object.httpEtag !== directory.sourceEtag) {
+    await object.body.cancel();
+    throw new Error("source_changed");
+  }
+  let read = 0;
+  if (object) {
+    const reader = object.body.getReader();
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        read += value.length;
+        if (read > entry.compressedSize) {
+          throw new Error("archive_parse_failed");
+        }
+        for (let i = 0; i < value.length; i += 1024) {
+          const chunk = value.subarray(i, i + 1024);
+          if (inflater) {
+            inflate(chunk, false);
+          } else {
+            accept(chunk);
+          }
+        }
+      }
+    } finally {
+      await reader.cancel();
+      reader.releaseLock();
+    }
+  }
+  if (inflater) {
+    inflate(new Uint8Array(), true);
+  }
+  if (read !== entry.compressedSize || total !== entry.uncompressedSize) {
+    throw new Error("archive_parse_failed");
+  }
+}
+export async function readZipEntry(
+  bucket: R2Bucket,
+  key: string,
+  directory: ZipDirectory,
+  entry: ZipCentralEntry,
+  limit: number,
+  maxRatio = MAX_RATIO
+): Promise<Uint8Array> {
+  if (entry.uncompressedSize > limit) {
+    throw new ArchiveEntryTooLargeError();
+  }
+  const bytes = new Uint8Array(entry.uncompressedSize);
+  let offset = 0;
+  await consumeZipEntry(
+    bucket,
+    key,
+    directory,
+    entry,
+    limit,
+    (chunk) => {
+      bytes.set(chunk, offset);
+      offset += chunk.length;
+    },
+    maxRatio
+  );
+  return bytes;
+}
+export interface ExtractZipEntryRequest {
+  contentType?: string;
+  destinationKey: string;
+  path: string;
+}
+export async function extractZipEntries(
+  bucket: R2Bucket,
+  archiveKey: string,
+  requested: unknown[],
+  expectedEtag?: string
+): Promise<Array<{ bytes: number; destinationKey: string; path: string }>> {
+  if (
+    !(
+      isValidUploadKey(archiveKey) &&
+      Array.isArray(requested) &&
+      requested.length
+    ) ||
+    requested.length > 50
+  ) {
+    throw new Error("invalid_extract_batch");
+  }
+  const namespace = (key: string) =>
+    key
+      .split("/")
+      .slice(0, key.startsWith("dev/") ? 3 : 2)
+      .join("/");
+  const validated: ExtractZipEntryRequest[] = [];
+  for (const value of requested) {
+    const item = value as ExtractZipEntryRequest | null;
+    if (
+      !item ||
+      typeof item.path !== "string" ||
+      !isSafeArchivePath(item.path) ||
+      typeof item.destinationKey !== "string" ||
+      !isValidUploadKey(item.destinationKey) ||
+      item.destinationKey === archiveKey ||
+      !item.destinationKey.startsWith(`${namespace(archiveKey)}/`) ||
+      (item.contentType !== undefined &&
+        (typeof item.contentType !== "string" || item.contentType.length > 255))
+    ) {
+      throw new Error("invalid_extract_entry");
+    }
+    validated.push(item);
+  }
+  const directory = await readZipDirectory(bucket, archiveKey, expectedEtag);
+  const byName = new Map(directory.entries.map((entry) => [entry.name, entry]));
+  const result: Array<{ bytes: number; destinationKey: string; path: string }> =
+    [];
+  for (const item of validated) {
+    const entry = byName.get(item.path);
+    if (!entry || entry.name.endsWith("/")) {
+      throw new Error("invalid_archive_entry");
+    }
+    const bytes = await readZipEntry(
+      bucket,
+      archiveKey,
+      directory,
+      entry,
+      20 * 1024 * 1024
+    );
+    await bucket.put(item.destinationKey, bytes, {
+      httpMetadata: {
+        contentType: item.contentType ?? "application/octet-stream",
+      },
+      customMetadata: { sourceEtag: directory.sourceEtag },
+    });
+    result.push({
+      bytes: bytes.length,
+      destinationKey: item.destinationKey,
+      path: item.path,
+    });
+  }
+  return result;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -104,6 +104,8 @@
         "@cf-wasm/photon": "^0.4.0",
         "@resvg/resvg-wasm": "^2.6.2",
         "@sentry/cloudflare": "10.69.0",
+        "@streamparser/json": "^0.0.26",
+        "@teak/convex": "workspace:*",
         "@teak/files-protocol": "workspace:*",
         "client-zip": "^2.4.5",
         "fflate": "^0.8.2",
@@ -1717,6 +1719,8 @@
     "@stoplight/yaml": ["@stoplight/yaml@4.3.0", "", { "dependencies": { "@stoplight/ordered-object-literal": "^1.0.5", "@stoplight/types": "^14.1.1", "@stoplight/yaml-ast-parser": "0.0.50", "tslib": "^2.2.0" } }, "sha512-JZlVFE6/dYpP9tQmV0/ADfn32L9uFarHWxfcRhReKUnljz1ZiUM5zpX+PH8h5CJs6lao3TuFqnPm9IJJCEkE2w=="],
 
     "@stoplight/yaml-ast-parser": ["@stoplight/yaml-ast-parser@0.0.50", "", {}, "sha512-Pb6M8TDO9DtSVla9yXSTAxmo9GVEouq5P40DWXdOie69bXogZTkgvopCq+yEvTMA0F6PEvdJmbtTV3ccIp11VQ=="],
+
+    "@streamparser/json": ["@streamparser/json@0.0.26", "", {}, "sha512-46597LNFI+MFdUnzX2QJWwmdTRdq0XVD+vVNJTtGVzIrnCuhG9pFo1OAzbNBqci8UJgk/X5KJZ6LcV+y7PTuDQ=="],
 
     "@stripe/react-stripe-js": ["@stripe/react-stripe-js@4.0.2", "", { "dependencies": { "prop-types": "^15.7.2" }, "peerDependencies": { "@stripe/stripe-js": ">=1.44.1 <8.0.0", "react": ">=16.8.0 <20.0.0", "react-dom": ">=16.8.0 <20.0.0" } }, "sha512-l2wau+8/LOlHl+Sz8wQ1oDuLJvyw51nQCsu6/ljT6smqzTszcMHifjAJoXlnMfcou3+jK/kQyVe04u/ufyTXgg=="],
 

--- a/packages/convex/__tests__/import/archiveZip.test.ts
+++ b/packages/convex/__tests__/import/archiveZip.test.ts
@@ -1,51 +1,94 @@
-import { describe, expect, test } from "bun:test";
-import { Readable } from "node:stream";
-import type * as yauzl from "yauzl";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
-  ArchiveEntryTooLargeError,
-  entryBuffer,
+  readImportIndexPage,
+  readLegacyMarkdown,
 } from "../../import/archiveZip";
 
-const entry = (fileName: string, uncompressedSize: number) =>
-  ({ fileName, uncompressedSize }) as yauzl.Entry;
-
-describe("entryBuffer", () => {
-  test("uses a typed error when declared entry size exceeds the limit", async () => {
-    const zip = {} as yauzl.ZipFile;
-
-    await expect(entryBuffer(zip, entry("note.md", 3), 2)).rejects.toEqual(
-      new ArchiveEntryTooLargeError("note.md is too large")
-    );
+const originalFetch = globalThis.fetch;
+const prior = {
+  FILES_BASE: process.env.FILES_BASE,
+  FILES_SIGNING_SECRET: process.env.FILES_SIGNING_SECRET,
+  R2_KEY_PREFIX: process.env.R2_KEY_PREFIX,
+};
+const fetchMock = mock(
+  (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> =>
+    Promise.reject(new Error("Unexpected fetch"))
+);
+beforeEach(() => {
+  process.env.FILES_BASE = "https://files.test";
+  process.env.FILES_SIGNING_SECRET = "test-secret";
+  process.env.R2_KEY_PREFIX = "";
+  globalThis.fetch = fetchMock;
+  fetchMock.mockReset();
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const [key, value] of Object.entries(prior)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+describe("import worker client", () => {
+  test("sends a signed source-version-bound page request", async () => {
+    const page = {
+      items: [{ sourceIndex: 100, card: { type: "text", content: "Hello" } }],
+      total: 101,
+      nextCursor: null,
+      sourceEtag: '"a"',
+    };
+    fetchMock.mockResolvedValue(Response.json({ ok: true, data: page }));
+    expect(
+      await readImportIndexPage({
+        sourceKey: "users/u/imports/j/source",
+        expectedSize: 20,
+        mode: "archive",
+        cursor: 100,
+        sourceEtag: '"a"',
+      })
+    ).toEqual(page);
+    const [url, request] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://files.test/__ops/v1");
+    expect(JSON.parse(String(request?.body))).toMatchObject({
+      op: "index-import-source",
+      params: { sourceEtag: '"a"', cursor: 100 },
+    });
   });
-
-  test("uses a typed error when streamed content exceeds the limit", async () => {
-    const zip = {
-      openReadStream(
-        _entry: yauzl.Entry,
-        callback: (error: Error | null, stream?: Readable) => void
-      ) {
-        callback(null, Readable.from([Buffer.from("abc")]));
-      },
-    } as unknown as yauzl.ZipFile;
-
+  test("preserves per-item Markdown failures from the worker", async () => {
+    const failure = {
+      status: "failed",
+      failureCode: "INVALID_UTF8",
+      failureReason: "Invalid UTF-8",
+    };
+    fetchMock.mockResolvedValue(Response.json({ ok: true, data: failure }));
+    expect(
+      await readLegacyMarkdown(
+        "users/u/imports/j/source",
+        '"a"',
+        "files/note.md"
+      )
+    ).toEqual(failure);
+  });
+  test("does not silently fall back to S3 or accept a different namespace", async () => {
+    fetchMock.mockResolvedValue(
+      Response.json(
+        { ok: false, error: { code: "NOT_FOUND" } },
+        { status: 404 }
+      )
+    );
     await expect(
-      entryBuffer(zip, entry("note.md", 2), 2)
-    ).rejects.toBeInstanceOf(ArchiveEntryTooLargeError);
-  });
-
-  test("preserves non-size archive read failures", async () => {
-    const failure = new Error("ZIP entry is corrupt");
-    const zip = {
-      openReadStream(
-        _entry: yauzl.Entry,
-        callback: (error: Error | null, stream?: Readable) => void
-      ) {
-        callback(failure);
-      },
-    } as unknown as yauzl.ZipFile;
-
-    await expect(entryBuffer(zip, entry("note.md", 2), 2)).rejects.toBe(
-      failure
-    );
+      readImportIndexPage({
+        sourceKey: "users/u/imports/j/source",
+        mode: "archive",
+        expectedSize: 20,
+      })
+    ).rejects.toThrow("import_source_unavailable");
+    fetchMock.mockClear();
+    await expect(
+      readLegacyMarkdown("elsewhere/source", '"a"', "files/note.md")
+    ).rejects.toThrow("invalid_storage_key_namespace");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/convex/__tests__/workflows/aiMetadata/transcript.test.ts
+++ b/packages/convex/__tests__/workflows/aiMetadata/transcript.test.ts
@@ -1,111 +1,85 @@
-// @ts-nocheck
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  mock,
-  test,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { generateTranscript } from "../../../workflows/aiMetadata/transcript";
 
-const originalFetch = global.fetch;
-const mockFetch = mock();
-
-let generateTranscript: any;
-
-const audioResponse = (mimeType = "audio/mp3") => ({
-  ok: true,
-  headers: { get: () => mimeType },
-  arrayBuffer: async () => new ArrayBuffer(8),
+const originalFetch = globalThis.fetch;
+const prior = {
+  FILES_BASE: process.env.FILES_BASE,
+  FILES_SIGNING_SECRET: process.env.FILES_SIGNING_SECRET,
+  R2_KEY_PREFIX: process.env.R2_KEY_PREFIX,
+};
+const mockFetch = mock(
+  (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> =>
+    Promise.reject(new Error("Unexpected fetch"))
+);
+beforeEach(() => {
+  process.env.FILES_BASE = "https://files.test";
+  process.env.FILES_SIGNING_SECRET = "test-secret";
+  process.env.R2_KEY_PREFIX = "";
+  globalThis.fetch = mockFetch;
+  mockFetch.mockReset();
 });
-
-const workersAiResponse = (text: string) => ({
-  ok: true,
-  json: async () => ({ result: { text }, success: true }),
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  for (const [key, value] of Object.entries(prior)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
 });
 
 describe("generateTranscript", () => {
-  beforeAll(async () => {
-    global.fetch = mockFetch;
-    generateTranscript = (
-      await import("../../../workflows/aiMetadata/transcript")
-    ).generateTranscript;
-  });
-
-  afterAll(() => {
-    global.fetch = originalFetch;
-  });
-
-  beforeEach(() => {
-    mockFetch.mockReset();
-  });
-
-  test("generates transcript successfully", async () => {
-    mockFetch
-      .mockResolvedValueOnce(audioResponse())
-      .mockResolvedValueOnce(workersAiResponse("Transcript text"));
-
-    const result = await generateTranscript("https://audio.com/file.mp3");
-    expect(result).toBe("Transcript text");
-
-    const request = mockFetch.mock.calls[1]?.[0];
-    expect(request).toContain("/ai/run/@cf/openai/whisper-large-v3-turbo");
-    expect(mockFetch.mock.calls[1]?.[1]?.method).toBe("POST");
-    expect(mockFetch.mock.calls[1]?.[1]?.headers["Content-Type"]).toBe(
-      "audio/mp3"
+  test("requests transcription by source key without downloading audio", async () => {
+    mockFetch.mockResolvedValue(
+      Response.json({
+        ok: true,
+        version: 1,
+        data: {
+          text: "Transcript",
+          byteLength: 8,
+          mimeType: "audio/mp4",
+          sourceEtag: '"1"',
+        },
+      })
     );
-  });
-
-  test("handles fetch error", async () => {
-    mockFetch.mockResolvedValue({
-      ok: false,
-      status: 404,
-      statusText: "Not Found",
+    expect(
+      await generateTranscript("users/u/card/file/audio.m4a", "audio/mp4")
+    ).toBe("Transcript");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, request] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://files.test/__ops/v1");
+    expect(JSON.parse(String(request?.body))).toMatchObject({
+      op: "transcribe-audio",
+      params: {
+        sourceKey: "users/u/card/file/audio.m4a",
+        mimeType: "audio/mp4",
+      },
     });
-    const result = await generateTranscript("url");
-    expect(result).toBeNull();
+    expect(new Headers(request?.headers).has("x-teak-signature")).toBe(true);
   });
-
-  test("handles transcription error response", async () => {
-    mockFetch.mockResolvedValueOnce(audioResponse()).mockResolvedValueOnce({
-      ok: false,
-      status: 400,
-      statusText: "Bad Request",
-      json: async () => ({
-        errors: [{ message: "Invalid input" }],
-        success: false,
-      }),
-    });
-    const result = await generateTranscript("url");
-    expect(result).toBeNull();
+  test("preserves optional enrichment failure semantics", async () => {
+    for (const code of [
+      "NOT_FOUND",
+      "PAYLOAD_TOO_LARGE",
+      "UNSUPPORTED",
+      "INTERNAL",
+    ]) {
+      mockFetch.mockResolvedValue(
+        Response.json(
+          { ok: false, error: { code, requestId: "test" } },
+          { status: 500 }
+        )
+      );
+      expect(await generateTranscript("users/u/file")).toBeNull();
+    }
+    mockFetch.mockRejectedValue(new Error("offline"));
+    expect(await generateTranscript("users/u/file")).toBeNull();
   });
-
-  test("handles network error during transcription", async () => {
-    mockFetch
-      .mockResolvedValueOnce(audioResponse())
-      .mockRejectedValueOnce(new Error("AI error"));
-    const result = await generateTranscript("url");
-    expect(result).toBeNull();
-  });
-
-  test("mime type extension logic > covers all branches", async () => {
-    mockFetch
-      .mockResolvedValueOnce(audioResponse("audio/wav"))
-      .mockResolvedValueOnce(workersAiResponse("Wav"));
-    await generateTranscript("u");
-    expect(mockFetch.mock.calls[1]?.[1]?.headers["Content-Type"]).toBe(
-      "audio/wav"
-    );
-  });
-
-  test("mime type extension logic > uses mimeHint", async () => {
-    mockFetch
-      .mockResolvedValueOnce(audioResponse("audio/unknown"))
-      .mockResolvedValueOnce(workersAiResponse("Mime"));
-    await generateTranscript("u", "audio/mp4");
-    expect(mockFetch.mock.calls[1]?.[1]?.headers["Content-Type"]).toBe(
-      "audio/mp4"
-    );
+  test("rejects arbitrary URLs and keys outside this deployment before fetching", async () => {
+    expect(await generateTranscript("https://attacker.test/audio")).toBeNull();
+    process.env.R2_KEY_PREFIX = "dev/";
+    expect(await generateTranscript("users/u/file")).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/packages/convex/__tests__/workflows/steps/metadata.test.ts
+++ b/packages/convex/__tests__/workflows/steps/metadata.test.ts
@@ -44,10 +44,9 @@ const originalFilesBase = process.env.FILES_BASE;
 const originalFilesSecret = process.env.FILES_SIGNING_SECRET;
 
 /**
- * Route the image/video AI path through the Files Worker op envelope: image
- * understanding now runs inside the worker against its `detail` rendition.
+ * Return the signed Files Worker operation envelope for media processing.
  */
-const enableWorkerImageOp = (data: unknown, { status = 200 } = {}) => {
+const enableWorkerOp = (data: unknown, { status = 200 } = {}) => {
   process.env.FILES_BASE = "https://files.teakvault.com";
   process.env.FILES_SIGNING_SECRET = "test-signing-secret";
   mockFetch.mockImplementation(
@@ -291,7 +290,7 @@ describe("metadata handler", () => {
     test("runs the image AI canary for production E2E users", async () => {
       const originalDomain = process.env.E2E_EMAIL_DOMAIN;
       process.env.E2E_EMAIL_DOMAIN = "tests.example.com";
-      enableWorkerImageOp({
+      enableWorkerOp({
         summary: "A red square.",
         tags: ["red", "square"],
       });
@@ -395,7 +394,7 @@ describe("metadata handler", () => {
         fileMetadata: { height: 1722, width: 3006 },
       });
       // A worker fallback surfaces as the deferred raster-pending condition.
-      enableWorkerImageOp(null, { status: 404 });
+      enableWorkerOp(null, { status: 404 });
 
       const result = await generateHandler(ctx, {
         cardId: "c1",
@@ -447,7 +446,7 @@ describe("metadata handler", () => {
         thumbnailKey: "t1",
         fileMetadata: { mimeType: "image/png" },
       });
-      enableWorkerImageOp({ summary: "A photo", tags: ["photo"] });
+      enableWorkerOp({ summary: "A photo", tags: ["photo"] });
 
       const result = await generateHandler(ctx, {
         cardId: "c1",
@@ -467,7 +466,7 @@ describe("metadata handler", () => {
         thumbnailKey: "t1",
         fileMetadata: { mimeType: "image/svg+xml" },
       });
-      enableWorkerImageOp({ summary: "SVG image", tags: ["svg"] });
+      enableWorkerOp({ summary: "SVG image", tags: ["svg"] });
 
       const result = await generateHandler(ctx, {
         cardId: "c1",
@@ -484,7 +483,7 @@ describe("metadata handler", () => {
         fileKey: "f1",
         fileMetadata: { height: 6000, mimeType: "image/png", width: 6000 },
       });
-      enableWorkerImageOp({ summary: "A large photo", tags: ["photo"] });
+      enableWorkerOp({ summary: "A large photo", tags: ["photo"] });
 
       const result = await generateHandler(ctx, {
         cardId: "c1",
@@ -502,7 +501,7 @@ describe("metadata handler", () => {
         thumbnailKey: "t1",
         fileMetadata: { fileName: "diagram.svg" },
       });
-      enableWorkerImageOp({ summary: "A diagram", tags: ["diagram"] });
+      enableWorkerOp({ summary: "A diagram", tags: ["diagram"] });
 
       await generateHandler(ctx, {
         cardId: "c1",
@@ -519,7 +518,7 @@ describe("metadata handler", () => {
         thumbnailKey: "t1",
         fileMetadata: { fileName: "diagram.SVG" },
       });
-      enableWorkerImageOp({ summary: "A diagram", tags: ["diagram"] });
+      enableWorkerOp({ summary: "A diagram", tags: ["diagram"] });
 
       await generateHandler(ctx, { cardId: "c1", cardType: "image" });
 
@@ -565,7 +564,7 @@ describe("metadata handler", () => {
         _id: "c1",
         thumbnailKey: "t1",
       });
-      enableWorkerImageOp({ summary: "Video content", tags: ["video"] });
+      enableWorkerOp({ summary: "Video content", tags: ["video"] });
 
       const result = await generateHandler(ctx, {
         cardId: "c1",
@@ -583,7 +582,7 @@ describe("metadata handler", () => {
         thumbnailKey: "t1",
         fileMetadata: { fileName: "movie.mp4" },
       });
-      enableWorkerImageOp({ summary: "A movie", tags: ["movie"] });
+      enableWorkerOp({ summary: "A movie", tags: ["movie"] });
 
       await generateHandler(ctx, { cardId: "c1", cardType: "video" });
 
@@ -595,23 +594,10 @@ describe("metadata handler", () => {
     test("generates metadata from audio transcript", async () => {
       mockRunQuery.mockResolvedValue({
         _id: "c1",
-        fileKey: "a1",
+        fileKey: "users/u/audio.mp3",
         fileMetadata: { mimeType: "audio/mp3" },
       });
-      r2Mocks.resolveObjectUrl.mockResolvedValue("https://audio.mp3");
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          headers: { get: () => "audio/mp3" },
-          arrayBuffer: async () => new ArrayBuffer(8),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            result: { text: "spoken text in audio" },
-            success: true,
-          }),
-        });
+      enableWorkerOp({ text: "spoken text in audio", byteLength: 8 });
       aiMocks.generateText.mockResolvedValue({
         output: { tags: ["speech"], summary: "Audio content" },
       });
@@ -624,15 +610,19 @@ describe("metadata handler", () => {
       expect(result.aiTranscript).toBe("spoken text in audio");
       expect(result.aiTags).toEqual(["speech"]);
       expect(result.confidence).toBe(0.85);
+      expect(lastWorkerOpRequest()).toMatchObject({
+        op: "transcribe-audio",
+        params: { sourceKey: "users/u/audio.mp3" },
+      });
     });
 
     test("handles missing audio file", async () => {
       mockRunQuery.mockResolvedValue({
         _id: "c1",
-        fileKey: "a1",
+        fileKey: "users/u/audio.wav",
         fileMetadata: { mimeType: "audio/wav" },
       });
-      r2Mocks.resolveObjectUrl.mockResolvedValue(null);
+      enableWorkerOp(null, { status: 404 });
 
       const result = await generateHandler(ctx, {
         cardId: "c1",

--- a/packages/convex/ai/models.ts
+++ b/packages/convex/ai/models.ts
@@ -38,11 +38,9 @@ export const IMAGE_METADATA_MODEL = workersAi(IMAGE_METADATA_MODEL_ID);
 
 /**
  * Transcription model for audio content
- * Whisper large v3 turbo — billed per audio minute via the REST `/ai/run`
- * endpoint (see workflows/aiMetadata/transcript.ts).
+ * Whisper large v3 turbo via the files worker AI binding.
  */
-export const TRANSCRIPTION_MODEL_ID =
-  "@cf/openai/whisper-large-v3-turbo" as const;
+export { FILES_TRANSCRIPTION_MODEL as TRANSCRIPTION_MODEL_ID } from "@teak/files-protocol";
 
 /**
  * System prompts optimized for reuse across requests.

--- a/packages/convex/dataImport.ts
+++ b/packages/convex/dataImport.ts
@@ -339,6 +339,19 @@ export const insertItems = internalMutation({
       if (exists) {
         continue;
       }
+      if (item.status === "pending" && item.url) {
+        const duplicate = await ctx.db
+          .query("importJobItems")
+          .withIndex("by_jobId_and_url", (q) =>
+            q.eq("jobId", jobId).eq("url", item.url)
+          )
+          .first();
+        if (duplicate) {
+          item.status = "skipped";
+          item.failureCode = "SOURCE_DUPLICATE";
+          item.failureReason = "Duplicate URL in import file";
+        }
+      }
       const now = Date.now();
       await ctx.db.insert("importJobItems", {
         ...item,

--- a/packages/convex/import/archiveZip.ts
+++ b/packages/convex/import/archiveZip.ts
@@ -1,169 +1,38 @@
-"use node";
+import type {
+  FilesImportIndexParams,
+  FilesImportIndexResult,
+  FilesImportMarkdownResult,
+} from "@teak/files-protocol";
+import { callFilesWorkerJson } from "../storage/filesWorkerClient";
+import { assertR2KeyInNamespace } from "../storage/r2";
 
-import { PassThrough, Readable } from "node:stream";
-import { GetObjectCommand } from "@aws-sdk/client-s3";
-import * as yauzl from "yauzl";
-import { MAX_IMPORT_EXPANDED_BYTES, MAX_IMPORT_JSON_BYTES } from "./constants";
-import type { createImportS3Client } from "./r2Client";
-import { isSafeArchivePath } from "./validate";
-
-export class ArchiveEntryTooLargeError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ArchiveEntryTooLargeError";
-  }
-}
-
-class R2RangeReader extends yauzl.RandomAccessReader {
-  private readonly bucket: string;
-  private readonly client: ReturnType<typeof createImportS3Client>;
-  private readonly key: string;
-
-  constructor(
-    client: ReturnType<typeof createImportS3Client>,
-    bucket: string,
-    key: string
-  ) {
-    super();
-    this.bucket = bucket;
-    this.client = client;
-    this.key = key;
-  }
-
-  _readStreamForRange(start: number, end: number) {
-    const output = new PassThrough();
-    void this.client
-      .send(
-        new GetObjectCommand({
-          Bucket: this.bucket,
-          Key: this.key,
-          Range: `bytes=${start}-${end - 1}`,
-        })
-      )
-      .then((response) => {
-        if (response.Body instanceof Readable) {
-          response.Body.pipe(output);
-        } else {
-          output.destroy(new Error("R2 did not return a readable range"));
-        }
-      })
-      .catch((error) => output.destroy(error as Error));
-    return output;
-  }
-}
-
-export function openZip(
-  client: ReturnType<typeof createImportS3Client>,
-  bucket: string,
-  key: string,
-  size: number
-) {
-  return new Promise<yauzl.ZipFile>((resolve, reject) => {
-    yauzl.fromRandomAccessReader(
-      new R2RangeReader(client, bucket, key),
-      size,
-      {
-        decodeStrings: true,
-        lazyEntries: true,
-        strictFileNames: true,
-        validateEntrySizes: true,
-      },
-      (error, zip) =>
-        error || !zip ? reject(error ?? new Error("Invalid ZIP")) : resolve(zip)
-    );
+/** File bytes and parsing stay in the worker; Convex consumes bounded facts. */
+export async function readImportIndexPage(
+  params: FilesImportIndexParams
+): Promise<FilesImportIndexResult> {
+  assertR2KeyInNamespace(params.sourceKey);
+  const outcome = await callFilesWorkerJson<FilesImportIndexResult>({
+    op: "index-import-source",
+    params: { ...params },
   });
-}
-
-export function entryBuffer(
-  zip: yauzl.ZipFile,
-  entry: yauzl.Entry,
-  limit: number
-) {
-  if (entry.uncompressedSize > limit) {
-    return Promise.reject(
-      new ArchiveEntryTooLargeError(`${entry.fileName} is too large`)
-    );
+  if (outcome.kind !== "ok") {
+    throw new Error("import_source_unavailable");
   }
-  return new Promise<Buffer>((resolve, reject) => {
-    zip.openReadStream(entry, (error, stream) => {
-      if (error || !stream) {
-        return reject(error ?? new Error("ZIP entry is unreadable"));
-      }
-      const chunks: Buffer[] = [];
-      let total = 0;
-      stream.on("data", (chunk: Buffer) => {
-        total += chunk.length;
-        if (total > limit) {
-          stream.destroy(
-            new ArchiveEntryTooLargeError(
-              "Expanded ZIP entry exceeds its limit"
-            )
-          );
-        } else {
-          chunks.push(chunk);
-        }
-      });
-      stream.on("error", reject);
-      stream.on("end", () => resolve(Buffer.concat(chunks)));
-    });
-  });
+  return outcome.data;
 }
 
-interface ZipIndex {
-  cards?: unknown[];
-  entries: Map<string, yauzl.Entry>;
-  manifest?: unknown;
-}
-
-export function readZipIndex(zip: yauzl.ZipFile): Promise<ZipIndex> {
-  const entries = new Map<string, yauzl.Entry>();
-  let manifest: unknown;
-  let cards: unknown[] | undefined;
-  let expanded = 0;
-  return new Promise((resolve, reject) => {
-    zip.on("error", reject);
-    zip.on("end", () => resolve({ entries, manifest, cards }));
-    zip.on("entry", (entry: yauzl.Entry) => {
-      void (async () => {
-        if (
-          !isSafeArchivePath(entry.fileName) ||
-          entry.generalPurposeBitFlag % 2 !== 0
-        ) {
-          throw new Error("Archive contains an unsafe or encrypted entry");
-        }
-        if (![0, 8].includes(entry.compressionMethod)) {
-          throw new Error("Archive uses unsupported compression");
-        }
-        expanded += entry.uncompressedSize;
-        if (expanded > MAX_IMPORT_EXPANDED_BYTES) {
-          throw new Error("Archive expands beyond 5 GiB");
-        }
-        if (!entry.fileName.endsWith("/")) {
-          if (entries.has(entry.fileName)) {
-            throw new Error(
-              `Archive contains a duplicate entry: ${entry.fileName}`
-            );
-          }
-          entries.set(entry.fileName, entry);
-        }
-        if (entry.fileName === "manifest.json") {
-          manifest = JSON.parse(
-            (await entryBuffer(zip, entry, MAX_IMPORT_JSON_BYTES)).toString(
-              "utf8"
-            )
-          );
-        }
-        if (entry.fileName === "cards.json") {
-          const parsed = JSON.parse(
-            (await entryBuffer(zip, entry, MAX_IMPORT_JSON_BYTES)).toString(
-              "utf8"
-            )
-          );
-          cards = Array.isArray(parsed) ? parsed : parsed?.cards;
-        }
-        zip.readEntry();
-      })().catch(reject);
-    });
-    zip.readEntry();
+export async function readLegacyMarkdown(
+  sourceKey: string,
+  sourceEtag: string,
+  path: string
+): Promise<FilesImportMarkdownResult> {
+  assertR2KeyInNamespace(sourceKey);
+  const outcome = await callFilesWorkerJson<FilesImportMarkdownResult>({
+    op: "read-import-markdown",
+    params: { sourceKey, sourceEtag, path },
   });
+  if (outcome.kind !== "ok") {
+    throw new Error("markdown_source_unavailable");
+  }
+  return outcome.data;
 }

--- a/packages/convex/import/bookmarks.ts
+++ b/packages/convex/import/bookmarks.ts
@@ -1,4 +1,4 @@
-import { DomUtils, parseDocument } from "htmlparser2";
+import { Parser } from "htmlparser2";
 import { sanitizeExternalUrl } from "../shared/utils/safeUrl";
 import type { ImportCardInput } from "./validate";
 
@@ -8,106 +8,110 @@ export interface ParsedBookmarkItem {
   label: string;
 }
 
-function children(node: any): any[] {
-  return Array.isArray(node?.children) ? node.children : [];
+interface BookmarkList {
+  folders: string[];
+  pendingFolder?: string;
 }
 
-function elementName(node: any): string {
-  return typeof node?.name === "string" ? node.name.toLowerCase() : "";
-}
-
-function attribute(node: any, name: string): string | undefined {
-  const value = node?.attribs?.[name] ?? node?.attribs?.[name.toUpperCase()];
-  return typeof value === "string" ? value : undefined;
-}
-
-function findFirst(node: any, name: string): any | undefined {
-  if (elementName(node) === name) {
-    return node;
-  }
-  for (const child of children(node)) {
-    const found = findFirst(child, name);
-    if (found) {
-      return found;
-    }
-  }
-}
-
-function walkList(node: any, folders: string[], output: ParsedBookmarkItem[]) {
-  const nodes = children(node).flatMap((child) =>
-    elementName(child) === "p" ? children(child) : [child]
-  );
-  let pendingFolder: string | undefined;
-  for (const child of nodes) {
-    const name = elementName(child);
-    if (name === "dt") {
-      const heading = children(child).find(
-        (value) => elementName(value) === "h3"
-      );
-      if (heading) {
-        pendingFolder = DomUtils.textContent(heading).trim();
-      }
-      const anchor = children(child).find(
-        (value) => elementName(value) === "a"
-      );
-      if (anchor) {
-        const title = DomUtils.textContent(anchor).trim();
-        const rawUrl = attribute(anchor, "href");
-        const url = sanitizeExternalUrl(rawUrl);
-        if (url) {
-          const addDate = attribute(anchor, "add_date");
-          const seconds = addDate ? Number(addDate) : Number.NaN;
-          output.push({
-            label: title || url,
-            card: {
-              type: "link",
-              content: title || url,
-              url,
-              tags: folders.length ? [...folders] : undefined,
-              createdAt:
-                Number.isFinite(seconds) && seconds > 0
-                  ? Math.floor(seconds * 1000)
-                  : undefined,
-            },
-          });
-        } else {
-          output.push({
-            label: title || rawUrl || "Bookmark",
-            error: "Bookmark URL is unsafe",
-          });
-        }
-      }
-      const nested = children(child).find(
-        (nestedChild) => elementName(nestedChild) === "dl"
-      );
-      if (nested) {
-        walkList(
-          nested,
-          pendingFolder ? [...folders, pendingFolder] : folders,
-          output
-        );
-        pendingFolder = undefined;
-      }
-      continue;
-    }
-    if (name === "dl") {
-      walkList(
-        child,
-        pendingFolder ? [...folders, pendingFolder] : folders,
-        output
-      );
-      pendingFolder = undefined;
-    }
-  }
-}
-
+/** Parse Netscape bookmark exports without constructing a DOM for the 20 MiB source. */
 export function parseBookmarksHtml(html: string): ParsedBookmarkItem[] {
-  const document = parseDocument(html, { decodeEntities: true });
-  const rootList = findFirst(document, "dl");
-  if (!rootList) {
+  const output: ParsedBookmarkItem[] = [];
+  const lists: BookmarkList[] = [];
+  let foundList = false;
+  let finishedList = false;
+  let depth = 0;
+  let heading: string[] | undefined;
+  let anchor:
+    | { attributes: Record<string, string>; text: string[] }
+    | undefined;
+  const parser = new Parser(
+    {
+      onopentag(name, attributes) {
+        depth += 1;
+        if (depth > 128) {
+          throw new Error("Bookmark HTML nesting exceeds its limit");
+        }
+        if (finishedList) {
+          return;
+        }
+        if (name === "dl") {
+          foundList = true;
+          const parent = lists[lists.length - 1];
+          const folders = parent?.pendingFolder
+            ? [...parent.folders, parent.pendingFolder]
+            : (parent?.folders ?? []);
+          if (parent) {
+            parent.pendingFolder = undefined;
+          }
+          lists.push({ folders });
+        }
+        if (!lists.length) {
+          return;
+        }
+        if (name === "h3") {
+          heading = [];
+        }
+        if (name === "a") {
+          anchor = { attributes, text: [] };
+        }
+      },
+      ontext(text) {
+        heading?.push(text);
+        anchor?.text.push(text);
+      },
+      onclosetag(name) {
+        depth -= 1;
+        if (name === "h3" && heading) {
+          const list = lists[lists.length - 1];
+          if (list) {
+            list.pendingFolder = heading.join("").trim();
+          }
+          heading = undefined;
+        }
+        if (name === "a" && anchor) {
+          const title = anchor.text.join("").trim();
+          const rawUrl = anchor.attributes.href;
+          const url = sanitizeExternalUrl(rawUrl);
+          const seconds = Number(anchor.attributes.add_date);
+          const folders = lists[lists.length - 1]?.folders ?? [];
+          if (output.length >= 10_000) {
+            throw new Error("Bookmark file exceeds 10,000 bookmarks");
+          }
+          output.push(
+            url
+              ? {
+                  label: title || url,
+                  card: {
+                    type: "link",
+                    content: title || url,
+                    url,
+                    tags: folders.length ? [...folders] : undefined,
+                    createdAt:
+                      Number.isFinite(seconds) && seconds > 0
+                        ? Math.floor(seconds * 1000)
+                        : undefined,
+                  },
+                }
+              : {
+                  label: title || rawUrl || "Bookmark",
+                  error: "Bookmark URL is unsafe",
+                }
+          );
+          anchor = undefined;
+        }
+        if (name === "dl" && lists.length) {
+          lists.pop();
+          if (!lists.length) {
+            finishedList = true;
+          }
+        }
+      },
+    },
+    { decodeEntities: true }
+  );
+  parser.end(html);
+  if (!foundList) {
     throw new Error("Bookmarks HTML does not contain a bookmark list");
   }
-  const output: ParsedBookmarkItem[] = [];
-  walkList(rootList, [], output);
   return output;
 }

--- a/packages/convex/import/raindrop.ts
+++ b/packages/convex/import/raindrop.ts
@@ -11,65 +11,71 @@ import { parseImportedTimestamp } from "./validate";
 export function parseCsvRows(input: string): string[][] {
   const rows: string[][] = [];
   let row: string[] = [];
-  let field = "";
+  let pieces: string[] = [];
+  let blocks: string[] = [];
+  let pieceLength = 0;
+  const appendPiece = (piece: string) => {
+    pieces.push(piece);
+    pieceLength += piece.length;
+    if (pieceLength >= 65_536 || pieces.length >= 1024) {
+      blocks.push(pieces.join(""));
+      pieces = [];
+      pieceLength = 0;
+    }
+  };
+  let fieldStart = 0;
   let inQuotes = false;
   let index = 0;
   const length = input.length;
-
   const endField = () => {
-    row.push(field);
-    field = "";
+    if (row.length >= 256) {
+      throw new Error("Raindrop CSV has too many columns");
+    }
+    appendPiece(input.slice(fieldStart, index));
+    blocks.push(pieces.join(""));
+    row.push(blocks.join(""));
+    pieces = [];
+    blocks = [];
+    pieceLength = 0;
+    fieldStart = index + 1;
   };
   const endRow = () => {
     endField();
-    rows.push(row);
+    if (rows.length === 0 || !isEmptyRow(row)) {
+      if (rows.length > 10_000) {
+        throw new Error("Raindrop CSV exceeds 10,000 bookmarks");
+      }
+      rows.push(row);
+    }
     row = [];
   };
-
   while (index < length) {
     const char = input[index];
-    if (inQuotes) {
-      if (char === '"') {
-        if (input[index + 1] === '"') {
-          field += '"';
-          index += 2;
-          continue;
-        }
-        inQuotes = false;
-        index += 1;
-        continue;
-      }
-      field += char;
-      index += 1;
-      continue;
-    }
     if (char === '"') {
-      inQuotes = true;
-      index += 1;
-      continue;
-    }
-    if (char === ",") {
-      endField();
-      index += 1;
-      continue;
-    }
-    if (char === "\r") {
-      if (input[index + 1] === "\n") {
+      appendPiece(input.slice(fieldStart, index));
+      if (inQuotes && input[index + 1] === '"') {
+        appendPiece('"');
+        index += 2;
+      } else {
+        inQuotes = !inQuotes;
         index += 1;
       }
-      endRow();
-      index += 1;
+      fieldStart = index;
       continue;
     }
-    if (char === "\n") {
-      endRow();
-      index += 1;
-      continue;
+    if (!inQuotes && char === ",") {
+      endField();
     }
-    field += char;
+    if (!inQuotes && (char === "\r" || char === "\n")) {
+      endRow();
+      if (char === "\r" && input[index + 1] === "\n") {
+        index += 1;
+        fieldStart = index + 1;
+      }
+    }
     index += 1;
   }
-  if (field.length > 0 || row.length > 0) {
+  if (fieldStart < length || pieces.length || blocks.length || row.length) {
     endRow();
   }
   return rows;

--- a/packages/convex/import/runImport.ts
+++ b/packages/convex/import/runImport.ts
@@ -1,57 +1,31 @@
 "use node";
 
-import {
-  AbortMultipartUploadCommand,
-  DeleteObjectCommand,
-  GetObjectCommand,
-  PutObjectCommand,
-} from "@aws-sdk/client-s3";
 import { v } from "convex/values";
-import type yauzl from "yauzl";
 import { internal } from "../_generated/api";
 import { type ActionCtx, internalAction } from "../_generated/server";
 import { inferFileFormat } from "../shared/fileFormats";
-import {
-  isMarkdownFileName,
-  MARKDOWN_CONTENT_MAX_BYTES,
-} from "../shared/markdown";
+import { isMarkdownFileName } from "../shared/markdown";
 import { TELEMETRY_OPERATIONS } from "../shared/telemetry";
 import {
   callFilesWorkerJson,
+  type FilesWorkerHeadObjectResult,
   isFilesWorkerConfigured,
+  putObjectViaFilesWorker,
 } from "../storage/filesWorkerClient";
-import { buildR2UserPrefix } from "../storage/r2";
+import { assertR2KeyInNamespace, buildR2UserPrefix } from "../storage/r2";
 import {
   recordBackendHandledFailure,
   withBackendSpan,
 } from "../telemetry/sentry";
-import {
-  ArchiveEntryTooLargeError,
-  entryBuffer,
-  openZip,
-  readZipIndex,
-} from "./archiveZip";
-import { type ParsedBookmarkItem, parseBookmarksHtml } from "./bookmarks";
+import { readImportIndexPage, readLegacyMarkdown } from "./archiveZip";
 import {
   IMPORT_INDEX_BATCH,
   type ImportMode,
-  MAX_BOOKMARK_BYTES,
   MAX_IMPORT_FILE_BYTES,
-  MAX_RAINDROP_BYTES,
 } from "./constants";
-import { resolveLegacyMarkdownImport } from "./markdown";
-import { createImportS3Client, getImportR2Config } from "./r2Client";
-import { parseRaindropCsv } from "./raindrop";
 import { assertImportCardCount, validateImportCard } from "./validate";
 
 const internalAny = internal as Record<string, any>;
-
-const isMissingMultipartUpload = (error: unknown): boolean =>
-  error instanceof Error &&
-  (error.name === "NoSuchUpload" ||
-    ("$metadata" in error &&
-      (error as { $metadata?: { httpStatusCode?: number } }).$metadata
-        ?.httpStatusCode === 404));
 
 const observeImport =
   <TArgs, TResult>(
@@ -79,7 +53,7 @@ const observeImport =
 function normalizeIndexItem(
   raw: unknown,
   sourceIndex: number,
-  entries: Map<string, yauzl.Entry>,
+  entries: Map<string, { uncompressedSize: number }>,
   seenUrls: Set<string>
 ) {
   try {
@@ -151,7 +125,11 @@ function normalizeIndexItem(
   }
 }
 
-async function storeItems(ctx: any, jobId: string, items: any[]) {
+async function storeItems(
+  ctx: ActionCtx,
+  jobId: string,
+  items: ReturnType<typeof normalizeIndexItem>[]
+) {
   for (let index = 0; index < items.length; index += IMPORT_INDEX_BATCH) {
     await ctx.runMutation(internalAny.dataImport.insertItems, {
       jobId,
@@ -160,173 +138,131 @@ async function storeItems(ctx: any, jobId: string, items: any[]) {
   }
 }
 
-async function decodeLegacyMarkdownItems(
-  client: ReturnType<typeof createImportS3Client>,
-  bucket: string,
-  key: string,
-  size: number,
-  items: any[]
+async function bindSourceVersion(
+  ctx: ActionCtx,
+  job: { _id: string; sourceKey: string; sourceEtag?: string; fileSize: number }
 ) {
-  const needed = new Map<string, any>(
-    items
-      .filter(
-        (item) =>
-          item.status === "pending" &&
-          item.type === "document" &&
-          item.filePath &&
-          item.fileName &&
-          isMarkdownFileName(item.fileName)
-      )
-      .map((item) => [item.filePath, item] as [string, any])
-  );
-  if (!needed.size) {
-    return;
+  if (job.sourceEtag) {
+    return job.sourceEtag;
   }
-
-  const zip = await openZip(client, bucket, key, size);
-  try {
-    await new Promise<void>((resolve, reject) => {
-      zip.on("error", reject);
-      zip.on("end", resolve);
-      zip.on("entry", (entry) => {
-        void (async () => {
-          const item = needed.get(entry.fileName);
-          if (item) {
-            try {
-              const bytes = await entryBuffer(
-                zip,
-                entry,
-                MARKDOWN_CONTENT_MAX_BYTES
-              );
-              Object.assign(item, resolveLegacyMarkdownImport(item, bytes));
-            } catch (error) {
-              item.status = "failed";
-              item.failureCode =
-                error instanceof ArchiveEntryTooLargeError
-                  ? "CONTENT_TOO_LARGE"
-                  : "INVALID_ITEM";
-              item.failureReason =
-                error instanceof Error
-                  ? error.message
-                  : "Markdown file could not be imported";
-            }
-            needed.delete(entry.fileName);
-          }
-          zip.readEntry();
-        })().catch(reject);
-      });
-      zip.readEntry();
-    });
-  } finally {
-    zip.close();
+  assertR2KeyInNamespace(job.sourceKey);
+  const outcome = await callFilesWorkerJson<FilesWorkerHeadObjectResult>({
+    op: "head-object",
+    params: { key: job.sourceKey },
+  });
+  if (outcome.kind !== "ok" || !outcome.data.exists || !outcome.data.etag) {
+    throw new Error("missing_source");
   }
-}
-
-async function indexParsedBookmarks(
-  ctx: any,
-  jobId: string,
-  parsed: ParsedBookmarkItem[],
-  mode: ImportMode
-) {
-  assertImportCardCount(parsed.length, mode);
-  const seen = new Set<string>();
-  const items = parsed.map((item, sourceIndex) =>
-    item.card
-      ? normalizeIndexItem(item.card, sourceIndex, new Map(), seen)
-      : {
-          sourceIndex,
-          status: "failed" as const,
-          type: "text" as const,
-          content: item.label,
-          failureCode: "INVALID_BOOKMARK",
-          failureReason: item.error,
-        }
-  );
-  await storeItems(ctx, jobId, items);
+  if (outcome.data.size !== job.fileSize) {
+    throw new Error("source_changed");
+  }
+  return ctx.runMutation(internalAny["import/sourceVersion"].bind, {
+    jobId: job._id,
+    sourceEtag: outcome.data.etag,
+  });
 }
 
 export const indexImportSource = internalAction({
-  args: { jobId: v.id("importJobs") },
-  returns: v.object({ ok: v.boolean(), failureClass: v.optional(v.string()) }),
+  args: { jobId: v.id("importJobs"), cursor: v.optional(v.number()) },
+  returns: v.object({
+    ok: v.boolean(),
+    failureClass: v.optional(v.string()),
+    nextCursor: v.optional(v.number()),
+  }),
   handler: observeImport(
     "import.index",
-    async (ctx, { jobId }: { jobId: string }) => {
+    async (ctx, { jobId, cursor = 0 }: { jobId: string; cursor?: number }) => {
       const job = await ctx.runQuery(internalAny.dataImport.getJob, { jobId });
       if (!job) {
         return { ok: false, failureClass: "missing_job" };
       }
-      const config = getImportR2Config();
-      const client = createImportS3Client(config);
       try {
-        if (job.mode === "bookmarks" || job.mode === "raindrop") {
-          const isRaindrop = job.mode === "raindrop";
-          const maxBytes = isRaindrop ? MAX_RAINDROP_BYTES : MAX_BOOKMARK_BYTES;
-          if (job.fileSize > maxBytes) {
-            throw new Error(
-              isRaindrop
-                ? "Raindrop CSV exceeds 20 MiB"
-                : "Bookmark file exceeds 20 MiB"
-            );
+        const seen = new Set<string>();
+        const sourceEtag = await bindSourceVersion(ctx, job);
+        const current = await ctx.runQuery(internalAny.dataImport.getJob, {
+          jobId,
+        });
+        if (!current || current.cancelRequested) {
+          return { ok: true };
+        }
+        const page = await readImportIndexPage({
+          sourceKey: job.sourceKey,
+          expectedSize: job.fileSize,
+          mode: job.mode as ImportMode,
+          cursor,
+          sourceEtag,
+        });
+        assertImportCardCount(page.total, job.mode as ImportMode);
+        if (page.sourceEtag !== sourceEtag) {
+          throw new Error("source_changed");
+        }
+        const normalized = page.items.map((raw) => {
+          if (raw.error) {
+            const failed = {
+              sourceIndex: raw.sourceIndex,
+              status: "failed" as const,
+              type: "text" as const,
+              content: (raw.label ?? `Item ${raw.sourceIndex + 1}`).slice(
+                0,
+                100_000
+              ),
+              failureCode:
+                job.mode === "archive" ? "INVALID_ITEM" : "INVALID_BOOKMARK",
+              failureReason: raw.error,
+            };
+            return failed;
           }
-          const response = await client.send(
-            new GetObjectCommand({ Bucket: config.bucket, Key: job.sourceKey })
-          );
-          const bytes = await response.Body?.transformToByteArray();
-          if (!bytes || bytes.byteLength !== job.fileSize) {
-            throw new Error(
-              isRaindrop
-                ? "Raindrop source could not be read"
-                : "Bookmark source could not be read"
-            );
+          const entries = new Map<string, { uncompressedSize: number }>();
+          if (raw.file) {
+            entries.set(raw.file.path, raw.file);
           }
-          const text = Buffer.from(bytes).toString("utf8");
-          const parsed = isRaindrop
-            ? parseRaindropCsv(text)
-            : parseBookmarksHtml(text);
-          await indexParsedBookmarks(
-            ctx,
-            jobId,
-            parsed,
-            job.mode as ImportMode
+          return normalizeIndexItem(raw.card, raw.sourceIndex, entries, seen);
+        });
+        const items: ReturnType<typeof normalizeIndexItem>[] = [];
+        let batchBytes = 0;
+        // Bound both concurrent remote reads and expanded Markdown memory.
+        for (let offset = 0; offset < normalized.length; offset += 8) {
+          const batch = normalized.slice(offset, offset + 8);
+          await Promise.all(
+            batch.map(async (item) => {
+              if (
+                item.status === "pending" &&
+                item.type === "document" &&
+                item.filePath &&
+                item.fileName &&
+                isMarkdownFileName(item.fileName)
+              ) {
+                Object.assign(
+                  item,
+                  await readLegacyMarkdown(
+                    job.sourceKey,
+                    sourceEtag,
+                    item.filePath
+                  )
+                );
+              }
+            })
           );
-        } else {
-          const zip = await openZip(
-            client,
-            config.bucket,
-            job.sourceKey,
-            job.fileSize
-          );
-          try {
-            const index = await readZipIndex(zip);
-            const manifest = index.manifest as any;
-            const version = manifest?.version ?? manifest?.exportVersion;
-            if (version !== 1) {
-              throw new Error("Unsupported Teak archive version");
+          for (const item of batch) {
+            const itemBytes = new TextEncoder().encode(
+              JSON.stringify(item)
+            ).byteLength;
+            if (items.length && batchBytes + itemBytes > 4 * 1024 * 1024) {
+              await storeItems(ctx, jobId, items);
+              items.length = 0;
+              batchBytes = 0;
             }
-            const rawCards = Array.isArray(manifest?.cards)
-              ? manifest.cards
-              : index.cards;
-            if (!Array.isArray(rawCards)) {
-              throw new Error("Archive is missing cards");
-            }
-            assertImportCardCount(rawCards.length, job.mode as ImportMode);
-            const seen = new Set<string>();
-            const items = rawCards.map((card, sourceIndex) =>
-              normalizeIndexItem(card, sourceIndex, index.entries, seen)
-            );
-            await decodeLegacyMarkdownItems(
-              client,
-              config.bucket,
-              job.sourceKey,
-              job.fileSize,
-              items
-            );
-            await storeItems(ctx, jobId, items);
-          } finally {
-            zip.close();
+            items.push(item);
+            batchBytes += itemBytes;
           }
         }
-        return { ok: true };
+        await storeItems(ctx, jobId, items);
+        if (page.nextCursor !== null && page.nextCursor <= cursor) {
+          throw new Error("invalid_import_cursor");
+        }
+        return page.nextCursor === null
+          ? { ok: true }
+          : { ok: true, nextCursor: page.nextCursor };
       } catch (error) {
         recordBackendHandledFailure(error, {
           operation: TELEMETRY_OPERATIONS.import,
@@ -374,7 +310,10 @@ export const importStoredContentType = (item: {
 };
 
 export const extractImportFiles = internalAction({
-  args: { jobId: v.id("importJobs"), itemIds: v.array(v.id("importJobItems")) },
+  args: {
+    jobId: v.id("importJobs"),
+    itemIds: v.array(v.id("importJobItems")),
+  },
   returns: v.object({ ok: v.boolean(), failureClass: v.optional(v.string()) }),
   handler: observeImport(
     "import.extract_files",
@@ -399,6 +338,7 @@ export const extractImportFiles = internalAction({
         if (!isFilesWorkerConfigured()) {
           throw new Error("files_worker_not_configured");
         }
+        const sourceEtag = await bindSourceVersion(ctx, job);
         const entries = [...needed.values()].map((item) => ({
           contentType: importStoredContentType(item),
           destinationKey: deterministicFileKey(
@@ -413,7 +353,7 @@ export const extractImportFiles = internalAction({
           Array<{ destinationKey: string; path: string }>
         >({
           op: "extract-import-files",
-          params: { archiveKey: job.sourceKey, entries },
+          params: { archiveKey: job.sourceKey, entries, sourceEtag },
         });
         if (outcome.kind !== "ok") {
           throw new Error("file_extract_rejected");
@@ -445,6 +385,36 @@ export const extractImportFiles = internalAction({
   ),
 });
 
+// Failure reports contain a bounded identifying excerpt, never entire card bodies.
+const reportLabel = (text: string) =>
+  text.length > 1024 ? `${text.slice(0, 1024)}…` : text;
+
+async function abortImportUpload(key: string, uploadId?: string) {
+  if (!uploadId) {
+    return;
+  }
+  assertR2KeyInNamespace(key);
+  const result = await callFilesWorkerJson({
+    op: "abort-multipart",
+    params: { key, uploadId },
+  });
+  if (result.kind !== "ok") {
+    throw new Error("import_upload_abort_unavailable");
+  }
+}
+
+async function queueImportObjectDeletion(
+  ctx: ActionCtx,
+  keys: Array<string | undefined>
+) {
+  await ctx.runMutation(
+    internalAny["workflows/objectCleanup"].startObjectDeletion,
+    {
+      keys: keys.filter((key): key is string => Boolean(key)),
+    }
+  );
+}
+
 export const finalizeImportObjects = internalAction({
   args: { jobId: v.id("importJobs") },
   returns: v.object({ reportKey: v.optional(v.string()) }),
@@ -455,8 +425,6 @@ export const finalizeImportObjects = internalAction({
       if (!job) {
         return {};
       }
-      const config = getImportR2Config();
-      const client = createImportS3Client(config);
       let reportKey: string | undefined;
       if (job.failedCount > 0) {
         const lines = [
@@ -474,27 +442,19 @@ export const finalizeImportObjects = internalAction({
           );
           for (const item of page.page) {
             lines.push(
-              `${item.sourceIndex + 1}. ${item.content || item.fileName}: ${item.failureReason ?? "Import failed"}`
+              `${item.sourceIndex + 1}. ${reportLabel(item.content || item.fileName || "Item")}: ${reportLabel(item.failureReason ?? "Import failed")}`
             );
           }
           cursor = page.isDone ? null : page.continueCursor;
         } while (cursor);
         reportKey = `${buildR2UserPrefix(job.userId)}/imports/${jobId}/error-report.txt`;
-        await client.send(
-          new PutObjectCommand({
-            Bucket: config.bucket,
-            Key: reportKey,
-            Body: lines.join("\n"),
-            ContentType: "text/plain; charset=utf-8",
-            ContentDisposition: 'attachment; filename="teak-import-report.txt"',
-          })
-        );
+        await putObjectViaFilesWorker({
+          key: reportKey,
+          body: new TextEncoder().encode(lines.join("\n")),
+          contentType: "text/plain; charset=utf-8",
+        });
       }
-      await client
-        .send(
-          new DeleteObjectCommand({ Bucket: config.bucket, Key: job.sourceKey })
-        )
-        .catch(() => undefined);
+      await queueImportObjectDeletion(ctx, [job.sourceKey]);
       return { reportKey };
     }
   ),
@@ -510,24 +470,8 @@ export const cleanupImportJob = internalAction({
       if (!job) {
         return null;
       }
-      const config = getImportR2Config();
-      const client = createImportS3Client(config);
-      if (job.uploadId) {
-        await client
-          .send(
-            new AbortMultipartUploadCommand({
-              Bucket: config.bucket,
-              Key: job.sourceKey,
-              UploadId: job.uploadId,
-            })
-          )
-          .catch(() => undefined);
-      }
-      for (const key of [job.sourceKey, job.reportKey].filter(Boolean)) {
-        await client
-          .send(new DeleteObjectCommand({ Bucket: config.bucket, Key: key }))
-          .catch(() => undefined);
-      }
+      await abortImportUpload(job.sourceKey, job.uploadId);
+      await queueImportObjectDeletion(ctx, [job.sourceKey, job.reportKey]);
       for (;;) {
         const result = await ctx.runMutation(
           internalAny.dataImport.deleteItemsPage,
@@ -557,27 +501,8 @@ export const cleanupExpiredUploads = internalAction({
         }
       );
       for (const job of jobs) {
-        const config = getImportR2Config();
-        const client = createImportS3Client(config);
-        if (job.uploadId) {
-          await client
-            .send(
-              new AbortMultipartUploadCommand({
-                Bucket: config.bucket,
-                Key: job.sourceKey,
-                UploadId: job.uploadId,
-              })
-            )
-            .catch(() => undefined);
-        }
-        await client
-          .send(
-            new DeleteObjectCommand({
-              Bucket: config.bucket,
-              Key: job.sourceKey,
-            })
-          )
-          .catch(() => undefined);
+        await abortImportUpload(job.sourceKey, job.uploadId);
+        await queueImportObjectDeletion(ctx, [job.sourceKey]);
         await ctx.runMutation(internalAny.dataImport.finishJob, {
           jobId: job._id,
           status: "failed",
@@ -600,30 +525,14 @@ export const deleteAccountImportObjects = internalAction({
     ),
   },
   returns: v.null(),
-  handler: async (_ctx, { objects }) => {
-    const config = getImportR2Config();
-    const client = createImportS3Client(config);
+  handler: async (ctx, { objects }) => {
     for (const object of objects) {
-      if (object.uploadId) {
-        try {
-          await client.send(
-            new AbortMultipartUploadCommand({
-              Bucket: config.bucket,
-              Key: object.sourceKey,
-              UploadId: object.uploadId,
-            })
-          );
-        } catch (error) {
-          if (!isMissingMultipartUpload(error)) {
-            throw error;
-          }
-        }
-      }
-      for (const key of [object.sourceKey, object.reportKey].filter(Boolean)) {
-        await client.send(
-          new DeleteObjectCommand({ Bucket: config.bucket, Key: key })
-        );
-      }
+      await abortImportUpload(object.sourceKey, object.uploadId);
+      // Persist deletion work before the account cleanup removes these rows.
+      await queueImportObjectDeletion(ctx, [
+        object.sourceKey,
+        object.reportKey,
+      ]);
     }
     return null;
   },

--- a/packages/convex/import/runImport.ts
+++ b/packages/convex/import/runImport.ts
@@ -69,9 +69,6 @@ function normalizeIndexItem(
         failureReason: "Duplicate URL in import file",
       };
     }
-    if (card.url) {
-      seenUrls.add(card.url);
-    }
     if (card.file) {
       const entry = entries.get(card.file.path);
       if (!entry) {
@@ -86,6 +83,9 @@ function normalizeIndexItem(
       ) {
         throw new Error("File size does not match the archive entry");
       }
+    }
+    if (card.url) {
+      seenUrls.add(card.url);
     }
     return {
       sourceIndex,
@@ -232,14 +232,18 @@ export const indexImportSource = internalAction({
                 item.fileName &&
                 isMarkdownFileName(item.fileName)
               ) {
-                Object.assign(
-                  item,
-                  await readLegacyMarkdown(
-                    job.sourceKey,
-                    sourceEtag,
-                    item.filePath
-                  )
+                const markdown = await readLegacyMarkdown(
+                  job.sourceKey,
+                  sourceEtag,
+                  item.filePath
                 );
+                Object.assign(item, markdown);
+                if ("type" in markdown && markdown.type === "text") {
+                  item.filePath = undefined;
+                  item.fileName = undefined;
+                  item.fileSize = undefined;
+                  item.mimeType = undefined;
+                }
               }
             })
           );
@@ -500,14 +504,24 @@ export const cleanupExpiredUploads = internalAction({
           limit: 50,
         }
       );
+      let failureCount = 0;
       for (const job of jobs) {
-        await abortImportUpload(job.sourceKey, job.uploadId);
-        await queueImportObjectDeletion(ctx, [job.sourceKey]);
-        await ctx.runMutation(internalAny.dataImport.finishJob, {
-          jobId: job._id,
-          status: "failed",
-          failureClass: "upload_expired",
-        });
+        try {
+          await abortImportUpload(job.sourceKey, job.uploadId);
+          await queueImportObjectDeletion(ctx, [job.sourceKey]);
+          await ctx.runMutation(internalAny.dataImport.finishJob, {
+            jobId: job._id,
+            status: "failed",
+            failureClass: "upload_expired",
+          });
+        } catch {
+          failureCount += 1;
+        }
+      }
+      if (failureCount) {
+        throw new Error(
+          `Import cleanup incomplete for ${failureCount} jobs; retry required`
+        );
       }
       return null;
     }
@@ -526,13 +540,23 @@ export const deleteAccountImportObjects = internalAction({
   },
   returns: v.null(),
   handler: async (ctx, { objects }) => {
+    let failureCount = 0;
     for (const object of objects) {
-      await abortImportUpload(object.sourceKey, object.uploadId);
-      // Persist deletion work before the account cleanup removes these rows.
-      await queueImportObjectDeletion(ctx, [
-        object.sourceKey,
-        object.reportKey,
-      ]);
+      try {
+        await abortImportUpload(object.sourceKey, object.uploadId);
+        // Persist deletion work before the account cleanup removes these rows.
+        await queueImportObjectDeletion(ctx, [
+          object.sourceKey,
+          object.reportKey,
+        ]);
+      } catch {
+        failureCount += 1;
+      }
+    }
+    if (failureCount) {
+      throw new Error(
+        `Account import cleanup incomplete for ${failureCount} objects; retry required`
+      );
     }
     return null;
   },

--- a/packages/convex/import/sourceVersion.ts
+++ b/packages/convex/import/sourceVersion.ts
@@ -1,0 +1,24 @@
+import { v } from "convex/values";
+import { internalMutation } from "../_generated/server";
+
+/** Bind once before storing any rows, including across action retries. */
+export const bind = internalMutation({
+  args: { jobId: v.id("importJobs"), sourceEtag: v.string() },
+  returns: v.string(),
+  handler: async (ctx, { jobId, sourceEtag }) => {
+    const job = await ctx.db.get(jobId);
+    if (!job) {
+      throw new Error("missing_job");
+    }
+    if (!sourceEtag || sourceEtag.length > 255) {
+      throw new Error("invalid_source_etag");
+    }
+    if (job.sourceEtag && job.sourceEtag !== sourceEtag) {
+      throw new Error("source_changed");
+    }
+    if (!job.sourceEtag) {
+      await ctx.db.patch(jobId, { sourceEtag });
+    }
+    return sourceEtag;
+  },
+});

--- a/packages/convex/importConsolidation.test.ts
+++ b/packages/convex/importConsolidation.test.ts
@@ -169,6 +169,8 @@ describe("import orchestration through the worker", () => {
       type: "text",
       content: "# Notes",
     });
+    expect(items[3]).not.toHaveProperty("filePath");
+    expect(items[3]).not.toHaveProperty("fileName");
     expect(
       requests.filter((request) => request.op === "read-import-markdown")
     ).toHaveLength(2);

--- a/packages/convex/importConsolidation.test.ts
+++ b/packages/convex/importConsolidation.test.ts
@@ -1,0 +1,230 @@
+/// <reference types="vite/client" />
+
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { internal } from "./_generated/api";
+import schema from "./schema";
+
+const modules = import.meta.glob("./**/*.ts");
+const sourceKey = "users/import-test/imports/job/source.zip";
+const setup = async (mode: "archive" | "bookmarks" = "archive") => {
+  const t = convexTest(schema, modules);
+  const jobId = await t.run((ctx) =>
+    ctx.db.insert("importJobs", {
+      userId: "import-test",
+      mode,
+      status: "parsing",
+      phase: "Parsing",
+      fileName: "source.zip",
+      fileSize: 128,
+      fileLastModified: 0,
+      sourceKey,
+      sourceEtag: '"stable"',
+      parsedCount: 0,
+      processedCount: 0,
+      createdCount: 0,
+      skippedCount: 0,
+      failedCount: 0,
+      createdAt: 0,
+      updatedAt: 0,
+    })
+  );
+  return { t, jobId };
+};
+beforeEach(() => {
+  vi.stubEnv("FILES_BASE", "https://files.test");
+  vi.stubEnv("FILES_SIGNING_SECRET", "test-secret");
+  vi.stubEnv("R2_KEY_PREFIX", "");
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("import orchestration through the worker", () => {
+  test("binds a legacy job once and rejects a different version on replay", async () => {
+    const { t, jobId } = await setup();
+    await t.run((ctx) => ctx.db.patch(jobId, { sourceEtag: undefined }));
+    expect(
+      await t.mutation(internal["import/sourceVersion"].bind, {
+        jobId,
+        sourceEtag: '"first"',
+      })
+    ).toBe('"first"');
+    expect(
+      await t.mutation(internal["import/sourceVersion"].bind, {
+        jobId,
+        sourceEtag: '"first"',
+      })
+    ).toBe('"first"');
+    await expect(
+      t.mutation(internal["import/sourceVersion"].bind, {
+        jobId,
+        sourceEtag: '"replacement"',
+      })
+    ).rejects.toThrow("source_changed");
+    expect(await t.run((ctx) => ctx.db.get(jobId))).toMatchObject({
+      sourceEtag: '"first"',
+    });
+  });
+  test("preserves deduplication across pages, invalid items, Markdown conversion, and replay counts", async () => {
+    const { t, jobId } = await setup();
+    const requests: Array<{ op: string; params: Record<string, unknown> }> = [];
+    vi.stubGlobal("fetch", (_url: string, request: RequestInit) => {
+      const body = JSON.parse(String(request.body));
+      requests.push(body);
+      if (body.op === "read-import-markdown") {
+        return Response.json({
+          ok: true,
+          data: { content: "# Notes", type: "text" },
+        });
+      }
+      expect(body.params.sourceEtag).toBe('"stable"');
+      const first = body.params.cursor === 0;
+      return Response.json({
+        ok: true,
+        data: {
+          sourceEtag: '"stable"',
+          total: 4,
+          nextCursor: first ? 1 : null,
+          items: first
+            ? [
+                {
+                  sourceIndex: 0,
+                  card: {
+                    type: "link",
+                    url: "https://example.com",
+                    content: "First",
+                  },
+                },
+              ]
+            : [
+                {
+                  sourceIndex: 1,
+                  card: {
+                    type: "link",
+                    url: "https://example.com",
+                    content: "Duplicate",
+                  },
+                },
+                {
+                  sourceIndex: 2,
+                  card: { type: "invalid", content: "Invalid" },
+                },
+                {
+                  sourceIndex: 3,
+                  card: {
+                    type: "document",
+                    content: "File",
+                    file: {
+                      fileName: "note.md",
+                      mimeType: "text/markdown",
+                      path: "files/note.md",
+                    },
+                  },
+                  file: { path: "files/note.md", uncompressedSize: 7 },
+                },
+              ],
+        },
+      });
+    });
+    const run = async () => {
+      let result = await t.action(
+        internal["import/runImport"].indexImportSource,
+        { jobId }
+      );
+      while (result.ok && result.nextCursor !== undefined) {
+        result = await t.action(
+          internal["import/runImport"].indexImportSource,
+          { jobId, cursor: result.nextCursor }
+        );
+      }
+      return result;
+    };
+    expect(await run()).toEqual({ ok: true });
+    expect(await run()).toEqual({ ok: true });
+    const job = await t.run((ctx) => ctx.db.get(jobId));
+    expect(job).toMatchObject({
+      parsedCount: 4,
+      skippedCount: 1,
+      failedCount: 1,
+      processedCount: 2,
+    });
+    const items = await t.run((ctx) =>
+      ctx.db
+        .query("importJobItems")
+        .withIndex("by_job_source", (q) => q.eq("jobId", jobId))
+        .take(10)
+    );
+    expect(items[1]).toMatchObject({
+      status: "skipped",
+      failureCode: "SOURCE_DUPLICATE",
+    });
+    expect(items[2]).toMatchObject({
+      status: "failed",
+      failureCode: "INVALID_ITEM",
+    });
+    expect(items[3]).toMatchObject({
+      status: "pending",
+      type: "text",
+      content: "# Notes",
+    });
+    expect(
+      requests.filter((request) => request.op === "read-import-markdown")
+    ).toHaveLength(2);
+  });
+  test("stops reading further pages after cancellation", async () => {
+    const { t, jobId } = await setup("bookmarks");
+    const fetchMock = vi.fn(async () => {
+      await t.run((ctx) => ctx.db.patch(jobId, { cancelRequested: true }));
+      return Response.json({
+        ok: true,
+        data: {
+          sourceEtag: '"stable"',
+          total: 2,
+          nextCursor: 1,
+          items: [
+            {
+              sourceIndex: 0,
+              card: {
+                type: "link",
+                content: "First",
+                url: "https://example.com",
+              },
+            },
+          ],
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    expect(
+      await t.action(internal["import/runImport"].indexImportSource, {
+        jobId,
+      })
+    ).toEqual({ ok: true, nextCursor: 1 });
+    expect(
+      await t.action(internal["import/runImport"].indexImportSource, {
+        jobId,
+        cursor: 1,
+      })
+    ).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+  test("rejects changed archive versions without storing a page", async () => {
+    const { t, jobId } = await setup();
+    vi.stubGlobal("fetch", async () =>
+      Response.json(
+        { ok: false, error: { code: "CONFLICT", requestId: "changed" } },
+        { status: 409 }
+      )
+    );
+    expect(
+      await t.action(internal["import/runImport"].indexImportSource, {
+        jobId,
+      })
+    ).toMatchObject({ ok: false });
+    expect(
+      await t.run((ctx) => ctx.db.query("importJobItems").take(1))
+    ).toHaveLength(0);
+  });
+});

--- a/packages/convex/schema.ts
+++ b/packages/convex/schema.ts
@@ -403,6 +403,8 @@ export const importJobValidator = v.object({
   fileSize: v.number(),
   fileLastModified: v.number(),
   sourceKey: r2KeyValidator,
+  // Bound on first processing attempt; optional for jobs created before rollout.
+  sourceEtag: v.optional(v.string()),
   uploadId: v.optional(v.string()),
   uploadExpiresAt: v.optional(v.number()),
   workflowId: v.optional(v.string()),
@@ -641,6 +643,7 @@ export default defineSchema({
     .index("by_user_status", ["userId", "status"])
     .index("by_status_upload_expires", ["status", "uploadExpiresAt"]),
   importJobItems: defineTable(importJobItemValidator)
+    .index("by_jobId_and_url", ["jobId", "url"])
     .index("by_job_source", ["jobId", "sourceIndex"])
     .index("by_job_status_source", ["jobId", "status", "sourceIndex"])
     .index("by_user", ["userId"]),

--- a/packages/convex/vitest.config.ts
+++ b/packages/convex/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     environment: "edge-runtime",
     include: [
       "./occContention.test.ts",
+      "./importConsolidation.test.ts",
       "./safariOAuth.test.ts",
       "./securitySessions.test.ts",
       "./mcpRevocation.test.ts",

--- a/packages/convex/workflows/aiMetadata/transcript.ts
+++ b/packages/convex/workflows/aiMetadata/transcript.ts
@@ -1,83 +1,29 @@
 "use node";
 
+import { trace } from "@opentelemetry/api";
+import type { FilesTranscriptResult } from "@teak/files-protocol";
 import { TRANSCRIPTION_MODEL_ID } from "../../ai/models";
 import { observeAiGeneration } from "../../ai/telemetry";
+import { callFilesWorkerJson } from "../../storage/filesWorkerClient";
+import { assertR2KeyInNamespace } from "../../storage/r2";
 import {
   recordBackendAiContent,
   recordBackendHandledFailure,
-  recordBackendLog,
   withBackendSpan,
 } from "../../telemetry/sentry";
 
-const workersAiRunUrl = () =>
-  `https://api.cloudflare.com/client/v4/accounts/${
-    process.env.CLOUDFLARE_ACCOUNT_ID ?? ""
-  }/ai/run/${TRANSCRIPTION_MODEL_ID}`;
-
-// Transcribe audio bytes via Cloudflare Workers AI. The REST `/ai/run`
-// endpoint accepts the raw audio as the request body and returns a
-// `{ result: { text } }` envelope.
-export const transcribeWorkersAi = async (
-  audio: ArrayBuffer,
-  mimeType: string
-): Promise<string> => {
-  const response = await fetch(workersAiRunUrl(), {
-    body: new Blob([audio], { type: mimeType }),
-    headers: {
-      Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN ?? ""}`,
-      "Content-Type": mimeType,
-    },
-    method: "POST",
-  });
-
-  const payload = (await response.json().catch(() => null)) as {
-    errors?: { message?: string }[];
-    result?: { text?: string };
-    success?: boolean;
-  } | null;
-
-  if (!(response.ok && payload?.success && payload.result)) {
-    const detail =
-      payload?.errors?.map((error) => error.message).join("; ") ??
-      `${response.status} ${response.statusText}`;
-    throw new Error(`Workers AI transcription failed: ${detail}`);
-  }
-
-  return payload.result.text ?? "";
-};
-
 // Generate transcript for audio content
 export const generateTranscript = async (
-  audioUrl: string,
+  sourceKey: string,
   mimeHint?: string
 ) => {
   let reportedBySpan = false;
   try {
-    // Fetch the audio so we can provide a proper filename and mime type
-    const response = await fetch(audioUrl);
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch audio: ${response.status} ${response.statusText}`
-      );
-    }
-
-    const mimeType =
-      mimeHint || response.headers.get("content-type") || "audio/webm";
-    if (!mimeType.startsWith("audio/")) {
-      recordBackendLog("warn", "ai.transcript.unexpected_mime_type", {
-        mimeType,
-      });
-    }
-
-    const arrayBuffer = await response.arrayBuffer();
-
-    // Use Whisper large v3 turbo on Cloudflare Workers AI for fast,
-    // cost-effective transcription (billed per audio minute)
+    assertR2KeyInNamespace(sourceKey);
     reportedBySpan = true;
     return await withBackendSpan(
       {
         attributes: {
-          "audio.byte_length": arrayBuffer.byteLength,
           model: TRANSCRIPTION_MODEL_ID,
           provider: "cloudflare",
         },
@@ -92,10 +38,19 @@ export const generateTranscript = async (
             functionId: "teak.ai.transcript",
             model: TRANSCRIPTION_MODEL_ID,
           },
-          () =>
-            transcribeWorkersAi(arrayBuffer, mimeType).then((text) => ({
-              text,
-            }))
+          async () => {
+            const result = await callFilesWorkerJson<FilesTranscriptResult>({
+              op: "transcribe-audio",
+              params: { sourceKey, mimeType: mimeHint },
+            });
+            if (result.kind !== "ok") {
+              throw new Error("transcription_rejected");
+            }
+            trace
+              .getActiveSpan()
+              ?.setAttribute("audio.byte_length", result.data.byteLength);
+            return { text: result.data.text };
+          }
         );
         recordBackendAiContent({ response: text });
         return text;

--- a/packages/convex/workflows/import.ts
+++ b/packages/convex/workflows/import.ts
@@ -45,10 +45,21 @@ export const importWorkflow = workflow.define({
       return finalize(step, jobId, "canceled");
     }
 
-    const indexed = await step.runAction(
+    let indexed = await step.runAction(
       internalAny["import/runImport"].indexImportSource,
       { jobId }
     );
+    // Old journal results have no cursor and replay the original step sequence.
+    // New imports checkpoint each bounded page instead of one long action.
+    while (indexed.ok && indexed.nextCursor !== undefined) {
+      indexed = await step.runAction(
+        internalAny["import/runImport"].indexImportSource,
+        {
+          jobId,
+          cursor: indexed.nextCursor,
+        }
+      );
+    }
     if (!indexed.ok) {
       return finalize(
         step,

--- a/packages/convex/workflows/steps/metadata.ts
+++ b/packages/convex/workflows/steps/metadata.ts
@@ -17,7 +17,6 @@ import { extractVisualStylesFromTags } from "../../shared/constants";
 import { inferFileFormat } from "../../shared/fileFormats";
 import { TELEMETRY_OPERATIONS } from "../../shared/telemetry";
 import type { Id } from "../../shared/types";
-import { resolveObjectUrl } from "../../storage/r2";
 import { withBackendSpan } from "../../telemetry/sentry";
 import {
   generateImageMetadataForStoredKey,
@@ -262,19 +261,16 @@ export async function generateHandler(
       }
       case "audio": {
         if (card.fileKey) {
-          const audioUrl = await resolveObjectUrl(card.fileKey);
-          if (audioUrl) {
-            const transcriptResult = await generateTranscript(
-              audioUrl,
-              card.fileMetadata?.mimeType
-            );
-            if (transcriptResult) {
-              aiTranscript = transcriptResult;
-              const result = await generateTextMetadata(transcriptResult);
-              aiTags = result.aiTags;
-              aiSummary = result.aiSummary;
-              confidence = 0.85;
-            }
+          const transcriptResult = await generateTranscript(
+            card.fileKey,
+            card.fileMetadata?.mimeType
+          );
+          if (transcriptResult) {
+            aiTranscript = transcriptResult;
+            const result = await generateTextMetadata(transcriptResult);
+            aiTags = result.aiTags;
+            aiSummary = result.aiSummary;
+            confidence = 0.85;
           }
         }
         break;

--- a/packages/files-protocol/src/index.ts
+++ b/packages/files-protocol/src/index.ts
@@ -28,6 +28,7 @@ export const FILES_UPLOAD_PATH = "/__upload/v1" as const;
 export const FILES_UPLOAD_MAX_TTL_SECONDS = 15 * 60;
 
 export const FILES_OPS = [
+  "capabilities",
   "analyze-image",
   // Additive alias of analyze-image; both are accepted so Worker and Convex
   // deployments can overlap safely within protocol version 1.
@@ -45,6 +46,9 @@ export const FILES_OPS = [
   "head-object",
   "inspect",
   "list-objects",
+  "transcribe-audio",
+  "index-import-source",
+  "read-import-markdown",
 ] as const;
 
 export type FilesOp = (typeof FILES_OPS)[number];
@@ -199,3 +203,53 @@ export const buildImageSourceSigningPayload = ({
   key: string;
 }): string =>
   ["image-source", String(FILES_PROTOCOL_VERSION), key, expiresAt].join("\n");
+
+export const FILES_TRANSCRIPTION_MODEL =
+  "@cf/openai/whisper-large-v3-turbo" as const;
+export const FILES_AUDIO_MAX_BYTES = 100 * 1024 * 1024;
+export const FILES_TRANSCRIPT_MAX_BYTES = 512 * 1024;
+export interface FilesTranscriptParams {
+  mimeType?: string;
+  sourceKey: string;
+}
+export interface FilesTranscriptResult {
+  byteLength: number;
+  mimeType: string;
+  sourceEtag: string;
+  text: string;
+}
+
+export const FILES_IMPORT_PAGE_BYTES = 4 * 1024 * 1024;
+export const FILES_IMPORT_PAGE_ITEMS = 100;
+export interface FilesImportIndexParams {
+  cursor?: number;
+  expectedSize: number;
+  mode: "archive" | "bookmarks" | "raindrop";
+  sourceEtag?: string;
+  sourceKey: string;
+}
+export interface FilesImportIndexItem {
+  card?: unknown;
+  error?: string;
+  file?: { path: string; uncompressedSize: number };
+  label?: string;
+  sourceIndex: number;
+}
+export interface FilesImportIndexResult {
+  items: FilesImportIndexItem[];
+  nextCursor: number | null;
+  sourceEtag: string;
+  total: number;
+}
+export interface FilesImportMarkdownParams {
+  path: string;
+  sourceEtag: string;
+  sourceKey: string;
+}
+export type FilesImportMarkdownResult =
+  | { content: string; type: "text" }
+  | {
+      status: "failed";
+      failureCode: "CONTENT_TOO_LARGE" | "INVALID_UTF8" | "INVALID_ITEM";
+      failureReason: string;
+    };

--- a/scripts/check-files-readiness.ts
+++ b/scripts/check-files-readiness.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+/** Read-only deployment gate: the worker must support the backend's byte paths. */
+import { buildSignedWorkerOpRequest } from "../packages/convex/storage/filesWorkerClient";
+
+const required = [
+  "transcribe-audio",
+  "index-import-source",
+  "read-import-markdown",
+  "extract-import-files",
+  "abort-multipart",
+  "delete-objects",
+];
+
+async function productionEnv(name: string): Promise<string> {
+  const child = Bun.spawn(
+    ["bun", "x", "convex", "env", "get", name, "--prod"],
+    {
+      cwd: new URL("../packages/convex", import.meta.url).pathname,
+      stdout: "pipe",
+      stderr: "pipe",
+    }
+  );
+  const [output, , code] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (code !== 0 || !output.trim()) {
+    throw new Error(`Cannot read production ${name}`);
+  }
+  return output.trim();
+}
+
+if (process.argv.includes("--prod")) {
+  process.env.FILES_BASE = await productionEnv("FILES_BASE");
+  process.env.FILES_SIGNING_SECRET = await productionEnv(
+    "FILES_SIGNING_SECRET"
+  );
+}
+
+const deadline =
+  Date.now() + (process.argv.includes("--wait") ? 10 * 60_000 : 0);
+for (;;) {
+  let ready = false;
+  try {
+    const signed = await buildSignedWorkerOpRequest({
+      op: "capabilities",
+      params: {},
+    });
+    const response = await fetch(signed.url, {
+      ...signed,
+      signal: AbortSignal.timeout(15_000),
+    });
+    const result = (await response.json()) as {
+      ok?: boolean;
+      data?: { operations?: string[]; ai?: boolean; images?: boolean };
+    };
+    ready =
+      response.ok &&
+      result.ok === true &&
+      result.data?.ai === true &&
+      result.data.images === true &&
+      required.every((op) => result.data?.operations?.includes(op));
+  } catch {
+    // Never log signed URLs, request headers, or deployment secrets.
+  }
+  if (ready) {
+    console.log(
+      "Files worker ready: required operations, AI, Images, and signing verified."
+    );
+    break;
+  }
+  if (Date.now() >= deadline) {
+    throw new Error("Files worker is not ready; backend deployment blocked.");
+  }
+  console.log("Waiting for files-worker deployment readiness…");
+  await Bun.sleep(15_000);
+}


### PR DESCRIPTION
## What changes
Import parsing and audio transcription now run in the files worker, keeping file bytes out of Convex while Convex retains authorization, card validation, deduplication, cancellation, and durable state. ZIP reads are bounded and source-version checked; Markdown, bookmarks, CSV, failure reports, and cleanup use the canonical worker paths.

Large imports checkpoint one page per action with bounded Markdown concurrency. The initial workflow step and arguments are preserved; historical results without a continuation cursor replay the original sequence. An optional source ETag and job/URL index support retries and cross-page deduplication without a data backfill.

Backend deployment now waits for a signed worker capability check before deploying callers. Remote preview ingestion retains its existing DNS-pinned Convex implementation because the Workers runtime could not preserve that protection.

## Validation
- Worker/protocol tests, complete Convex unit and edge suites, typechecks, and pre-commit build/lint checks pass.
- Local workerd exercised signed upload, indexing, Markdown, extraction, cleanup, and real Workers AI transcription.
- An isolated local Convex backend using disposable dev-prefix R2 fixtures indexed 10,000 items (about 55 MiB of JSON and 256 Markdown files) over 100 pages in 391 seconds; fixtures cleaned up.
- Local browser verified bookmark deduplication, archive Markdown/image creation, and invalid UTF-8 reporting against isolated Convex and dev-prefix R2 storage. A test-only transport route was needed because the isolated localhost port is outside bucket CORS.
- Deployed worker version 7b1790da-ef1f-4ca7-a3bc-a900b3fcc9f5 passed signed production readiness, 103-card pagination, Markdown decoding, ZIP extraction, HTML/CSV parsing, real Workers AI transcription, and fixture cleanup.
- Greptile rated latest head 294b2f1e 5/5; Vercel Agent and all PR checks passed; all review threads resolved. Production backend and full browser workflow verification follow merge.

## Rollout
Worker first, signed readiness gate second, Convex callers third. No migration/backfill. On rollback retain the optional sourceEtag schema field and compatible worker; do not remove stored fields without a separate migration.
