### PR TITLE
test(e2e): wait for account deletion before asserting API key revocation

### DIFF
--- a/packages/tests/src/helpers/prod.ts
+++ b/packages/tests/src/helpers/prod.ts
@@ -328,6 +328,10 @@ export const deleteAccountViaUi = async (page: Page, account: AccountState) => {
   ).toBeVisible();
   await page.locator("#deleteConfirm").fill("delete account");
   await page.getByRole("button", { name: "Delete account" }).click();
+  // Batched account-data cleanup runs before the session is dropped, so
+  // deleting a data-heavy account can take minutes: wait for the app to
+  // return to /login before asserting that the API key is revoked.
+  await page.waitForURL(/\/login/, { timeout: 180_000 });
   if (account.apiKey) {
     await expect
       .poll(
@@ -337,19 +341,10 @@ export const deleteAccountViaUi = async (page: Page, account: AccountState) => {
               headers: { Authorization: `Bearer ${account.apiKey}` },
             })
           ).status,
-        { timeout: 60_000 }
+        { timeout: 30_000 }
       )
       .toBe(401);
   }
-  await page
-    .waitForURL(/\/login/, { timeout: account.apiKey ? 10_000 : 30_000 })
-    .catch(async (error: unknown) => {
-      if (!account.apiKey) {
-        throw error;
-      }
-      await page.context().clearCookies();
-      await page.goto(appPath("/login"));
-    });
   updateState((state) => {
     for (const saved of state.accounts) {
       if (saved.email === account.email) {


### PR DESCRIPTION
## Why

Today's Production E2E run failed on `journey` (run [#196](https://github.com/praveenjuge/teak/actions/runs/34685799241), refs #394):

```
✘ [journey-api] › src/journey/13-occ-concurrency.e2e.ts:9:1 › preview OCC harness keeps parallel card operations coherent (1.5m)
Error: expect(received).toBe(expected)
Expected: 401
Received: 200
- Timeout 60000ms exceeded while waiting on the predicate
at helpers/prod.ts:342 (deleteAccountViaUi)
```

`deleteAccountViaUi` clicked **Delete account** and immediately polled `/v1/tags` with the account's API key, expecting `401` within 60s. But account deletion runs batched data cleanup first (`deleteAccountData` loops over cards, storage objects, and imports before the user row is removed), so a data-heavy account - like the OCC harness account, which creates dozens of cards - keeps validating as `200` until cleanup finishes. The primary-account path (`99-delete-account`) passes because that account has little data and deletes fast.

## Fix

Wait for the app to return to `/login` first (the UI only navigates after the backend finishes deletion), with a generous 180s timeout, then assert the API key revokes with a short 30s poll. Also removes the now-unneeded cookie-clearing fallback.

Test-harness only; no product behavior changes.

## Notes

- Key validation itself is sound: once the user row is gone, `validateComponentApiKey` returns null and the key is revoked (verified by the passing `100-post-delete` spec in the same run).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account deletion flow reliability by allowing more time for navigation to the login page.
  * Reduced the wait time for confirming API-key revocation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->