### PR TITLE
Align production E2E with import, changelog, and OAuth contracts

### DIFF
--- a/packages/tests/src/docs/pages.e2e.ts
+++ b/packages/tests/src/docs/pages.e2e.ts
@@ -37,12 +37,17 @@ test("changelog renders Blume release notes", async ({ page }) => {
   const releaseNotes = page.locator("[data-blume-update]").first();
   await expect(releaseNotes).toBeVisible();
   const releaseLink = releaseNotes.getByRole("link").first();
-  await expect(releaseLink).toHaveText(/^[A-Z][a-z]+ 20\d{2}$/);
+  await expect(releaseLink).toHaveText(/\S/);
   await expect(releaseLink).toHaveAttribute(
     "href",
-    /^\/changelog\/[a-z]+-20\d{2}$/
+    /^\/changelog\/[a-z0-9-]+\/?$/
   );
   await expect(releaseNotes.locator("li")).not.toHaveCount(0);
+  const title = await releaseLink.innerText();
+  await releaseLink.click();
+  await expect(
+    page.getByRole("heading", { name: title, exact: true })
+  ).toBeVisible();
 });
 
 test("public docs describe expanded file support and optional card types", async ({

--- a/packages/tests/src/extension/save-page.e2e.ts
+++ b/packages/tests/src/extension/save-page.e2e.ts
@@ -47,43 +47,18 @@ test("extension saves a selected file and safe page asset with private URL fallb
     const nextPage = context.waitForEvent("page");
     await signIn.click();
     const authPage = await nextPage;
-    const approveDevice = authPage.getByRole("button", {
-      name: "Approve device",
-    });
-    await expect(approveDevice).toBeVisible();
-    await approveDevice.click();
-    await authPage
-      .waitForURL((url) => url.pathname === "/native/auth/complete")
-      .catch((error: unknown) => {
-        if (!authPage.isClosed()) {
-          throw error;
-        }
-      });
+    await expect(
+      authPage.getByText("Allow this app to access Teak?")
+    ).toBeVisible();
+    await expect(authPage.getByText("Teak Chrome · teak-chrome")).toBeVisible();
+    await authPage.getByRole("button", { name: "Allow", exact: true }).click();
 
-    // The completion tab can close before its document-idle content script
-    // runs. Reopening the popup exercises the extension's normal fallback poll.
+    // Verify the completed OAuth flow through the authenticated upload UI.
     const finishingPopup = await context.newPage();
     await finishingPopup.goto(popupUrl);
-
-    await expect
-      .poll(
-        () =>
-          serviceWorker.evaluate(() => {
-            const extensionChrome = (
-              globalThis as typeof globalThis & { chrome: ExtensionChrome }
-            ).chrome;
-            return new Promise<boolean>((resolveToken) => {
-              extensionChrome.storage.local.get(
-                "teakSessionToken",
-                (result) => {
-                  resolveToken(Boolean(result.teakSessionToken));
-                }
-              );
-            });
-          }),
-        { timeout: 30_000 }
-      )
-      .toBe(true);
+    await expect(finishingPopup.locator('input[type="file"]')).toBeAttached({
+      timeout: 30_000,
+    });
 
     const marker = `extension-file-${Date.now()}`;
     const markdown = `\uFEFF  # ${marker}\r\n\r\nSaved from the extension.  \n`;

--- a/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
+++ b/packages/tests/src/journey/09-web-product-surfaces.e2e.ts
@@ -631,8 +631,8 @@ test("settings import and export surface terminal states", async ({ page }) => {
     )
     .toMatchObject({
       content: legacyContent,
-      fileName: legacyFileName,
-      fileUrl: expect.stringMatching(/^https?:\/\//),
+      fileName: null,
+      fileUrl: null,
       type: "text",
     });
 


### PR DESCRIPTION
Production verification after #392 exposed outdated expectations in three tests. Markdown archive imports now assert preserved text with no attachment metadata; changelog coverage follows the dated release link and verifies its title; extension coverage grants OAuth consent and verifies the authenticated upload UI instead of the retired device flow/session storage key.

Validation: all required pre-commit checks pass; 32 docs checks passed locally against production. Full Production E2E succeeded with 37 journey tests plus docs, extension, browser matrix, and cleanup: https://github.com/praveenjuge/teak/actions/runs/34684574594. The Firefox setup lane required one retry. Greptile rated this head 5/5, Vercel Agent passed, and there are no unresolved review threads.
