### PR TITLE
fix(convex): retry transient files-worker failures in stale-upload sweep

### DIFF
--- a/packages/convex/__tests__/storage/pendingUploadCleanup.test.ts
+++ b/packages/convex/__tests__/storage/pendingUploadCleanup.test.ts
@@ -83,6 +83,25 @@ describe("withFilesWorkerRetry", () => {
     expect(calls).toBe(1);
   });
 
+  test("stops retrying when the shared budget is exhausted", async () => {
+    const budget = { remainingMs: 5 };
+    let calls = 0;
+    await expect(
+      withFilesWorkerRetry(
+        () => {
+          calls += 1;
+          return Promise.reject(
+            new Error("files_worker_network_error:fetch failed")
+          );
+        },
+        [3, 3],
+        budget
+      )
+    ).rejects.toThrow("files_worker_network_error:fetch failed");
+    expect(calls).toBe(2);
+    expect(budget.remainingMs).toBe(2);
+  });
+
   test("gives up after the retry budget", async () => {
     let calls = 0;
     await expect(

--- a/packages/convex/__tests__/storage/pendingUploadCleanup.test.ts
+++ b/packages/convex/__tests__/storage/pendingUploadCleanup.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { stalePendingUploadKeys } from "../../storage/pendingUploadCleanup";
+import {
+  stalePendingUploadKeys,
+  withFilesWorkerRetry,
+} from "../../storage/pendingUploadCleanup";
 
 describe("stalePendingUploadKeys", () => {
   const now = Date.UTC(2026, 7, 19, 12);
@@ -24,5 +27,75 @@ describe("stalePendingUploadKeys", () => {
         now
       )
     ).toEqual(["users/a/cards/upload-pending-v2/file/old"]);
+  });
+});
+
+describe("withFilesWorkerRetry", () => {
+  test("retries transient network errors until the call succeeds", async () => {
+    let calls = 0;
+    const result = await withFilesWorkerRetry(
+      () => {
+        calls += 1;
+        if (calls < 3) {
+          return Promise.reject(
+            new Error("files_worker_network_error:fetch failed")
+          );
+        }
+        return Promise.resolve("ok");
+      },
+      [0, 0]
+    );
+    expect(result).toBe("ok");
+    expect(calls).toBe(3);
+  });
+
+  test("retries transient 5xx responses", async () => {
+    let calls = 0;
+    const result = await withFilesWorkerRetry(
+      () => {
+        calls += 1;
+        if (calls === 1) {
+          return Promise.reject(
+            new Error("files_worker_error:INTERNAL:500:req-1")
+          );
+        }
+        return Promise.resolve("ok");
+      },
+      [0, 0]
+    );
+    expect(result).toBe("ok");
+    expect(calls).toBe(2);
+  });
+
+  test("does not retry non-transient errors", async () => {
+    let calls = 0;
+    await expect(
+      withFilesWorkerRetry(
+        () => {
+          calls += 1;
+          return Promise.reject(
+            new Error("files_worker_error:UNAUTHORIZED:401:req-1")
+          );
+        },
+        [0, 0]
+      )
+    ).rejects.toThrow("files_worker_error:UNAUTHORIZED:401:req-1");
+    expect(calls).toBe(1);
+  });
+
+  test("gives up after the retry budget", async () => {
+    let calls = 0;
+    await expect(
+      withFilesWorkerRetry(
+        () => {
+          calls += 1;
+          return Promise.reject(
+            new Error("files_worker_network_error:fetch failed")
+          );
+        },
+        [0, 0]
+      )
+    ).rejects.toThrow("files_worker_network_error:fetch failed");
+    expect(calls).toBe(3);
   });
 });

--- a/packages/convex/storage/pendingUploadCleanup.ts
+++ b/packages/convex/storage/pendingUploadCleanup.ts
@@ -17,6 +17,38 @@ const DELETE_BATCH_SIZE = 100;
 // Hard page cap so a pathological bucket cannot spin the cron forever; the
 // next hourly run resumes from wherever listing left off.
 const MAX_LIST_PAGES = 200;
+// Transient files-worker failures (network resets, 5xx) should not fail the
+// whole hourly sweep: retry the idempotent list/delete ops with backoff.
+const RETRY_DELAYS_MS = [1000, 4000];
+
+const isTransientFilesWorkerError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.startsWith("files_worker_network_error:") ||
+    /^files_worker_error:[A-Z0-9_]+:5\d\d:/.test(message)
+  );
+};
+
+export const withFilesWorkerRetry = async <T>(
+  operation: () => Promise<T>,
+  retryDelaysMs: readonly number[] = RETRY_DELAYS_MS
+): Promise<T> => {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retryDelaysMs.length; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      const delay = retryDelaysMs[attempt];
+      if (delay === undefined || !isTransientFilesWorkerError(error)) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+  throw lastError;
+};
+
 
 export const stalePendingUploadKeys = (
   objects: Array<{ key: string; lastModified: number }>,
@@ -47,10 +79,12 @@ export const sweepStalePendingUploadsHandler = async (): Promise<null> => {
     if (cursor) {
       params.cursor = cursor;
     }
-    const outcome = await callFilesWorkerJson<FilesWorkerListObjectsResult>({
-      op: "list-objects",
-      params,
-    });
+    const outcome = await withFilesWorkerRetry(() =>
+      callFilesWorkerJson<FilesWorkerListObjectsResult>({
+        op: "list-objects",
+        params,
+      })
+    );
     if (outcome.kind !== "ok") {
       throw new Error("files_worker_list_objects_unavailable");
     }
@@ -59,10 +93,12 @@ export const sweepStalePendingUploadsHandler = async (): Promise<null> => {
 
     const staleKeys = stalePendingUploadKeys(outcome.data.objects);
     for (let index = 0; index < staleKeys.length; index += DELETE_BATCH_SIZE) {
-      const deleted = await callFilesWorkerJson<{ deleted: number }>({
-        op: "delete-objects",
-        params: { keys: staleKeys.slice(index, index + DELETE_BATCH_SIZE) },
-      });
+      const deleted = await withFilesWorkerRetry(() =>
+        callFilesWorkerJson<{ deleted: number }>({
+          op: "delete-objects",
+          params: { keys: staleKeys.slice(index, index + DELETE_BATCH_SIZE) },
+        })
+      );
       if (deleted.kind !== "ok") {
         throw new Error("files_worker_delete_objects_unavailable");
       }
@@ -77,3 +113,4 @@ export const sweepStalePendingUploads = internalAction({
   returns: v.null(),
   handler: sweepStalePendingUploadsHandler,
 });
+

--- a/packages/convex/storage/pendingUploadCleanup.ts
+++ b/packages/convex/storage/pendingUploadCleanup.ts
@@ -18,8 +18,11 @@ const DELETE_BATCH_SIZE = 100;
 // next hourly run resumes from wherever listing left off.
 const MAX_LIST_PAGES = 200;
 // Transient files-worker failures (network resets, 5xx) should not fail the
-// whole hourly sweep: retry the idempotent list/delete ops with backoff.
+// whole hourly sweep: retry the idempotent list/delete ops with backoff. One
+// budget is shared across every call in a run so intermittent failures cannot
+// consume the action's execution window.
 const RETRY_DELAYS_MS = [1000, 4000];
+const SWEEP_RETRY_BUDGET_MS = 30_000;
 
 const isTransientFilesWorkerError = (error: unknown): boolean => {
   const message = error instanceof Error ? error.message : String(error);
@@ -31,7 +34,8 @@ const isTransientFilesWorkerError = (error: unknown): boolean => {
 
 export const withFilesWorkerRetry = async <T>(
   operation: () => Promise<T>,
-  retryDelaysMs: readonly number[] = RETRY_DELAYS_MS
+  retryDelaysMs: readonly number[] = RETRY_DELAYS_MS,
+  budget?: { remainingMs: number }
 ): Promise<T> => {
   let lastError: unknown;
   for (let attempt = 0; attempt <= retryDelaysMs.length; attempt += 1) {
@@ -40,8 +44,15 @@ export const withFilesWorkerRetry = async <T>(
     } catch (error) {
       lastError = error;
       const delay = retryDelaysMs[attempt];
-      if (delay === undefined || !isTransientFilesWorkerError(error)) {
+      if (
+        delay === undefined ||
+        !isTransientFilesWorkerError(error) ||
+        (budget !== undefined && delay > budget.remainingMs)
+      ) {
         break;
+      }
+      if (budget !== undefined) {
+        budget.remainingMs -= delay;
       }
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
@@ -70,6 +81,7 @@ export const sweepStalePendingUploadsHandler = async (): Promise<null> => {
   }
   let cursor: string | null = null;
   let pages = 0;
+  const retryBudget = { remainingMs: SWEEP_RETRY_BUDGET_MS };
 
   do {
     const params: Record<string, unknown> = {
@@ -79,11 +91,14 @@ export const sweepStalePendingUploadsHandler = async (): Promise<null> => {
     if (cursor) {
       params.cursor = cursor;
     }
-    const outcome = await withFilesWorkerRetry(() =>
-      callFilesWorkerJson<FilesWorkerListObjectsResult>({
-        op: "list-objects",
-        params,
-      })
+    const outcome = await withFilesWorkerRetry(
+      () =>
+        callFilesWorkerJson<FilesWorkerListObjectsResult>({
+          op: "list-objects",
+          params,
+        }),
+      RETRY_DELAYS_MS,
+      retryBudget
     );
     if (outcome.kind !== "ok") {
       throw new Error("files_worker_list_objects_unavailable");
@@ -93,11 +108,14 @@ export const sweepStalePendingUploadsHandler = async (): Promise<null> => {
 
     const staleKeys = stalePendingUploadKeys(outcome.data.objects);
     for (let index = 0; index < staleKeys.length; index += DELETE_BATCH_SIZE) {
-      const deleted = await withFilesWorkerRetry(() =>
-        callFilesWorkerJson<{ deleted: number }>({
-          op: "delete-objects",
-          params: { keys: staleKeys.slice(index, index + DELETE_BATCH_SIZE) },
-        })
+      const deleted = await withFilesWorkerRetry(
+        () =>
+          callFilesWorkerJson<{ deleted: number }>({
+            op: "delete-objects",
+            params: { keys: staleKeys.slice(index, index + DELETE_BATCH_SIZE) },
+          }),
+        RETRY_DELAYS_MS,
+        retryBudget
       );
       if (deleted.kind !== "ok") {
         throw new Error("files_worker_delete_objects_unavailable");


### PR DESCRIPTION
## Why

Daily Sentry review (teakvault org, production) surfaced repeated failures in the hourly `cleanup-stale-pending-card-uploads` cron:

- `TEAK-BACKEND-PROD-V` - `files_worker_network_error:fetch failed` killed the Sept 10 sweep run. One transient network reset fails the entire sweep because the per-page list/delete calls have no retry.
- `TEAK-BACKEND-PROD-T` - "Consecutive HTTP" on the same cron (200 events): the sweep's serial page-by-page calls dominate the issue feed, so keeping each call resilient keeps real failures visible.
- `TEAK-BACKEND-PROD-S` - files worker delete op returned a transient internal error (10001) on Sept 1.

## What changes

`packages/convex/storage/pendingUploadCleanup.ts` only:

- New `withFilesWorkerRetry` helper: retries transient files-worker failures (network errors, 5xx) with backoff (1s, 4s; 3 attempts total). Non-transient errors (4xx, config) still throw immediately.
- The sweep's `list-objects` and `delete-objects` calls (both idempotent) now run through it. Each attempt re-signs the request, so the 10-minute op TTL is unaffected.

## Tests

New `withFilesWorkerRetry` coverage: retries network errors until success, retries 5xx, does not retry 4xx, stops after the retry budget. Existing `stalePendingUploadKeys` test unchanged. Not run locally (web-editor change); retry semantics verified against the exact error shapes thrown by `callFilesWorkerJson`.